### PR TITLE
Release 1.7.0: CHANGELOG + version bump + US spelling fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.7.0] - 2026-05-27
+
+### Added
+
+- **Wait-box cancel for long signature generation.** A non-blocking wait box now appears while sigmaker is searching, with a Cancel button you can click at any time to stop the search cleanly. Replaces the previous default of recurring "Continue?" modal popups. Canceling produces a clean `Operation canceled by user` message in the output log, with no traceback. ([#18](https://github.com/mahmoudimus/ida-sigmaker/issues/18), [#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+- **Opt-in `Enable continue prompt` checkbox** on the main form. Ticking it restores the previous periodic prompt behavior for anyone who prefers it. Off by default. ([#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+- **Opt-in `Prompt interval` field** in the "Other options..." dialog. Sets how many seconds to wait before the first periodic prompt fires; `-1` disables the prompt entirely. Default `-1`. ([#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+- **Opt-in `Output partial signature on cancel` checkbox** on the main form. When ticked, canceling a unique-signature search emits the partial signature with a match count instead of nothing. Off by default; output goes to the console only (no clipboard write) so an accidental cancel cannot clobber the clipboard. ([#22](https://github.com/mahmoudimus/ida-sigmaker/issues/22), [#25](https://github.com/mahmoudimus/ida-sigmaker/pull/25))
+
+### Changed
+
+- **Default cancel UX.** Out of the box, a sigmaker search now shows a wait box with a Cancel button instead of firing periodic "Continue?" popups. The popup behavior is preserved as the new opt-in described above. ([#18](https://github.com/mahmoudimus/ida-sigmaker/issues/18), [#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+
+### Fixed
+
+- **Canceling a unique-signature search no longer misreports as "Signature not unique".** `InstructionWalker` now raises a proper `UserCanceledError` on cancel rather than swallowing it as `StopIteration`, which the generators were treating as "ran out of instructions". The user now sees `Operation canceled by user`, not a confusing error. ([#18](https://github.com/mahmoudimus/ida-sigmaker/issues/18), [#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+- **Wait-box Cancel button now actually cancels.** `CheckContinuePrompt.should_cancel` now polls `idaapi_user_canceled()` so the wait-box Cancel propagates through the progress reporter regardless of whether the periodic prompts are enabled. Previously the button was effectively a no-op unless the modal popup was the one being dismissed. ([#18](https://github.com/mahmoudimus/ida-sigmaker/issues/18), [#24](https://github.com/mahmoudimus/ida-sigmaker/pull/24))
+- **User-facing cancel message now matches the rest of the codebase.** The output line on cancel is `Operation canceled by user` (US English), aligning with the spelling used everywhere else in the plugin.
+- **Partial-on-cancel match count no longer reports `0`.** When the user clicks Cancel mid-search, the internal match-counting also bails (it polls the same cancel flag), and would return a partial count of `0`. The generator now preserves the most recently completed iteration's count instead, so users see e.g. `Partial signature (NOT unique, 3 matches)` rather than `0 matches` or `match count unavailable`. ([#22](https://github.com/mahmoudimus/ida-sigmaker/issues/22), [#25](https://github.com/mahmoudimus/ida-sigmaker/pull/25))
+
+### Internal
+
+- New `Action` IntEnum replaces the bare `0/1/2/3` magic numbers in `SigMakerPlugin.run`'s dispatch.
+- New `GenerationStatus` enum and `GenerationPolicy` dataclass formalize the opt-in vocabulary for partial-on-cancel.
+- `GeneratedSignature` now carries `status` and `match_count` fields.
+- `SignatureSearcher.count_matches` exposes the per-iteration database scan count that `is_unique` was already computing and discarding.
+- `InstructionWalker.end_ea` default is resolved lazily via `default_factory` so runtime patches of `idaapi.BADADDR` take effect (testability fix).
+
+[1.7.0]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.6.0...v1.7.0

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.6.0"
+        "version": "1.7.0"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -25,7 +25,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2455,7 +2455,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             idaapi.msg(f"Error: {str(e)}\n")
         except UserCanceledError:
             # User cancellation is expected, not an error
-            idaapi.msg("Operation cancelled by user\n")
+            idaapi.msg("Operation canceled by user\n")
         except Exception as e:
             LOGGER.error("Exception occurred: %s%s%s", e, os.linesep, traceback.format_exc())
             return


### PR DESCRIPTION
Cuts the 1.7.0 release.

## What's included

Three commits, smallest to largest:

| Commit | What |
|---|---|
| `docs: add CHANGELOG.md covering 1.7.0 (#24, #25)` | New CHANGELOG.md at repo root, Keep a Changelog format. Documents the wait-box cancel UX from issue #18 / PR #24 and the opt-in partial-on-cancel output from issue #22 / PR #25, including the new opt-in form controls and the bug fixes folded in along the way. |
| `fix: use US spelling in user-facing cancel message` | The output line on `UserCanceledError` was `Operation cancelled by user` (UK), the only UK-spelled user-visible string left in the plugin. Aligns with the rest of the codebase which uses `canceled` throughout (per the comment at `src/sigmaker/__init__.py:87`). |
| `chore: bump version to 1.7.0` | `__version__` in `src/sigmaker/__init__.py` and `version` in `ida-plugin.json`. |

## After merge

Tag and push to cut the release:

```
git checkout main
git pull
git tag -a v1.7.0 -m "Release 1.7.0"
git push origin v1.7.0
```

`.github/workflows/release.yml` triggers on `v*` tag push, copies `src/sigmaker/__init__.py` to `sigmaker.py`, and creates a GitHub Release with that file as the asset.

## Verification

Host unit suite still passes (`Ran 136 tests, OK, skipped=3`). No production code logic changed apart from the one-character spelling fix; the rest is docs and metadata.
