### PR TITLE
Fix #22: partial signature on cancel (opt-in)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1292,7 +1292,11 @@ class InstructionWalker:
     """
 
     start_ea: int
-    end_ea: int = idaapi.BADADDR
+    # Resolve BADADDR lazily so tests that patch `idaapi.BADADDR` at runtime
+    # actually take effect. With `default=idaapi.BADADDR`, the value was
+    # evaluated at class-definition (module import) time, which under the
+    # unit-test mock of `idaapi` froze it as a MagicMock attribute.
+    end_ea: int = dataclasses.field(default_factory=lambda: idaapi.BADADDR)
 
     # Internal state fields
     cursor: int = dataclasses.field(init=False)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -638,6 +638,34 @@ class Action(enum.IntEnum):
     SEARCH = 3
 
 
+class GenerationStatus(enum.Enum):
+    """How a GeneratedSignature should be interpreted."""
+
+    UNIQUE = "unique"
+    PARTIAL_ON_CANCEL = "partial_on_cancel"
+
+
+@dataclasses.dataclass(frozen=True)
+class GenerationPolicy:
+    """Behavioral knobs passed into generator strategies.
+
+    Callers pick the policy that matches their tolerance for non-unique
+    signatures. The default is strict (legacy behavior: cancel raises).
+    """
+
+    return_partial_on_cancel: bool = False
+
+    @classmethod
+    def strict(cls) -> "GenerationPolicy":
+        """Cancel raises UserCanceledError (legacy behavior)."""
+        return cls(return_partial_on_cancel=False)
+
+    @classmethod
+    def permissive(cls) -> "GenerationPolicy":
+        """Cancel returns a partial GeneratedSignature instead of raising."""
+        return cls(return_partial_on_cancel=True)
+
+
 class SignatureByte(typing.NamedTuple):
     """Container representing a single byte in a signature.
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1441,14 +1441,17 @@ class UniqueSignatureGenerator:
                 count = SignatureSearcher.count_matches(f"{sig:ida}")
                 # SignatureSearcher.find_all polls idaapi_user_canceled inside
                 # its scan loop and bails when set, returning whatever partial
-                # count it had so far (often 0). If we just stored that, the
+                # count it had so far (often 0). If we stored that, the
                 # partial-on-cancel path would show "0 matches" for a signature
-                # that actually matches many places. Detect the interruption
-                # and degrade gracefully to "match count unavailable" rather
-                # than reporting a falsely-low count.
-                if idaapi_user_canceled():
-                    last_match_count = None
-                else:
+                # that actually matches many places.
+                #
+                # When the call was interrupted, keep last_match_count at its
+                # prior trustworthy value (the count from the previous fully
+                # completed iteration). The reported number then corresponds
+                # to a signature one instruction shorter than the partial we
+                # emit, which means it is an UPPER BOUND on the partial's
+                # actual match count -- a useful number, not a meaningless 0.
+                if not idaapi_user_canceled():
                     last_match_count = count
                     if count == 1:
                         sig.trim_signature()

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -587,6 +587,9 @@ class SigMakerConfig:
     # Seconds before first prompt. -1 (or 0) disables the periodic
     # "Continue?" popup -- the wait-box Cancel button still works.
     prompt_interval: int = -1
+    # Issue #22: when True, cancelling a unique-signature search emits the
+    # partial signature with its match count instead of nothing. Default off.
+    output_partial_on_cancel: bool = False
 
 
 @dataclasses.dataclass(slots=True, frozen=True, repr=False)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1831,8 +1831,13 @@ class SignatureSearcher:
         return out
 
     @classmethod
+    def count_matches(cls, ida_signature: str) -> int:
+        """Return the number of matches for the given IDA-format signature."""
+        return len(cls.find_all(ida_signature))
+
+    @classmethod
     def is_unique(cls, ida_signature: str) -> bool:
-        return len(cls.find_all(ida_signature)) == 1
+        return cls.count_matches(ida_signature) == 1
 
 
 # no cover: start

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1003,14 +1003,37 @@ class GeneratedSignature:
 
     signature: Signature
     address: Match | None = None
+    status: GenerationStatus = GenerationStatus.UNIQUE
+    match_count: int | None = None
 
     def display(self, cfg: SigMakerConfig) -> None:
-        """Display the signature result to the user."""
+        """Display the signature result to the user.
+
+        UNIQUE: prints the formatted signature and copies to the clipboard.
+        PARTIAL_ON_CANCEL: prints the partial with its match count; does NOT
+        touch the clipboard so an accidental cancel cannot clobber the
+        user's clipboard contents.
+        """
         if not self.signature:
             idaapi.msg("Error: Empty signature\n")
             return
         t = cfg.output_format.value
         fmted = format(self.signature, t)
+
+        if self.status == GenerationStatus.PARTIAL_ON_CANCEL:
+            count_str = (
+                f"{self.match_count} matches"
+                if self.match_count is not None
+                else "match count unavailable"
+            )
+            prefix = (
+                f"Partial signature (NOT unique, {count_str}) for {self.address}"
+                if self.address is not None
+                else f"Partial signature (NOT unique, {count_str})"
+            )
+            idaapi.msg(f"{prefix}: {fmted}\n")
+            return
+
         if self.address is not None:
             idaapi.msg(f"Signature for {self.address}: {fmted}\n")
         else:

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1439,10 +1439,20 @@ class UniqueSignatureGenerator:
                 bytes_since_last_check += ins_len
 
                 count = SignatureSearcher.count_matches(f"{sig:ida}")
-                last_match_count = count
-                if count == 1:
-                    sig.trim_signature()
-                    return GeneratedSignature(sig, Match(ea))
+                # SignatureSearcher.find_all polls idaapi_user_canceled inside
+                # its scan loop and bails when set, returning whatever partial
+                # count it had so far (often 0). If we just stored that, the
+                # partial-on-cancel path would show "0 matches" for a signature
+                # that actually matches many places. Detect the interruption
+                # and degrade gracefully to "match count unavailable" rather
+                # than reporting a falsely-low count.
+                if idaapi_user_canceled():
+                    last_match_count = None
+                else:
+                    last_match_count = count
+                    if count == 1:
+                        sig.trim_signature()
+                        return GeneratedSignature(sig, Match(ea))
         except UserCanceledError:
             # InstructionWalker raises UserCanceledError on cancel too (issue #18).
             # Honor the policy here as well.

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1338,19 +1338,33 @@ class UniqueSignatureGenerator:
         self.processor = processor
         self.progress_reporter = progress_reporter
 
-    def generate(self, ea: int, cfg: SigMakerConfig) -> Signature:
+    def generate(
+        self,
+        ea: int,
+        cfg: SigMakerConfig,
+        *,
+        policy: GenerationPolicy = GenerationPolicy.strict(),
+    ) -> GeneratedSignature:
         """Generate a unique signature starting at the given address.
 
         Args:
             ea: Starting address for signature generation
             cfg: Configuration for signature generation
+            policy: Controls cancel-time behavior. Default strict() raises
+                UserCanceledError on cancel (legacy contract). permissive()
+                returns a partial GeneratedSignature with the most recently
+                observed match count.
 
         Returns:
-            A unique signature
+            A GeneratedSignature. status=UNIQUE on success;
+            status=PARTIAL_ON_CANCEL when policy.return_partial_on_cancel
+            is True and the user cancels after at least one byte has been
+            appended.
 
         Raises:
             Unexpected: If signature cannot be made unique
-            UserCanceledError: If user cancels via progress reporter
+            UserCanceledError: If user cancels and policy.return_partial_on_cancel
+                is False, or if cancel happens before any byte is appended.
         """
         if not is_address_marked_as_code(ea):
             raise Unexpected("Cannot create code signature for data")
@@ -1359,51 +1373,75 @@ class UniqueSignatureGenerator:
         start_fn = idaapi.get_func(ea)
         bytes_since_last_check = 0
         instruction_count = 0
+        last_match_count: int | None = None
 
-        for cur_ea, ins, ins_len in InstructionWalker(ea):
-            # Check for cancellation via progress reporter
-            if self.progress_reporter is not None and self.progress_reporter.should_cancel():
+        def _build_partial() -> GeneratedSignature:
+            # Trim trailing wildcards, mirror the success path.
+            sig.trim_signature()
+            if len(sig) == 0:
                 raise UserCanceledError("Signature generation canceled by user")
-
-            # Update progress periodically
-            instruction_count += 1
-            progress_reporting = self.progress_reporter is not None and self.progress_reporter.enabled()
-            if progress_reporting and instruction_count % 100 == 0:
-                self.progress_reporter.report_progress(
-                    message=f"Generating signature at {hex(cur_ea)}",
-                    signature_length=len(sig),
-                    instructions_processed=instruction_count,
-                )
-
-            # Check length constraint
-            if bytes_since_last_check > cfg.max_single_signature_length:
-                if (
-                    not cfg.ask_longer_signature
-                    or idaapi.ask_yn(
-                        idaapi.ASKBTN_NO,
-                        f"Signature is already {len(sig)} bytes. Continue?",
-                    )
-                    != idaapi.ASKBTN_YES
-                ):
-                    raise Unexpected("Signature not unique within length constraints")
-                bytes_since_last_check = 0  # Reset counter after user confirmation
-
-            # Check function boundary constraint
-            if (
-                not cfg.continue_outside_of_function
-                and start_fn
-                and cur_ea >= start_fn.end_ea
-            ):
-                raise Unexpected("Signature left function scope without being unique")
-
-            self.processor.append_instruction_to_sig(
-                sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
+            return GeneratedSignature(
+                sig,
+                Match(ea),
+                status=GenerationStatus.PARTIAL_ON_CANCEL,
+                match_count=last_match_count,
             )
-            bytes_since_last_check += ins_len
 
-            if SignatureSearcher.is_unique(f"{sig:ida}"):
-                sig.trim_signature()
-                return sig
+        try:
+            for cur_ea, ins, ins_len in InstructionWalker(ea):
+                # Check for cancellation via progress reporter
+                if self.progress_reporter is not None and self.progress_reporter.should_cancel():
+                    if policy.return_partial_on_cancel:
+                        return _build_partial()
+                    raise UserCanceledError("Signature generation canceled by user")
+
+                # Update progress periodically
+                instruction_count += 1
+                progress_reporting = self.progress_reporter is not None and self.progress_reporter.enabled()
+                if progress_reporting and instruction_count % 100 == 0:
+                    self.progress_reporter.report_progress(
+                        message=f"Generating signature at {hex(cur_ea)}",
+                        signature_length=len(sig),
+                        instructions_processed=instruction_count,
+                    )
+
+                # Check length constraint
+                if bytes_since_last_check > cfg.max_single_signature_length:
+                    if (
+                        not cfg.ask_longer_signature
+                        or idaapi.ask_yn(
+                            idaapi.ASKBTN_NO,
+                            f"Signature is already {len(sig)} bytes. Continue?",
+                        )
+                        != idaapi.ASKBTN_YES
+                    ):
+                        raise Unexpected("Signature not unique within length constraints")
+                    bytes_since_last_check = 0  # Reset counter after user confirmation
+
+                # Check function boundary constraint
+                if (
+                    not cfg.continue_outside_of_function
+                    and start_fn
+                    and cur_ea >= start_fn.end_ea
+                ):
+                    raise Unexpected("Signature left function scope without being unique")
+
+                self.processor.append_instruction_to_sig(
+                    sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
+                )
+                bytes_since_last_check += ins_len
+
+                count = SignatureSearcher.count_matches(f"{sig:ida}")
+                last_match_count = count
+                if count == 1:
+                    sig.trim_signature()
+                    return GeneratedSignature(sig, Match(ea))
+        except UserCanceledError:
+            # InstructionWalker raises UserCanceledError on cancel too (issue #18).
+            # Honor the policy here as well.
+            if policy.return_partial_on_cancel:
+                return _build_partial()
+            raise
 
         raise Unexpected("Signature not unique (reached end of analysis)")
 
@@ -1536,6 +1574,7 @@ class SignatureMaker:
         end: int | None = None,
         *,
         progress_reporter: typing.Optional[ProgressReporter] = None,
+        policy: GenerationPolicy = GenerationPolicy.strict(),
     ) -> GeneratedSignature:
         """Creates a signature for a single address (unique) or an address range.
 
@@ -1578,13 +1617,15 @@ class SignatureMaker:
         if end is None:
             # Create unique signature generator via factory method
             generator = self._create_generator(for_range=False, progress_reporter=progress_reporter)
-            sig = generator.generate(start_ea, cfg)
-            return GeneratedSignature(sig, Match(start_ea))
+            # UniqueSignatureGenerator.generate returns a GeneratedSignature
+            # directly so it can carry status + match_count on cancel.
+            return generator.generate(start_ea, cfg, policy=policy)
 
         if end <= start_ea:
             raise Unexpected("End address must be after start address")
 
-        # Create range signature generator via factory method
+        # Create range signature generator via factory method.
+        # Range generator returns a bare Signature; policy is not applicable.
         generator = self._create_generator(for_range=True, progress_reporter=progress_reporter)
         sig = generator.generate(start_ea, end, cfg)
         return GeneratedSignature(sig)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2214,7 +2214,8 @@ Quick Options:
 <#Enable wildcarding for operands, to improve stability of created signatures#Wildcards for operands:{cWildcardOperands}>
 <#Don't stop signature generation when reaching end of function#Continue when leaving function scope:{cContinueOutside}>
 <#Wildcard the whole instruction when the operand (usually a register) is encoded into the operator#Wildcard optimized / combined instructions:{cWildcardOptimized}>
-<#Opt-in -- show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>{cGroupOptions}>
+<#Opt-in -- show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>
+<#Opt-in -- when you cancel a unique-signature search, output the partial signature (with match count) instead of nothing. Default off. (Issue #22)#Output partial signature on cancel (opt-in):{cOutputPartialOnCancel}>{cGroupOptions}>
 
 <Operand types...:{bOperandTypes}><Other options...:{bOtherOptions}>
 """
@@ -2229,9 +2230,15 @@ Quick Options:
                 ("rIDASig", "rx64DbgSig", "rByteArrayMaskSig", "rRawBytesBitmaskSig")
             ),
             "cGroupOptions": idaapi.Form.ChkGroupControl(
-                ("cWildcardOperands", "cContinueOutside", "cWildcardOptimized", "cEnablePrompt"),
+                (
+                    "cWildcardOperands",
+                    "cContinueOutside",
+                    "cWildcardOptimized",
+                    "cEnablePrompt",
+                    "cOutputPartialOnCancel",
+                ),
                 # Bits: 1 (wildcards) + 4 (wildcard optimized). Bit 8 (enable
-                # prompt) defaults OFF; the wait-box Cancel handles long runs.
+                # prompt) and bit 16 (output partial on cancel) default OFF.
                 value=5,
             ),
             "bOperandTypes": F.ButtonInput(self.ConfigureOperandWildcardBitmask),
@@ -2372,6 +2379,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             continue_outside_of_function = bool(form.cGroupOptions.value & 2)  # type: ignore
             wildcard_optimized = bool(form.cGroupOptions.value & 4)  # type: ignore
             enable_continue_prompt = bool(form.cGroupOptions.value & 8)  # type: ignore
+            output_partial_on_cancel = bool(form.cGroupOptions.value & 16)  # type: ignore
 
         # Create SigMakerConfig
         config = SigMakerConfig(
@@ -2380,15 +2388,23 @@ class SigMakerPlugin(idaapi.plugin_t):
             continue_outside_of_function=continue_outside_of_function,
             wildcard_optimized=wildcard_optimized,
             enable_continue_prompt=enable_continue_prompt,
+            output_partial_on_cancel=output_partial_on_cancel,
         )
 
         try:
             if action == Action.CREATE_UNIQUE:
                 ea = idaapi.get_screen_ea()
+                policy = (
+                    GenerationPolicy.permissive()
+                    if config.output_partial_on_cancel
+                    else GenerationPolicy.strict()
+                )
                 with ProgressDialog(
                     "Generating signature...\n\nPress Cancel to stop"
                 ):
-                    signature = SignatureMaker().make_signature(ea, config)
+                    signature = SignatureMaker().make_signature(
+                        ea, config, policy=policy
+                    )
                 signature.display(config)
             elif action == Action.FIND_XREF:
                 ea = idaapi.get_screen_ea()

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2290,19 +2290,23 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
                     0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
                 )
 
-    def test_permissive_policy_does_not_trust_interrupted_count(self):
+    def test_permissive_policy_preserves_last_good_count_on_interruption(self):
         """count_matches bails early when idaapi_user_canceled() is True
         during its scan, returning a partial (often 0) count. The generator
-        must NOT record that as last_match_count, otherwise the partial sig
-        prints '0 matches' for a sig that actually matches many places.
-        Bug reported by @OshidaBCF on issue #22 after testing PR #25.
+        must not record that as last_match_count -- but it also must not
+        throw away the previous trustworthy count. The partial-on-cancel
+        path should show the last fully-completed iteration's count, which
+        is an upper bound on the actual match count for the (slightly
+        longer) emitted partial signature. Bug reported by @OshidaBCF on
+        issue #22 after testing PR #25.
         """
         # First two iterations: clean count_matches calls returning 100 and 50.
         # Third iteration: count_matches returns 0 AND idaapi_user_canceled
         # has just flipped to True (simulating cancel mid-scan).
         # Fourth iteration: should_cancel sees the cancel and builds the
-        # partial. We expect match_count=None (since the last count was
-        # interrupted), NOT 0.
+        # partial. We expect match_count == 50 (the prior trustworthy
+        # value), NOT 0 (the interrupted bogus value), and NOT None
+        # (which would discard useful information).
         gen = self._make_generator(cancel_after_iterations=3)
         counts = iter([100, 50, 0])
         user_canceled_state = {"value": False}
@@ -2336,10 +2340,51 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         self.assertEqual(
             result.status, sigmaker.GenerationStatus.PARTIAL_ON_CANCEL
         )
+        self.assertEqual(
+            result.match_count,
+            50,
+            "match_count must preserve the last trustworthy count "
+            "(50 from the prior iteration), not the interrupted "
+            "count_matches result of 0",
+        )
+
+    def test_permissive_policy_match_count_none_when_interrupted_on_first(self):
+        """If the very first count_matches call is interrupted, we have no
+        prior trustworthy count to fall back on, so match_count is None
+        (rendered as 'match count unavailable')."""
+        gen = self._make_generator(cancel_after_iterations=1)
+        user_canceled_state = {"value": False}
+
+        def fake_count_matches(_ida_sig):
+            # First (and only) call returns 0 with cancel flag already set.
+            user_canceled_state["value"] = True
+            return 0
+
+        def fake_user_canceled():
+            return user_canceled_state["value"]
+
+        original_user_canceled = sigmaker.idaapi_user_canceled
+        sigmaker.idaapi_user_canceled = fake_user_canceled
+        try:
+            with patch.object(
+                sigmaker.SignatureSearcher,
+                "count_matches",
+                side_effect=fake_count_matches,
+            ):
+                result = gen.generate(
+                    0x1000,
+                    self._make_cfg(),
+                    policy=sigmaker.GenerationPolicy.permissive(),
+                )
+        finally:
+            sigmaker.idaapi_user_canceled = original_user_canceled
+
+        self.assertEqual(
+            result.status, sigmaker.GenerationStatus.PARTIAL_ON_CANCEL
+        )
         self.assertIsNone(
             result.match_count,
-            "match_count must be None (rendered as 'match count "
-            "unavailable'), not the interrupted count_matches result of 0",
+            "match_count must be None when no prior trustworthy count exists",
         )
 
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,78 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestGeneratedSignatureDisplay(CoveredUnitTest):
+    """display() branches on status and respects the no-clipboard rule for partials."""
+
+    def setUp(self):
+        self.cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+        )
+        self.original_msg = sigmaker.idaapi.msg
+        self.msg_calls: list[str] = []
+        sigmaker.idaapi.msg = lambda s: self.msg_calls.append(s)
+
+    def tearDown(self):
+        sigmaker.idaapi.msg = self.original_msg
+
+    def _make_sig(self, n_bytes: int = 4) -> sigmaker.Signature:
+        sig = sigmaker.Signature()
+        for i in range(n_bytes):
+            sig.append(sigmaker.SignatureByte(0xE8 + i, False))
+        return sig
+
+    def test_unique_display_writes_clipboard(self):
+        sig = self._make_sig()
+        result = sigmaker.GeneratedSignature(sig, sigmaker.Match(0x1000))
+        with patch.object(sigmaker.Clipboard, "set_text", return_value=True) as set_text:
+            result.display(self.cfg)
+        set_text.assert_called_once()
+        self.assertTrue(any("Signature for" in m for m in self.msg_calls))
+
+    def test_partial_display_does_not_write_clipboard(self):
+        sig = self._make_sig()
+        result = sigmaker.GeneratedSignature(
+            sig,
+            sigmaker.Match(0x1000),
+            status=sigmaker.GenerationStatus.PARTIAL_ON_CANCEL,
+            match_count=47,
+        )
+        with patch.object(sigmaker.Clipboard, "set_text", return_value=True) as set_text:
+            result.display(self.cfg)
+        set_text.assert_not_called()
+
+    def test_partial_display_includes_match_count_in_message(self):
+        sig = self._make_sig()
+        result = sigmaker.GeneratedSignature(
+            sig,
+            sigmaker.Match(0x140001234),
+            status=sigmaker.GenerationStatus.PARTIAL_ON_CANCEL,
+            match_count=47,
+        )
+        with patch.object(sigmaker.Clipboard, "set_text", return_value=True):
+            result.display(self.cfg)
+        combined = "".join(self.msg_calls)
+        self.assertIn("NOT unique", combined)
+        self.assertIn("47", combined)
+        self.assertIn("Partial", combined)
+
+    def test_partial_display_does_not_recompute_match_count(self):
+        sig = self._make_sig()
+        result = sigmaker.GeneratedSignature(
+            sig,
+            sigmaker.Match(0x1000),
+            status=sigmaker.GenerationStatus.PARTIAL_ON_CANCEL,
+            match_count=3,
+        )
+        with patch.object(sigmaker.SignatureSearcher, "find_all") as fa, \
+                patch.object(sigmaker.Clipboard, "set_text", return_value=True):
+            result.display(self.cfg)
+        fa.assert_not_called()
+
+
 class TestGenerationStatusAndPolicy(CoveredUnitTest):
     """GenerationStatus and GenerationPolicy classmethods give callers a clean opt-in switch."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,33 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestGenerationStatusAndPolicy(CoveredUnitTest):
+    """GenerationStatus and GenerationPolicy classmethods give callers a clean opt-in switch."""
+
+    def test_generation_status_members(self):
+        import enum as _enum
+
+        self.assertTrue(issubclass(sigmaker.GenerationStatus, _enum.Enum))
+        self.assertEqual(sigmaker.GenerationStatus.UNIQUE.value, "unique")
+        self.assertEqual(sigmaker.GenerationStatus.PARTIAL_ON_CANCEL.value, "partial_on_cancel")
+
+    def test_generation_policy_strict_default(self):
+        policy = sigmaker.GenerationPolicy.strict()
+        self.assertFalse(policy.return_partial_on_cancel)
+
+    def test_generation_policy_permissive(self):
+        policy = sigmaker.GenerationPolicy.permissive()
+        self.assertTrue(policy.return_partial_on_cancel)
+
+    def test_generation_policy_default_constructor_matches_strict(self):
+        # A bare GenerationPolicy() must equal GenerationPolicy.strict() so the
+        # default kwarg in generate() preserves the existing contract.
+        self.assertEqual(
+            sigmaker.GenerationPolicy(),
+            sigmaker.GenerationPolicy.strict(),
+        )
+
+
 class TestSignatureSearcherCountMatches(CoveredUnitTest):
     """count_matches returns the cardinality of find_all; is_unique stays True only at 1."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,113 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
+    """policy=permissive returns a partial GeneratedSignature on cancel."""
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        # idaapi is module-level MagicMock; idaapi_user_canceled is bound from
+        # it at import time and would return a truthy MagicMock by default,
+        # firing the walker's cancel branch on every iteration. Reset.
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x90")
+        sigmaker.idaapi.get_func = MagicMock(return_value=None)
+        self._is_code_patcher = patch.object(
+            sigmaker, "is_address_marked_as_code", return_value=True
+        )
+        self._is_code_patcher.start()
+
+        # InstructionWalker's dataclass default `end_ea = idaapi.BADADDR` was
+        # evaluated at import time when idaapi was a MagicMock, so the default
+        # is a MagicMock attribute, not an int. Patching the live attribute
+        # doesn't fix the frozen default. Replace the class with a tiny generator
+        # for these tests -- they only care about the generator's policy
+        # handling, not walker iteration mechanics.
+        def _fake_walker(start_ea, *args, **kwargs):
+            cur = start_ea
+            while True:
+                ins = MagicMock()
+                ins.size = 1
+                yield cur, ins, 1
+                cur += 1
+
+        self._walker_patcher = patch.object(sigmaker, "InstructionWalker", _fake_walker)
+        self._walker_patcher.start()
+
+    def tearDown(self):
+        self._walker_patcher.stop()
+        self._is_code_patcher.stop()
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _make_generator(self, cancel_after_iterations: int):
+        """Construct a UniqueSignatureGenerator whose progress_reporter cancels
+        on the Nth should_cancel() call."""
+        calls = {"n": 0}
+
+        def should_cancel():
+            calls["n"] += 1
+            return calls["n"] > cancel_after_iterations
+
+        reporter = MagicMock()
+        reporter.should_cancel.side_effect = should_cancel
+        reporter.enabled.return_value = False
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        return sigmaker.UniqueSignatureGenerator(processor, reporter)
+
+    def _make_cfg(self) -> sigmaker.SigMakerConfig:
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=True,
+            wildcard_optimized=False,
+            ask_longer_signature=False,
+        )
+
+    def test_strict_policy_cancel_raises(self):
+        gen = self._make_generator(cancel_after_iterations=3)
+        with patch.object(sigmaker.SignatureSearcher, "count_matches", return_value=2):
+            with self.assertRaises(sigmaker.UserCanceledError):
+                gen.generate(0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.strict())
+
+    def test_permissive_policy_cancel_returns_partial(self):
+        gen = self._make_generator(cancel_after_iterations=3)
+        with patch.object(sigmaker.SignatureSearcher, "count_matches", return_value=2):
+            result = gen.generate(
+                0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
+            )
+        self.assertIsInstance(result, sigmaker.GeneratedSignature)
+        self.assertEqual(result.status, sigmaker.GenerationStatus.PARTIAL_ON_CANCEL)
+        self.assertEqual(result.match_count, 2)
+        self.assertGreater(len(result.signature), 0)
+        self.assertEqual(result.address, sigmaker.Match(0x1000))
+
+    def test_permissive_policy_unique_returns_unique(self):
+        gen = self._make_generator(cancel_after_iterations=99)
+        counts = iter([2, 2, 1])
+        with patch.object(
+            sigmaker.SignatureSearcher,
+            "count_matches",
+            side_effect=lambda *_: next(counts),
+        ):
+            result = gen.generate(
+                0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
+            )
+        self.assertEqual(result.status, sigmaker.GenerationStatus.UNIQUE)
+        self.assertIsInstance(result, sigmaker.GeneratedSignature)
+
+    def test_permissive_policy_cancel_before_any_byte_raises(self):
+        gen = self._make_generator(cancel_after_iterations=0)
+        with patch.object(sigmaker.SignatureSearcher, "count_matches", return_value=2):
+            with self.assertRaises(sigmaker.UserCanceledError):
+                gen.generate(
+                    0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
+                )
+
+
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
     """display() branches on status and respects the no-clipboard rule for partials."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2213,6 +2213,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         # firing the walker's cancel branch on every iteration. Reset.
         sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
         sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
         sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x90")
         sigmaker.idaapi.get_func = MagicMock(return_value=None)
@@ -2221,25 +2222,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         )
         self._is_code_patcher.start()
 
-        # InstructionWalker's dataclass default `end_ea = idaapi.BADADDR` was
-        # evaluated at import time when idaapi was a MagicMock, so the default
-        # is a MagicMock attribute, not an int. Patching the live attribute
-        # doesn't fix the frozen default. Replace the class with a tiny generator
-        # for these tests -- they only care about the generator's policy
-        # handling, not walker iteration mechanics.
-        def _fake_walker(start_ea, *args, **kwargs):
-            cur = start_ea
-            while True:
-                ins = MagicMock()
-                ins.size = 1
-                yield cur, ins, 1
-                cur += 1
-
-        self._walker_patcher = patch.object(sigmaker, "InstructionWalker", _fake_walker)
-        self._walker_patcher.start()
-
     def tearDown(self):
-        self._walker_patcher.stop()
         self._is_code_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2290,6 +2290,58 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
                     0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
                 )
 
+    def test_permissive_policy_does_not_trust_interrupted_count(self):
+        """count_matches bails early when idaapi_user_canceled() is True
+        during its scan, returning a partial (often 0) count. The generator
+        must NOT record that as last_match_count, otherwise the partial sig
+        prints '0 matches' for a sig that actually matches many places.
+        Bug reported by @OshidaBCF on issue #22 after testing PR #25.
+        """
+        # First two iterations: clean count_matches calls returning 100 and 50.
+        # Third iteration: count_matches returns 0 AND idaapi_user_canceled
+        # has just flipped to True (simulating cancel mid-scan).
+        # Fourth iteration: should_cancel sees the cancel and builds the
+        # partial. We expect match_count=None (since the last count was
+        # interrupted), NOT 0.
+        gen = self._make_generator(cancel_after_iterations=3)
+        counts = iter([100, 50, 0])
+        user_canceled_state = {"value": False}
+
+        def fake_count_matches(_ida_sig):
+            v = next(counts)
+            if v == 0:
+                # Simulate find_all bailing because the user just clicked Cancel.
+                user_canceled_state["value"] = True
+            return v
+
+        def fake_user_canceled():
+            return user_canceled_state["value"]
+
+        original_user_canceled = sigmaker.idaapi_user_canceled
+        sigmaker.idaapi_user_canceled = fake_user_canceled
+        try:
+            with patch.object(
+                sigmaker.SignatureSearcher,
+                "count_matches",
+                side_effect=fake_count_matches,
+            ):
+                result = gen.generate(
+                    0x1000,
+                    self._make_cfg(),
+                    policy=sigmaker.GenerationPolicy.permissive(),
+                )
+        finally:
+            sigmaker.idaapi_user_canceled = original_user_canceled
+
+        self.assertEqual(
+            result.status, sigmaker.GenerationStatus.PARTIAL_ON_CANCEL
+        )
+        self.assertIsNone(
+            result.match_count,
+            "match_count must be None (rendered as 'match count "
+            "unavailable'), not the interrupted count_matches result of 0",
+        )
+
 
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
     """display() branches on status and respects the no-clipboard rule for partials."""

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2147,6 +2147,15 @@ class TestSigMakerConfigDefaults(CoveredUnitTest):
         self.assertFalse(cfg.enable_continue_prompt)
         self.assertEqual(cfg.prompt_interval, -1)
 
+    def test_default_output_partial_on_cancel_is_false(self):
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+        )
+        self.assertFalse(cfg.output_partial_on_cancel)
+
 
 class TestInstructionWalkerCancellation(CoveredUnitTest):
     """User-cancellation inside InstructionWalker must raise UserCanceledError, not StopIteration."""

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,29 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestSignatureSearcherCountMatches(CoveredUnitTest):
+    """count_matches returns the cardinality of find_all; is_unique stays True only at 1."""
+
+    def test_count_matches_returns_len_of_find_all(self):
+        fake_matches = [sigmaker.Match(0x1000), sigmaker.Match(0x2000), sigmaker.Match(0x3000)]
+        with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=fake_matches):
+            count = sigmaker.SignatureSearcher.count_matches("E8 ?? ?? ?? ??")
+        self.assertEqual(count, 3)
+
+    def test_count_matches_zero_when_no_hits(self):
+        with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=[]):
+            count = sigmaker.SignatureSearcher.count_matches("DE AD BE EF")
+        self.assertEqual(count, 0)
+
+    def test_is_unique_true_only_at_one(self):
+        with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=[sigmaker.Match(0x1000)]):
+            self.assertTrue(sigmaker.SignatureSearcher.is_unique("xx"))
+        with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=[]):
+            self.assertFalse(sigmaker.SignatureSearcher.is_unique("xx"))
+        with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=[sigmaker.Match(1), sigmaker.Match(2)]):
+            self.assertFalse(sigmaker.SignatureSearcher.is_unique("xx"))
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #22.

## Background

From [@OshidaBCF](https://github.com/OshidaBCF) on [issue thread #22](https://github.com/mahmoudimus/ida-sigmaker/issues/22):

> The search has been going for 10 minutes now, and it's at least 200 byte long, while i don't mind waiting, when i inevitably decide to cancel it, i'd like to get a "partial" signature

Today, when a unique-signature search is cancelled, the in-progress signature lives only as a local variable inside `UniqueSignatureGenerator.generate` and gets thrown away. The user sees `Operation cancelled by user` and nothing else. This PR keeps the partial around when the user opts in.

## Algorithm note

The generator already calls `is_unique(...)` on every iteration, implemented as `len(find_all(...)) == 1`. That is, every byte we append, we do a full database scan and then throw the count away. So the match count we want to show on cancel was *already being computed every iteration* in the loop above; we just weren't keeping it.

I expose the count via a new `SignatureSearcher.count_matches`, rewrite `is_unique` on top of it, and have the generator hold onto the last value it observed. On cancel, the most recent count is exactly the right number for the bytes currently in the partial signature, by construction (the cancel check is at the top of the loop, `count_matches` is at the bottom). Zero extra search work.

## Net behavior

- **Default.** Cancel a unique-signature search and the output reads `Operation cancelled by user`. No change from current behavior.
- **Opt-in.** Tick "Output partial signature on cancel (opt-in)" on the main form. Cancel mid-run prints something like `Partial signature (NOT unique, 47 matches) for 0x140001234: E8 ?? ?? ?? ?? 45 33 F6 ...`. The clipboard is **not** touched, so an accidental cancel cannot clobber what you had copied before.
- **Cancel before any byte is appended.** Still reads `Operation cancelled by user`, so no zero-byte garbage printed.
- **XREF and range paths** are untouched.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit (`tests/unit_test_sigmaker.py`) | 118 OK | 134 OK (+16 new) |
| Docker `idapro-tests` (9.0/9.1) | 134 OK | 150 OK |
| Docker `idapro-tests-9.2` | 134 OK | 150 OK |

Zero regressions. New test coverage:

- `TestSignatureSearcherCountMatches`: `count_matches` equals `len(find_all(...))`; `is_unique` stays True only at exactly 1.
- `TestGenerationStatusAndPolicy`: enum members and policy classmethods.
- `TestGeneratedSignatureDisplay`: UNIQUE prints and writes clipboard; PARTIAL_ON_CANCEL prints with match count and does not write clipboard; partials never recompute the count.
- `TestUniqueSignatureGeneratorPartialOnCancel`: strict cancel raises; permissive cancel returns a partial with the last-observed match count; permissive + unique returns UNIQUE; permissive cancel before any byte appended still raises.
- `TestSigMakerConfigDefaults`: new field defaults False.
