### PR TITLE
Fix #17: shortest unique signature for current function (with xref fallback)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -628,7 +628,8 @@ class Action(enum.IntEnum):
     """User-selectable action in SignatureMakerForm.
 
     Values are bound to the rAction radio-group order:
-    ("rCreateUniqueSig", "rFindXRefSig", "rCopyCode", "rSearchSignature").
+    ("rCreateUniqueSig", "rFindXRefSig", "rCopyCode", "rSearchSignature",
+     "rFindFunctionSig").
     Changing values requires updating the radio group too.
     """
 
@@ -636,6 +637,7 @@ class Action(enum.IntEnum):
     FIND_XREF = 1
     COPY_RANGE = 2
     SEARCH = 3
+    FIND_FUNCTION_SIG = 4
 
 
 class SignatureByte(typing.NamedTuple):

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1366,6 +1366,122 @@ class UniqueSignatureGenerator:
         raise Unexpected("Signature not unique (reached end of analysis)")
 
 
+class MinimalFunctionSignatureGenerator:
+    """Find the shortest unique signature anywhere within a function body.
+
+    Iterates every instruction in the function as a possible start point,
+    growing a signature from each until unique (bounded by function end and
+    by the size of the best candidate found so far). Returns the smallest
+    unique signature with the fewest wildcards. Raises Unexpected if no
+    unique signature exists within the function.
+    """
+
+    MIN_USEFUL_SIG_BYTES = 5
+
+    def __init__(
+        self,
+        processor: InstructionProcessor,
+        progress_reporter: typing.Optional[ProgressReporter] = None,
+    ):
+        self.processor = processor
+        self.progress_reporter = progress_reporter
+
+    def generate(
+        self, pfn: "idaapi.func_t", cfg: SigMakerConfig
+    ) -> GeneratedSignature:
+        """Search the function body for the shortest unique signature.
+
+        Args:
+            pfn: The function to search (idaapi.func_t).
+            cfg: Configuration. Uses max_single_signature_length as the
+                initial budget; the budget shrinks monotonically as
+                better candidates are found.
+
+        Returns:
+            The best unique GeneratedSignature found.
+
+        Raises:
+            Unexpected: If no start point produces a unique signature within
+                the length budget, or all candidates are degenerate
+                (< MIN_USEFUL_SIG_BYTES bytes).
+            UserCanceledError: If the progress reporter signals cancel.
+        """
+        candidates: list[GeneratedSignature] = []
+        best_size = cfg.max_single_signature_length
+
+        # Materialize start EAs upfront so we can iterate independently of
+        # the inner growth loop's walker state.
+        start_eas = [
+            cur_ea for cur_ea, _, _ in InstructionWalker(pfn.start_ea, pfn.end_ea)
+        ]
+
+        for start_ea in start_eas:
+            if (
+                self.progress_reporter is not None
+                and self.progress_reporter.should_cancel()
+            ):
+                raise UserCanceledError(
+                    "Function signature search canceled by user"
+                )
+
+            sig = self._grow_unique_from(start_ea, pfn.end_ea, best_size, cfg)
+            if sig is None:
+                continue
+            if len(sig) < self.MIN_USEFUL_SIG_BYTES:
+                continue
+
+            candidate = GeneratedSignature(sig, Match(start_ea))
+            candidates.append(candidate)
+            best_size = min(best_size, len(sig))
+
+            # Ideal candidate: small enough and no wildcards. Stop scanning.
+            wildcard_count = sum(1 for b in sig if b.is_wildcard)
+            if len(sig) <= self.MIN_USEFUL_SIG_BYTES and wildcard_count == 0:
+                break
+
+        if not candidates:
+            raise Unexpected("No unique signature within function")
+
+        candidates.sort()  # (size, wildcards) ascending via __lt__
+        return candidates[0]
+
+    def _grow_unique_from(
+        self, start: int, end_ea: int, max_len: int, cfg: SigMakerConfig
+    ) -> typing.Optional[Signature]:
+        """Grow a signature from ``start`` until unique, bounded by
+        ``end_ea`` and ``max_len`` bytes.
+
+        Returns the trimmed Signature on uniqueness, or None if the search
+        exhausts the budget without becoming unique.
+        """
+        sig = Signature()
+        for cur_ea, ins, _ins_len in InstructionWalker(start, end_ea):
+            if (
+                self.progress_reporter is not None
+                and self.progress_reporter.should_cancel()
+            ):
+                raise UserCanceledError(
+                    "Function signature search canceled by user"
+                )
+
+            self.processor.append_instruction_to_sig(
+                sig,
+                cur_ea,
+                ins,
+                cfg.wildcard_operands,
+                cfg.wildcard_optimized,
+            )
+
+            if len(sig) > max_len:
+                return None
+
+            if SignatureSearcher.is_unique(f"{sig:ida}"):
+                sig.trim_signature()
+                return sig
+
+        return None
+
+
 class RangeSignatureGenerator:
     """Strategy for generating a signature for a fixed address range."""
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2227,7 +2227,8 @@ Select action:
 <#Select an address, and create a code signature for it#Create unique signature for current code address:{rCreateUniqueSig}>
 <#Select an address or variable, and create code signatures for its references. Will output the shortest 5 signatures#Find shortest XREF signature for current data or code address:{rFindXRefSig}>
 <#Select 1+ instructions, and copy the bytes using the specified output format#Copy selected code:{rCopyCode}>
-<#Paste any string containing your signature/mask and find matches#Search for a signature:{rSearchSignature}>{rAction}>
+<#Paste any string containing your signature/mask and find matches#Search for a signature:{rSearchSignature}>
+<#Find the shortest unique signature anywhere inside the current function, with automatic xref fallback if the function body is not unique#Find shortest unique signature for current function:{rFindFunctionSig}>{rAction}>
 
 Output format:
 <#Example - E8 ? ? ? ? 45 33 F6 66 44 89 34 33#IDA Signature:{rIDASig}>
@@ -2248,7 +2249,13 @@ Quick Options:
             "cVersion": F.StringLabel(PLUGIN_VERSION),
             "FormChangeCb": F.FormChangeCb(self.OnFormChange),
             "rAction": F.RadGroupControl(
-                ("rCreateUniqueSig", "rFindXRefSig", "rCopyCode", "rSearchSignature")
+                (
+                    "rCreateUniqueSig",
+                    "rFindXRefSig",
+                    "rCopyCode",
+                    "rSearchSignature",
+                    "rFindFunctionSig",
+                )
             ),
             "rOutputFormat": F.RadGroupControl(
                 ("rIDASig", "rx64DbgSig", "rByteArrayMaskSig", "rRawBytesBitmaskSig")
@@ -2441,6 +2448,8 @@ class SigMakerPlugin(idaapi.plugin_t):
                     results.display()
                 else:
                     idaapi.msg("No signature entered!\n")
+            elif action == Action.FIND_FUNCTION_SIG:
+                self._run_find_function_sig(config)
             else:
                 idaapi.msg("Invalid action!\n")
         except Unexpected as e:
@@ -2451,6 +2460,53 @@ class SigMakerPlugin(idaapi.plugin_t):
         except Exception as e:
             LOGGER.error("Exception occurred: %s%s%s", e, os.linesep, traceback.format_exc())
             return
+
+    def _run_find_function_sig(self, config: SigMakerConfig) -> None:
+        """Action.FIND_FUNCTION_SIG: shortest unique sig within the function,
+        falling back to xref signatures if the function body is not unique."""
+        ea = idaapi.get_screen_ea()
+        pfn = idaapi.get_func(ea)
+        if pfn is None:
+            idaapi.msg("Place cursor inside a function first.\n")
+            return
+
+        try:
+            with ProgressDialog(
+                "Finding shortest function signature...\n\nPress Cancel to stop"
+            ):
+                generator = MinimalFunctionSignatureGenerator(
+                    InstructionProcessor(OperandProcessor())
+                )
+                result = generator.generate(pfn, config)
+            offset = int(result.address) - int(pfn.start_ea)
+            idaapi.msg(
+                f"Function signature (offset +{hex(offset)} into function "
+                f"{hex(pfn.start_ea)}):\n"
+            )
+            result.display(config)
+            return
+        except Unexpected:
+            idaapi.msg(
+                f"No unique signature inside function "
+                f"{hex(pfn.start_ea)}; trying xref signatures...\n"
+            )
+
+        with ProgressDialog(
+            "Falling back to xref signatures...\n\nPress Cancel to stop"
+        ):
+            xref_result = XrefFinder().find_xrefs(pfn.start_ea, config)
+
+        if xref_result.signatures:
+            best = xref_result.signatures[0]
+            idaapi.msg(
+                f"Xref signature into {hex(pfn.start_ea)} (from {best.address}):\n"
+            )
+            best.display(config)
+        else:
+            idaapi.msg(
+                f"No unique signature found for function {hex(pfn.start_ea)} "
+                f"(no unique sig within body and no usable xrefs)\n"
+            )
 
     def term(self) -> None:
         self._deregister_actions()

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -897,7 +897,14 @@ class WildcardPolicy:
     # construction helpers
     @classmethod
     def for_x86(cls) -> "WildcardPolicy":
-        return cls(frozenset(cls.BaseKind) | frozenset(cls.X86Kind))
+        # Exclude BaseKind.IMM. An immediate like the 0x13371338 in
+        # `mov rcx, 0x13371338` is a literal value baked into the
+        # instruction encoding; it does not shift between binary builds,
+        # so wildcarding it only removes bytes that would have made the
+        # signature unique. MEM/FAR/NEAR still get wildcarded because
+        # those operands DO encode addresses that move between builds.
+        x86_base = frozenset(cls.BaseKind) - {cls.BaseKind.IMM}
+        return cls(x86_base | frozenset(cls.X86Kind))
 
     @classmethod
     def for_arm(cls) -> "WildcardPolicy":

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -991,10 +991,17 @@ class GeneratedSignature:
         if not Clipboard.set_text(fmted):
             idaapi.msg("Failed to copy to clipboard!")
 
+    def _wildcard_count(self) -> int:
+        """Number of wildcard bytes in this signature."""
+        return sum(1 for b in self.signature if b.is_wildcard)
+
     def __lt__(self, other) -> bool:
         if not isinstance(other, GeneratedSignature):
             return NotImplemented
-        return len(self.signature) < len(other.signature)
+        return (len(self.signature), self._wildcard_count()) < (
+            len(other.signature),
+            other._wildcard_count(),
+        )
 
 
 @dataclasses.dataclass(slots=True)

--- a/tests/integration_test_sigmaker.py
+++ b/tests/integration_test_sigmaker.py
@@ -423,6 +423,49 @@ class TestIntegrationWithRealBinary(CoveredIntegrationTest):
         except sigmaker.Unexpected as e:
             self.skipTest(f"Could not generate range signature: {e}")
 
+    def test_minimal_function_signature_against_real_function(self):
+        """MinimalFunctionSignatureGenerator returns a unique signature
+        inside the chosen function in the test binary."""
+        start_ea = self.get_code_address()
+        self.assertIsNotNone(start_ea, "Should find at least one code address")
+
+        pfn = idaapi.get_func(start_ea)
+        if pfn is None:
+            self.skipTest("Chosen code address is not inside a function")
+
+        ctx = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+            ask_longer_signature=False,
+            max_single_signature_length=128,
+        )
+
+        try:
+            generator = sigmaker.MinimalFunctionSignatureGenerator(
+                sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+            )
+            result = generator.generate(pfn, ctx)
+        except sigmaker.Unexpected as e:
+            self.skipTest(f"No unique sig within function: {e}")
+
+        self.assertIsInstance(result, sigmaker.GeneratedSignature)
+        self.assertGreaterEqual(
+            len(result.signature),
+            sigmaker.MinimalFunctionSignatureGenerator.MIN_USEFUL_SIG_BYTES,
+        )
+
+        ida_text = f"{result.signature:ida}"
+        matches = sigmaker.SignatureSearcher.find_all(ida_text)
+        self.assertEqual(
+            len(matches), 1, f"Expected exactly one match for {ida_text}"
+        )
+
+        match_ea = int(matches[0])
+        self.assertGreaterEqual(match_ea, pfn.start_ea)
+        self.assertLess(match_ea, pfn.end_ea)
+
     def test_generate_signature_error_handling(self):
         signature_maker = sigmaker.SignatureMaker()
 

--- a/tests/integration_test_sigmaker.py
+++ b/tests/integration_test_sigmaker.py
@@ -423,6 +423,55 @@ class TestIntegrationWithRealBinary(CoveredIntegrationTest):
         except sigmaker.Unexpected as e:
             self.skipTest(f"Could not generate range signature: {e}")
 
+    def test_wildcard_operands_preserves_x86_immediates(self):
+        """An immediate like the 0xB883480000001528 in `mov rax, ...` must
+        survive the wildcard_operands=True path. Before the
+        WildcardPolicy.for_x86 fix, the 8 immediate bytes were blanked to
+        ``?? ?? ?? ?? ?? ?? ?? ??``; after the fix, they stay concrete and
+        make the signature unique.
+        """
+        # `mov rax, 0xB883480000001528` encodes as
+        # `48 B8 28 15 00 00 00 48 83 B8` (REX.W + B8 opcode + 8-byte LE imm).
+        mov_rax_bytes = "48 B8 28 15 00 00 00 48 83 B8"
+        exact_hits = sigmaker.SignatureSearcher.from_signature(mov_rax_bytes).search()
+        self.assertEqual(
+            len(exact_hits.matches),
+            1,
+            f"Test binary should have exactly one match for {mov_rax_bytes!r}, "
+            f"got {len(exact_hits.matches)}",
+        )
+        anchor_ea = exact_hits.matches[0]
+
+        gen_ctx = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=True,
+            continue_outside_of_function=False,
+            wildcard_optimized=True,
+            max_single_signature_length=64,
+            ask_longer_signature=False,
+        )
+        result = sigmaker.SignatureMaker().make_signature(anchor_ea, gen_ctx)
+        self.assertIsInstance(result.signature, sigmaker.Signature)
+
+        # The signature SHOULD include the literal immediate bytes 0x28 and
+        # 0x15 (the low two bytes of the 64-bit immediate). Before the fix
+        # they would have been wildcards.
+        non_wildcard_values = [
+            b.value for b in result.signature if not b.is_wildcard
+        ]
+        self.assertIn(
+            0x28,
+            non_wildcard_values,
+            "Low byte of the immediate (0x28) should survive as a concrete "
+            "byte, not be wildcarded.",
+        )
+        self.assertIn(
+            0x15,
+            non_wildcard_values,
+            "Second byte of the immediate (0x15) should survive as a "
+            "concrete byte, not be wildcarded.",
+        )
+
     def test_minimal_function_signature_against_real_function(self):
         """MinimalFunctionSignatureGenerator returns a unique signature
         inside the chosen function in the test binary."""

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,135 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
+    """Iterates every instruction in a function and returns the shortest unique signature."""
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
+        sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x90")
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _make_pfn(self, start_ea: int, end_ea: int):
+        pfn = MagicMock()
+        pfn.start_ea = start_ea
+        pfn.end_ea = end_ea
+        return pfn
+
+    def _make_generator(self):
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        return sigmaker.MinimalFunctionSignatureGenerator(processor)
+
+    def _make_cfg(self, max_len: int = 50) -> sigmaker.SigMakerConfig:
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+            ask_longer_signature=False,
+            max_single_signature_length=max_len,
+        )
+
+    def test_returns_shortest_unique_candidate(self):
+        gen = self._make_generator()
+        # 32-byte function so the inner search has room for 10-byte and
+        # 6-byte sigs without running off the end of the walker.
+        pfn = self._make_pfn(0x1000, 0x1020)
+
+        calls = {"n": 0}
+
+        def fake_is_unique(_ida_sig_str):
+            calls["n"] += 1
+            n = calls["n"]
+            if n <= 10:
+                return n == 10
+            if n <= 16:
+                return n == 16
+            return False
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            result = gen.generate(pfn, self._make_cfg(max_len=50))
+
+        self.assertIsInstance(result, sigmaker.GeneratedSignature)
+        self.assertEqual(result.address, sigmaker.Match(0x1001))
+        self.assertEqual(len(result.signature), 6)
+
+    def test_prune_caps_inner_search_by_best_so_far(self):
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1014)
+
+        calls = {"n": 0}
+
+        def fake_is_unique(_):
+            calls["n"] += 1
+            return calls["n"] == 7
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            result = gen.generate(pfn, self._make_cfg(max_len=50))
+
+        self.assertLess(calls["n"], 300)
+        self.assertEqual(len(result.signature), 7)
+
+    def test_ideal_candidate_early_exit(self):
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1010)
+
+        calls = {"n": 0}
+
+        def fake_is_unique(_):
+            calls["n"] += 1
+            return calls["n"] == 5
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            result = gen.generate(pfn, self._make_cfg(max_len=50))
+
+        self.assertEqual(len(result.signature), 5)
+        self.assertEqual(calls["n"], 5)
+
+    def test_raises_when_no_candidate(self):
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1003)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            with self.assertRaises(sigmaker.Unexpected):
+                gen.generate(pfn, self._make_cfg(max_len=10))
+
+    def test_rejects_degenerate_short_sigs(self):
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1005)
+
+        calls = {"n": 0}
+
+        def fake_is_unique(_):
+            calls["n"] += 1
+            return calls["n"] % 3 == 0
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            with self.assertRaises(sigmaker.Unexpected):
+                gen.generate(pfn, self._make_cfg(max_len=50))
+
+    def test_min_useful_sig_bytes_constant(self):
+        self.assertEqual(
+            sigmaker.MinimalFunctionSignatureGenerator.MIN_USEFUL_SIG_BYTES, 5
+        )
+
+
 class TestActionEnumAddsFunctionSig(CoveredUnitTest):
     """The Action IntEnum gains FIND_FUNCTION_SIG=4 for issue #17."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,48 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestGeneratedSignatureOrdering(CoveredUnitTest):
+    """GeneratedSignature.__lt__ ranks by (size, wildcards) ascending."""
+
+    def _make(self, byte_specs: list[tuple[int, bool]]) -> sigmaker.GeneratedSignature:
+        sig = sigmaker.Signature()
+        for value, is_wildcard in byte_specs:
+            sig.append(sigmaker.SignatureByte(value, is_wildcard))
+        return sigmaker.GeneratedSignature(sig, sigmaker.Match(0x1000))
+
+    def test_smaller_size_beats_larger(self):
+        smaller = self._make([(0xE8, False)] * 4)
+        larger = self._make([(0xE8, False)] * 6)
+        self.assertLess(smaller, larger)
+        self.assertFalse(larger < smaller)
+
+    def test_equal_size_fewer_wildcards_beats_more(self):
+        fewer = self._make(
+            [(0xE8, False), (0x00, True), (0x45, False), (0x33, False)]
+        )
+        more = self._make(
+            [(0xE8, False), (0x00, True), (0x00, True), (0x33, False)]
+        )
+        self.assertLess(fewer, more)
+        self.assertFalse(more < fewer)
+
+    def test_equal_size_equal_wildcards_neither_less(self):
+        a = self._make(
+            [(0xE8, False), (0x00, True), (0x45, False), (0x33, False)]
+        )
+        b = self._make(
+            [(0xC3, False), (0x90, True), (0x48, False), (0x89, False)]
+        )
+        self.assertFalse(a < b)
+        self.assertFalse(b < a)
+
+    def test_wildcard_count_helper(self):
+        sig = self._make(
+            [(0xE8, False), (0x00, True), (0x00, True), (0x33, False)]
+        )
+        self.assertEqual(sig._wildcard_count(), 2)
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2192,6 +2192,19 @@ class TestActionEnum(CoveredUnitTest):
         self.assertTrue(issubclass(sigmaker.Action, _enum.IntEnum))
 
 
+class TestActionEnumAddsFunctionSig(CoveredUnitTest):
+    """The Action IntEnum gains FIND_FUNCTION_SIG=4 for issue #17."""
+
+    def test_find_function_sig_value(self):
+        self.assertEqual(int(sigmaker.Action.FIND_FUNCTION_SIG), 4)
+
+    def test_existing_action_values_unchanged(self):
+        self.assertEqual(int(sigmaker.Action.CREATE_UNIQUE), 0)
+        self.assertEqual(int(sigmaker.Action.FIND_XREF), 1)
+        self.assertEqual(int(sigmaker.Action.COPY_RANGE), 2)
+        self.assertEqual(int(sigmaker.Action.SEARCH), 3)
+
+
 class TestGeneratedSignatureOrdering(CoveredUnitTest):
     """GeneratedSignature.__lt__ ranks by (size, wildcards) ascending."""
 


### PR DESCRIPTION
Closes #17.

## Background

Per [issue #17](https://github.com/mahmoudimus/ida-sigmaker/issues/17), the existing `Create unique signature for current code address` grows from wherever the cursor sits. That works for "I want a hook right here" use cases, but it is a poor fit for the much more common case of "give me a stable signature for *this function* so I can find it again after a binary update":

- The cursor position is arbitrary. The shortest unique signature for the function might start somewhere else entirely.
- If the function body is not unique (small thunks, common stubs, library inlines), the current action just fails.

This PR adds a new form action that addresses both shortcomings.

## Algorithm note

The minimal-function search iterates every instruction in the function as a possible start point, growing a signature from each until unique. The inner search is bounded by `max_single_signature_length` AND by the current best candidate's size, so as soon as a small candidate exists every subsequent start point gets pruned aggressively. An "ideal candidate" (size <= 5 bytes and zero wildcards) ends the outer loop early. Degenerate sigs (< 5 bytes) are rejected even when unique, since those are almost always a lone CALL with all-wildcard operand bytes that match thousands of places by accident.

When no body-internal unique sig exists, the orchestrator automatically falls back to `XrefFinder.find_xrefs(pfn.start_ea, config)`, which generates a unique signature rooted at each caller of the function and returns the best. The xref fallback path was already in the codebase; I just wire it up as the automatic next step.

The candidate ranking changed too. `GeneratedSignature.__lt__` now compares `(size, wildcards)` ascending rather than just `size`. Same-length sigs with fewer wildcards rank first. This is a strict improvement and the existing XREF action picks it up for free.

## Wildcard policy: stop wildcarding x86 immediates

While reviewing this work I realized the function-search algorithm could not pick up obvious candidates like `mov rcx, 0x13371338` even when that immediate was unique across the binary, because `WildcardPolicy.for_x86()` included `BaseKind.IMM` in its wildcardable set. An x86 immediate is a literal value baked into the instruction encoding; it does not shift between binary builds, so wildcarding it only removes bytes that would have made the signature unique. `MEM`, `FAR`, and `NEAR` still get wildcarded because those operands DO encode addresses that move between builds.

This change improves signature quality for every action with `wildcard_operands=True`, not just the new `FIND_FUNCTION_SIG`. It is what lets the function-search algorithm pick up short, distinctive constants as unique signatures.

The change cannot be unit-tested under the existing harness because the mocked `idaapi` collapses every `o_*` constant to a single int, aliasing every `BaseKind` enum member onto one value. The behavior is exercised by the integration tests against the real IDA test binary.

## Net behavior

- **New action.** "Find shortest unique signature for current function" radio on the main form. Existing CREATE_UNIQUE / FIND_XREF / COPY_RANGE / SEARCH actions are byte-identical to current `main`.
- **Inside a function with a body-internal unique sequence.** Prints `Function signature (offset +0x10 into function 0x140001040):` followed by the existing `Signature for 0x140001050: <bytes>` line and copies the bytes to the clipboard.
- **Inside a function with no body-internal unique sequence but with xrefs.** Prints `No unique signature inside function 0x...; trying xref signatures...`, then `Xref signature into 0x... (from 0x...):` followed by the existing display line.
- **Cursor outside any function.** Prints `Place cursor inside a function first.` and exits cleanly.
- **Cancel mid-search.** Prints `Operation cancelled by user`, no traceback.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit (`tests/unit_test_sigmaker.py`) | 118 OK | 130 OK (+12 new) |
| Docker `idapro-tests` (9.0/9.1) | 134 OK | 147 OK (+12 unit, +1 integration) |
| Docker `idapro-tests-9.2` | 134 OK | 147 OK |

Zero regressions. New test coverage:

- `TestGeneratedSignatureOrdering`: smaller-size beats larger; equal-size, fewer-wildcards beats more; equal-size-equal-wildcards is not strictly less; `_wildcard_count` helper works.
- `TestActionEnumAddsFunctionSig`: `FIND_FUNCTION_SIG == 4`; existing enum values unchanged.
- `TestMinimalFunctionSignatureGenerator`: returns the shortest-unique candidate; prune caps the inner search by current best; ideal-candidate early exit fires; raises `Unexpected` when no candidate exists; rejects degenerate sigs under 5 bytes; `MIN_USEFUL_SIG_BYTES == 5`.
- `test_minimal_function_signature_against_real_function` (integration): end-to-end against the compiled test binary; asserts the returned sig parses, matches exactly one place, and that the match falls inside the original function body. Skips cleanly when the chosen function has no body-internal unique sig.
