### PR TITLE
Fix #18: replace 'Continue?' popups with wait-box + Cancel

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2114,7 +2114,7 @@ Quick Options:
 <#Enable wildcarding for operands, to improve stability of created signatures#Wildcards for operands:{cWildcardOperands}>
 <#Don't stop signature generation when reaching end of function#Continue when leaving function scope:{cContinueOutside}>
 <#Wildcard the whole instruction when the operand (usually a register) is encoded into the operator#Wildcard optimized / combined instructions:{cWildcardOptimized}>
-<#Opt-in: show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>{cGroupOptions}>
+<#Opt-in -- show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>{cGroupOptions}>
 
 <Operand types...:{bOperandTypes}><Other options...:{bOtherOptions}>
 """

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1252,7 +1252,7 @@ class InstructionWalker:
             raise StopIteration
 
         if idaapi_user_canceled():
-            raise StopIteration("Aborted by user")
+            raise UserCanceledError("Aborted by user during instruction walk")
 
         current_instruction_ea = self.cursor
         ins_len = idaapi.decode_insn(self._instruction, current_instruction_ea)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2053,12 +2053,14 @@ Options
 <#Print top X shortest signatures when generating xref signatures#Print top X XREF signatures     :{opt1}>
 <#Stop after reaching X bytes when generating a single signature#Maximum single signature length :{opt2}>
 <#Stop after reaching X bytes when generating xref signatures#Maximum xref signature length   :{opt3}>
+<#Seconds before the first 'Continue?' prompt fires. -1 disables the prompt entirely (default).#Prompt interval (seconds, -1 disables):{opt4}>
 """
 
         self.controls = {
             "opt1": F.NumericInput(tp=F.FT_DEC),
             "opt2": F.NumericInput(tp=F.FT_DEC),
             "opt3": F.NumericInput(tp=F.FT_DEC),
+            "opt4": F.NumericInput(tp=F.FT_DEC),
         }
         super().__init__(form_text, self.controls)
 
@@ -2069,6 +2071,7 @@ Options
         self.controls["opt1"].value = SigMakerConfig.print_top_x
         self.controls["opt2"].value = SigMakerConfig.max_single_signature_length
         self.controls["opt3"].value = SigMakerConfig.max_xref_signature_length
+        self.controls["opt4"].value = SigMakerConfig.prompt_interval
 
         result = self.Execute()
         if result != 1:
@@ -2078,6 +2081,7 @@ Options
         SigMakerConfig.print_top_x = self.controls["opt1"].value
         SigMakerConfig.max_single_signature_length = self.controls["opt2"].value
         SigMakerConfig.max_xref_signature_length = self.controls["opt3"].value
+        SigMakerConfig.prompt_interval = self.controls["opt4"].value
         self.Free()
         return result
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -304,6 +304,15 @@ class CheckContinuePrompt:
         if self._user_canceled:
             return True
 
+        # Wait-box cancel: propagate regardless of whether prompts are enabled.
+        if idaapi_user_canceled():
+            self._user_canceled = True
+            if self.logger is not None:
+                self.logger.info(
+                    "Wait-box cancel detected at %.1fs", self.elapsed_time
+                )
+            return True
+
         # Check if it's time to prompt
         if self._should_prompt() and self._timer.should_prompt(self.elapsed_time):
             if self.logger is not None:

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -613,6 +613,20 @@ class SignatureType(enum.Enum):
         return list(cls.__members__.values())[index]
 
 
+class Action(enum.IntEnum):
+    """User-selectable action in SignatureMakerForm.
+
+    Values are bound to the rAction radio-group order:
+    ("rCreateUniqueSig", "rFindXRefSig", "rCopyCode", "rSearchSignature").
+    Changing values requires updating the radio group too.
+    """
+
+    CREATE_UNIQUE = 0
+    FIND_XREF = 1
+    COPY_RANGE = 2
+    SEARCH = 3
+
+
 class SignatureByte(typing.NamedTuple):
     """Container representing a single byte in a signature.
 
@@ -2235,7 +2249,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             if not ok:
                 return
 
-            action = form.rAction.value  # type: ignore
+            action = Action(int(form.rAction.value))  # type: ignore
             output_format = form.rOutputFormat.value  # type: ignore
             wildcard_operands = bool(form.cGroupOptions.value & 1)  # type: ignore
             continue_outside_of_function = bool(form.cGroupOptions.value & 2)  # type: ignore
@@ -2252,22 +2266,22 @@ class SigMakerPlugin(idaapi.plugin_t):
         )
 
         try:
-            if action == 0:
+            if action == Action.CREATE_UNIQUE:
                 ea = idaapi.get_screen_ea()
                 signature = SignatureMaker().make_signature(ea, config)
                 signature.display(config)
-            elif action == 1:
+            elif action == Action.FIND_XREF:
                 ea = idaapi.get_screen_ea()
                 signatures = XrefFinder().find_xrefs(ea, config)
                 signatures.display(cfg=config)
-            elif action == 2:
+            elif action == Action.COPY_RANGE:
                 start, end = self.get_selected_addresses(idaapi.get_current_viewer())
                 if start and end:
                     signature = SignatureMaker().make_signature(start, config, end=end)
                     signature.display(config)
                 else:
                     idaapi.msg("Select a range to copy the code!\n")
-            elif action == 3:
+            elif action == Action.SEARCH:
                 input_signature = idaapi.ask_str(
                     "", idaapi.HIST_SRCH, "Enter a signature"
                 )

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2285,7 +2285,10 @@ class SigMakerPlugin(idaapi.plugin_t):
         try:
             if action == Action.CREATE_UNIQUE:
                 ea = idaapi.get_screen_ea()
-                signature = SignatureMaker().make_signature(ea, config)
+                with ProgressDialog(
+                    "Generating signature...\n\nPress Cancel to stop"
+                ):
+                    signature = SignatureMaker().make_signature(ea, config)
                 signature.display(config)
             elif action == Action.FIND_XREF:
                 ea = idaapi.get_screen_ea()
@@ -2294,7 +2297,12 @@ class SigMakerPlugin(idaapi.plugin_t):
             elif action == Action.COPY_RANGE:
                 start, end = self.get_selected_addresses(idaapi.get_current_viewer())
                 if start and end:
-                    signature = SignatureMaker().make_signature(start, config, end=end)
+                    with ProgressDialog(
+                        "Generating range signature...\n\nPress Cancel to stop"
+                    ):
+                        signature = SignatureMaker().make_signature(
+                            start, config, end=end
+                        )
                     signature.display(config)
                 else:
                     idaapi.msg("Select a range to copy the code!\n")

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -579,12 +579,14 @@ class SigMakerConfig:
     wildcard_operands: bool
     continue_outside_of_function: bool
     wildcard_optimized: bool
-    enable_continue_prompt: bool = True
+    enable_continue_prompt: bool = False
     ask_longer_signature: bool = True
     print_top_x: int = 5
     max_single_signature_length: int = 100
     max_xref_signature_length: int = 250
-    prompt_interval: int = 10  # Seconds before first prompt (default: 10 for testing)
+    # Seconds before first prompt. -1 (or 0) disables the periodic
+    # "Continue?" popup -- the wait-box Cancel button still works.
+    prompt_interval: int = -1
 
 
 @dataclasses.dataclass(slots=True, frozen=True, repr=False)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2110,7 +2110,7 @@ Quick Options:
 <#Enable wildcarding for operands, to improve stability of created signatures#Wildcards for operands:{cWildcardOperands}>
 <#Don't stop signature generation when reaching end of function#Continue when leaving function scope:{cContinueOutside}>
 <#Wildcard the whole instruction when the operand (usually a register) is encoded into the operator#Wildcard optimized / combined instructions:{cWildcardOptimized}>
-<#Show periodic continue prompts while generating signatures#Enable continue prompt:{cEnablePrompt}>{cGroupOptions}>
+<#Opt-in: show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>{cGroupOptions}>
 
 <Operand types...:{bOperandTypes}><Other options...:{bOtherOptions}>
 """
@@ -2126,7 +2126,9 @@ Quick Options:
             ),
             "cGroupOptions": idaapi.Form.ChkGroupControl(
                 ("cWildcardOperands", "cContinueOutside", "cWildcardOptimized", "cEnablePrompt"),
-                value=13,  # Bits: 1 (wildcards) + 4 (wildcard optimized) + 8 (enable prompt)
+                # Bits: 1 (wildcards) + 4 (wildcard optimized). Bit 8 (enable
+                # prompt) defaults OFF; the wait-box Cancel handles long runs.
+                value=5,
             ),
             "bOperandTypes": F.ButtonInput(self.ConfigureOperandWildcardBitmask),
             "bOtherOptions": F.ButtonInput(self.ConfigureOptions),

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2134,6 +2134,20 @@ class TestSearchCancellation(CoveredUnitTest):
             sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
 
 
+class TestSigMakerConfigDefaults(CoveredUnitTest):
+    """Defaults must give the wait-box-cancel UX out of the box (issue #18)."""
+
+    def test_default_disables_continue_prompt(self):
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+        )
+        self.assertFalse(cfg.enable_continue_prompt)
+        self.assertEqual(cfg.prompt_interval, -1)
+
+
 class TestInstructionWalkerCancellation(CoveredUnitTest):
     """User-cancellation inside InstructionWalker must raise UserCanceledError, not StopIteration."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2100,6 +2100,33 @@ class TestSearchCancellation(CoveredUnitTest):
             sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
 
 
+class TestInstructionWalkerCancellation(CoveredUnitTest):
+    """User-cancellation inside InstructionWalker must raise UserCanceledError, not StopIteration."""
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def test_walker_raises_user_canceled_error_on_cancel(self):
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=True)
+        walker = sigmaker.InstructionWalker(start_ea=0x1000, end_ea=0x2000)
+        with self.assertRaises(sigmaker.UserCanceledError):
+            next(iter(walker))
+
+    def test_walker_does_not_raise_when_not_canceled(self):
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        walker = sigmaker.InstructionWalker(start_ea=0x1000, end_ea=0x2000)
+        ea, ins, ins_len = next(iter(walker))
+        self.assertEqual(ea, 0x1000)
+        self.assertEqual(ins_len, 1)
+
+
 class TestActionEnum(CoveredUnitTest):
     """The Action IntEnum must mirror the SignatureMakerForm.rAction radio order."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2100,6 +2100,23 @@ class TestSearchCancellation(CoveredUnitTest):
             sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
 
 
+class TestActionEnum(CoveredUnitTest):
+    """The Action IntEnum must mirror the SignatureMakerForm.rAction radio order."""
+
+    def test_action_values_match_form_order(self):
+        # Order is locked by SignatureMakerForm.rAction:
+        #   ("rCreateUniqueSig", "rFindXRefSig", "rCopyCode", "rSearchSignature")
+        self.assertEqual(int(sigmaker.Action.CREATE_UNIQUE), 0)
+        self.assertEqual(int(sigmaker.Action.FIND_XREF), 1)
+        self.assertEqual(int(sigmaker.Action.COPY_RANGE), 2)
+        self.assertEqual(int(sigmaker.Action.SEARCH), 3)
+
+    def test_action_is_intenum(self):
+        import enum as _enum
+
+        self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -1905,12 +1905,20 @@ class TestProgressReporter(CoveredUnitTest):
         """Set up test fixtures."""
         # Store the original ask_yn function
         self.original_ask_yn = getattr(sigmaker.idaapi, "ask_yn", MagicMock())
+        # Without this, sigmaker.idaapi_user_canceled (bound from a MagicMock
+        # at import time) returns a truthy MagicMock instance and the new
+        # wait-box-cancel poll inside should_cancel() fires on every call.
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
         # Ensure BADADDR is set to a real integer
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
 
     def tearDown(self):
         """Restore original functions."""
         sigmaker.idaapi.ask_yn = self.original_ask_yn
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
 
     def test_check_continue_prompt_basic(self):
         """Test basic CheckContinuePrompt functionality."""
@@ -1949,6 +1957,32 @@ class TestProgressReporter(CoveredUnitTest):
         self.assertEqual(prompt._dynamic_metadata["dynamic_key"], "dynamic_value")
         self.assertEqual(prompt._dynamic_metadata["count"], 42)
         self.assertEqual(prompt._progress_message, "Processing...")
+
+    def test_should_cancel_polls_idaapi_user_canceled(self):
+        """Even with prompts disabled, the wait-box Cancel must propagate."""
+        original = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        try:
+            sigmaker.idaapi_user_canceled = MagicMock(return_value=True)
+            prompt = sigmaker.CheckContinuePrompt(enable_prompt=False)
+            self.assertTrue(prompt.should_cancel())
+            # And once flagged, it stays canceled even if the wait-box flag clears.
+            sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+            self.assertTrue(prompt.should_cancel())
+        finally:
+            sigmaker.idaapi_user_canceled = original
+
+    def test_should_cancel_returns_false_when_no_cancel(self):
+        original = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        try:
+            sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+            prompt = sigmaker.CheckContinuePrompt(enable_prompt=False)
+            self.assertFalse(prompt.should_cancel())
+        finally:
+            sigmaker.idaapi_user_canceled = original
 
     # Note: Integration tests for UniqueSignatureGenerator and RangeSignatureGenerator
     # with progress reporters are complex due to mocking requirements. The core functionality


### PR DESCRIPTION
Closes #18.

## Background

The original cancelable-search work I shipped in PR #20 gave users an exponential-backoff modal "Continue?" prompt every 10s/20s/40s of generation. `@bukowa` reported in the issue that this was "ultra confusing" and clarified the actual ask:

> My expectation wasn't an automated timeout or recurring prompts, I simply want a 'Cancel' button that allows the user to stop the search manually if they decide it's taking too long.

This PR delivers that. I kept the exponential-backoff path around as an opt-in for anyone who liked it.

## Four bugs I fixed

1. **`SigMakerConfig` defaults made popups loud.** I had shipped `enable_continue_prompt=True` and `prompt_interval=10` as defaults, so popups fired 10s into every generation.
2. **No wait-box for single/range generation.** I never wrapped `SignatureMaker.make_signature` in `ProgressDialog`, so there was no Cancel button in the CREATE_UNIQUE and COPY_RANGE modes. The XREF and Search paths were already wrapped.
3. **`CheckContinuePrompt.should_cancel` ignored the wait-box flag.** It only checked an internal `_user_canceled` flag and never polled `idaapi_user_canceled()`, so even if a wait box had been shown, hitting Cancel wouldn't have propagated.
4. **`InstructionWalker.__next__` swallowed cancellations.** On cancel it raised `StopIteration("Aborted by user")`, which the generators above it read as "ran out of instructions" and reported as the confusing `"Signature not unique"` error instead of a clean cancellation.

## Changes

| Commit | What I did |
|---|---|
| `refactor: introduce Action IntEnum for SigMakerPlugin dispatch` | Replaced the `0/1/2/3` magic in `SigMakerPlugin.run` with `Action.CREATE_UNIQUE / FIND_XREF / COPY_RANGE / SEARCH`. |
| `fix(walker): raise UserCanceledError on cancel instead of StopIteration` | Cancellation now propagates cleanly to the existing `except UserCanceledError` handler. |
| `fix(progress): poll idaapi_user_canceled in CheckContinuePrompt.should_cancel` | Wait-box Cancel now flows through the progress reporter regardless of prompt state. |
| `feat: flip SigMakerConfig defaults to off-by-default prompts (-1 sentinel)` | `enable_continue_prompt=False`, `prompt_interval=-1`. I picked `-1` as the canonical "off" sentinel. |
| `feat(form): default 'Enable continue prompt' OFF; clarify tooltip` | `SignatureMakerForm.cGroupOptions.value`: 13 to 5 (drops bit 8). |
| `feat(form): expose prompt_interval in ConfigureOptionsForm (-1 disables)` | Added a numeric field in Other options so users can opt in via the UI. |
| `feat: wrap single/range make_signature in ProgressDialog for cancel` | CREATE_UNIQUE and COPY_RANGE branches now wrap in the wait box. FIND_XREF already wraps internally so I left it alone. |

## Net behavior

- **Default.** Wait-box with a Cancel button during signature generation. No popups. Cancel produces a clean `Operation cancelled by user` log with no traceback.
- **Opt-in.** Tick "Enable continue prompt (opt-in)" in the main form, and optionally set "Prompt interval (seconds, -1 disables)" via Other options.

## Verification

| Suite | Baseline | After |
|---|---|---|
| Host unit (`tests/unit_test_sigmaker.py`) | 111 OK | 118 OK (+7 new) |
| Docker `idapro-tests` (9.0/9.1) | 127 OK | 134 OK |
| Docker `idapro-tests-9.2` | 127 OK | 134 OK |

Zero regressions. The new test coverage I added:

- `TestActionEnum`. Locks `Action` values to the radio order.
- `TestInstructionWalkerCancellation`. Cancel raises `UserCanceledError`, not `StopIteration`.
- `TestProgressReporter.test_should_cancel_polls_idaapi_user_canceled` + `test_should_cancel_returns_false_when_no_cancel`. The wait-box poll fires regardless of prompt state, and once flagged it stays canceled.
- `TestSigMakerConfigDefaults`. Defaults are `enable_continue_prompt=False` and `prompt_interval=-1`.


## Notes

- Single-file plugin invariant preserved. All production-code changes live in `src/sigmaker/__init__.py`.
- No new dependencies.
- `ExponentialBackoffTimer` and its tests are untouched. The opt-in path is fully intact.

