### PR TITLE
Release 1.7.1: CHANGELOG + acknowledgements rewrite + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.1] - 2026-05-27
+
+### Added
+
+- **New `Find shortest unique signature for current function` action** on the main form. Iterates every instruction in the containing function as a possible start point, growing a signature from each (bounded by function end and by the current best candidate's size), and returns the smallest unique result with the fewest wildcards. Output annotates the address with an offset into the function so you can see exactly where the unique sequence sits. ([#17](https://github.com/mahmoudimus/ida-sigmaker/issues/17), [#26](https://github.com/mahmoudimus/ida-sigmaker/pull/26))
+- **Automatic xref fallback for the new action.** If no unique signature exists anywhere in the function body (e.g., the function is a small thunk identical to many others), the action falls back to generating signatures rooted at each code xref into the function and picks the best. Output reads `Xref signature into 0x... (from 0x...):`. ([#17](https://github.com/mahmoudimus/ida-sigmaker/issues/17), [#26](https://github.com/mahmoudimus/ida-sigmaker/pull/26))
+
+### Changed
+
+- **`WildcardPolicy.for_x86()` no longer wildcards `o_imm` immediates.** An immediate like the `0x13371338` in `mov rcx, 0x13371338` is a literal value baked into the instruction encoding; it does not shift between binary builds, so wildcarding it only removed bytes that would have made the signature unique. Memory addresses (`o_mem`), jump/call targets (`o_far`, `o_near`), and architecture-specific register operands still get wildcarded. This is a strict improvement to every action with `wildcard_operands=True`, including the existing `Create unique signature` and `Find shortest XREF signature` actions. ([#26](https://github.com/mahmoudimus/ida-sigmaker/pull/26))
+- **`GeneratedSignature.__lt__` now ranks by `(size, wildcards)` ascending** instead of just size. Same-length signatures with fewer wildcards rank first. The existing `Find shortest XREF signature` action picks this up for free, picking more specific candidates as the "best" result. ([#26](https://github.com/mahmoudimus/ida-sigmaker/pull/26))
+- **README acknowledgements** clarified to better reflect the historical relationship between this plugin and the broader SigMaker ecosystem.
+
+### Internal
+
+- New `MinimalFunctionSignatureGenerator` class implements the function-wide search with monotonic best-size pruning and an ideal-candidate early exit (size <= 5 bytes and zero wildcards stops the outer loop).
+- New `Action.FIND_FUNCTION_SIG = 4` enum value for the new form action.
+- Integration test coverage exercises both the function-search end to end and the x86 immediate preservation against the compiled test binary.
+
+[1.7.1]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.7.0...v1.7.1
+
 ## [1.7.0] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ There are also various options that be configured via the `Other options` button
 
 ## Acknowledgements
 
-Thank you to [@A200K](https://github.com/A200K)'s [IDA-Pro-SigMaker](https://github.com/A200K/IDA-Pro-SigMaker) plugin which served as an inspiration and the initial port of this plugin. A special thank you to [@kweatherman](https://github.com/kweatherman)'s [sigmakerex](https://github.com/kweatherman/sigmakerex) for the inspiration behind [@A200K]'s plugin. From [@kweatherman](https://github.com/kweatherman)'s own [README](https://github.com/kweatherman/sigmakerex#credits), there is a long history of SigMaker authors and I would like to also acknowledge my thanks to them:
+Thank you to [@A200K](https://github.com/A200K)'s [IDA-Pro-SigMaker](https://github.com/A200K/IDA-Pro-SigMaker) plugin, which served as inspiration and the basis for the initial port of this plugin. I would also like to acknowledge [@kweatherman](https://github.com/kweatherman)'s [sigmakerex](https://github.com/kweatherman/sigmakerex) as independent prior work within the SigMaker ecosystem. While the initial port did not draw from sigmakerex, members of the community later requested compatibility and feature parity with parts of its functionality (for example, see [issue #17](https://github.com/mahmoudimus/ida-sigmaker/issues/17)). As documented in [sigmakerex's README credits](https://github.com/kweatherman/sigmakerex#credits), there is a long history of SigMaker authors and contributors, and I would like to thank and acknowledge them as well:
 
 > thanks to the previous creators of the original SigMaker tool back from the gamedeception.net days up to the current C/C++ and Python iteration authors:
 > P4TR!CK, bobbysing, xero|hawk, ajkhoury, and zoomgod et al.

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.7.0"
+        "version": "1.7.1"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -25,7 +25,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
Cuts the 1.7.1 release covering the changes from #26 (issue #17), plus a small README acknowledgements rewrite.

## What's included

Three commits:

| Commit | What |
|---|---|
| `docs(changelog): add [1.7.1] entry for #26 (issue #17)` | New [1.7.1] section in CHANGELOG.md, prepended above 1.7.0. Documents the new `Find shortest unique signature for current function` action with xref fallback, the `WildcardPolicy.for_x86()` change that preserves x86 immediates, and the new `(size, wildcards)` ranking on `GeneratedSignature.__lt__`. |
| `docs(readme): clarify acknowledgements` | Rewrites the acknowledgements paragraph to make explicit that the initial port drew from @A200K's IDA-Pro-SigMaker, and that @kweatherman's sigmakerex is independent prior work within the SigMaker ecosystem. Notes that community members later requested compatibility with parts of sigmakerex's functionality (see #17), so the link is worth flagging directly. The long-form credits chain from sigmakerex's README is preserved verbatim below the paragraph. |
| `chore: bump version to 1.7.1` | `__version__` in `src/sigmaker/__init__.py` and `version` in `ida-plugin.json`. |

## After merge

Tag and push to cut the release:

```
git checkout main
git pull
git tag -a v1.7.1 -m "Release 1.7.1"
git push origin v1.7.1
```

`.github/workflows/release.yml` triggers on `v*` tag push and creates the GitHub Release with `sigmaker.py` as the asset, same as 1.7.0.

## Verification

Host unit suite passes (`Ran 148 tests, OK, skipped=3`). No production code changes in this PR; everything is docs and metadata.
