### PR TITLE
Fix #27: live wait-box progress for CREATE_UNIQUE and FIND_FUNCTION_SIG

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2501,6 +2501,10 @@ class _FunctionSigProgress:
         inner_bounds = f"{anchor:#x} .. {inner_end:#x}"
         if self.inner_matches is None:
             inner_matches_str = "scanning..."
+        elif self.inner_matches >= 2:
+            # Uniqueness is decided with an early-bail scan that stops at the
+            # second match, so the exact count past 1 is unknown: show "2+".
+            inner_matches_str = "2+ matches so far"
         else:
             inner_matches_str = f"{self.inner_matches} matches so far"
         best = f"{self.best_size} bytes" if self.candidates else "-"

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -168,22 +168,6 @@ class ProgressReporter(typing.Protocol):
         """Return the elapsed time since the operation started."""
         ...
 
-    def report_progress(
-        self,
-        *,
-        message: typing.Optional[str] = None,
-        metadata: typing.Optional[dict[str, typing.Any]] = None,
-        **metadata_kwargs,
-    ) -> None:
-        """Update progress information.
-
-        Args:
-            message: Optional progress message to display
-            metadata: Optional dictionary of metadata to report
-            **metadata_kwargs: Additional metadata as keyword arguments
-        """
-        ...
-
     def should_cancel(self) -> bool:
         """Check if the operation should be canceled.
 
@@ -282,12 +266,6 @@ class CheckContinuePrompt:
 
     start_time: float = dataclasses.field(init=False)
     _timer: ExponentialBackoffTimer = dataclasses.field(init=False)
-    _dynamic_metadata: dict[str, typing.Any] = dataclasses.field(
-        default_factory=dict, init=False, repr=False
-    )
-    _progress_message: typing.Optional[str] = dataclasses.field(
-        default=None, init=False, repr=False
-    )
     _user_canceled: bool = dataclasses.field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -304,36 +282,6 @@ class CheckContinuePrompt:
     def elapsed_time(self) -> float:
         """Return the elapsed time since the operation started."""
         return time.time() - self.start_time
-
-    def report_progress(
-        self,
-        *,
-        message: typing.Optional[str] = None,
-        metadata: typing.Optional[dict[str, typing.Any]] = None,
-        **metadata_kwargs,
-    ) -> None:
-        """Update metadata/message used in the next prompt.
-
-        Args:
-            message: Optional progress message to display
-            metadata: Optional dictionary of metadata to report
-            **metadata_kwargs: Additional metadata as keyword arguments
-        """
-        combined = metadata.copy() if metadata else {}
-        if metadata_kwargs:
-            combined.update(metadata_kwargs)
-        if combined:
-            self._dynamic_metadata.update(combined)
-        if message is not None:
-            self._progress_message = message
-
-        if self.logger is not None and self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug(
-                "Progress reported (%.1fs elapsed): message=%s, metadata=%s",
-                self.elapsed_time,
-                message,
-                combined or None,
-            )
 
     def should_cancel(self) -> bool:
         """Check if the operation should be canceled.
@@ -396,20 +344,9 @@ class CheckContinuePrompt:
         time_str = f"{minutes}m {seconds}s" if minutes else f"{seconds}s"
         message_lines = [f"{func_name} has been running for {time_str}.", ""]
 
-        # Combine static and dynamic metadata
-        combined_metadata: dict[str, typing.Any] = {}
         if self.metadata:
-            combined_metadata.update(self.metadata)
-        if self._dynamic_metadata:
-            combined_metadata.update(self._dynamic_metadata)
-
-        if combined_metadata:
-            for key, value in combined_metadata.items():
+            for key, value in self.metadata.items():
                 message_lines.append(f"{key}: {value}")
-            message_lines.append("")
-
-        if self._progress_message:
-            message_lines.append(self._progress_message)
             message_lines.append("")
 
         message_lines.append("Continue?")
@@ -716,6 +653,35 @@ class GenerationPolicy:
     def permissive(cls) -> "GenerationPolicy":
         """Cancel returns a partial GeneratedSignature instead of raising."""
         return cls(return_partial_on_cancel=True)
+
+
+@dataclasses.dataclass(slots=True)
+class _CancelToPartial:
+    """Context manager that converts UserCanceledError into a partial result.
+
+    If ``policy.return_partial_on_cancel`` is True and a UserCanceledError
+    is raised inside the ``with`` block, calls ``build_partial()`` and
+    stashes the result in ``.partial``, suppressing the original exception.
+    If ``build_partial()`` itself raises UserCanceledError (the empty-sig
+    case where there's nothing useful to return), the original
+    UserCanceledError is allowed to propagate, not this new one.
+    """
+
+    policy: GenerationPolicy
+    build_partial: typing.Callable[[], "GeneratedSignature"]
+    partial: typing.Optional["GeneratedSignature"] = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is UserCanceledError and self.policy.return_partial_on_cancel:
+            try:
+                self.partial = self.build_partial()
+            except UserCanceledError:
+                return False  # propagate the ORIGINAL UserCanceledError
+            return True  # suppress; partial is ready
+        return False
 
 
 class SignatureByte(typing.NamedTuple):
@@ -1459,10 +1425,9 @@ class UniqueSignatureGenerator:
         sig = Signature()
         start_fn = idaapi.get_func(ea)
         bytes_since_last_check = 0
-        instruction_count = 0
-        last_match_count: int | None = None
+        progress = _UniqueSigProgress(sig=sig)
 
-        def _build_partial() -> GeneratedSignature:
+        def build_partial() -> GeneratedSignature:
             # Trim trailing wildcards, mirror the success path.
             sig.trim_signature()
             if len(sig) == 0:
@@ -1471,26 +1436,23 @@ class UniqueSignatureGenerator:
                 sig,
                 Match(ea),
                 status=GenerationStatus.PARTIAL_ON_CANCEL,
-                match_count=last_match_count,
+                match_count=progress.last_match_count,
             )
 
-        try:
-            for cur_ea, ins, ins_len in InstructionWalker(ea):
-                # Check for cancellation via progress reporter
-                if self.progress_reporter is not None and self.progress_reporter.should_cancel():
-                    if policy.return_partial_on_cancel:
-                        return _build_partial()
+        with _CancelToPartial(policy, build_partial) as cancel:
+            for cur_ea, ins, ins_len in ProgressBox(
+                InstructionWalker(ea),
+                initial_message="Generating signature...\n\nPress Cancel to stop",
+                format_message=progress,
+            ):
+                # Modal continue-prompt opt-in (issue #18) still goes through
+                # the progress reporter. The wait-box cancel is already handled
+                # by ProgressBox raising UserCanceledError.
+                if (
+                    self.progress_reporter is not None
+                    and self.progress_reporter.should_cancel()
+                ):
                     raise UserCanceledError("Signature generation canceled by user")
-
-                # Update progress periodically
-                instruction_count += 1
-                progress_reporting = self.progress_reporter is not None and self.progress_reporter.enabled()
-                if progress_reporting and instruction_count % 100 == 0:
-                    self.progress_reporter.report_progress(
-                        message=f"Generating signature at {hex(cur_ea)}",
-                        signature_length=len(sig),
-                        instructions_processed=instruction_count,
-                    )
 
                 # Check length constraint
                 if bytes_since_last_check > cfg.max_single_signature_length:
@@ -1521,28 +1483,18 @@ class UniqueSignatureGenerator:
                 count = SignatureSearcher.count_matches(f"{sig:ida}")
                 # SignatureSearcher.find_all polls idaapi_user_canceled inside
                 # its scan loop and bails when set, returning whatever partial
-                # count it had so far (often 0). If we stored that, the
-                # partial-on-cancel path would show "0 matches" for a signature
-                # that actually matches many places.
-                #
-                # When the call was interrupted, keep last_match_count at its
-                # prior trustworthy value (the count from the previous fully
-                # completed iteration). The reported number then corresponds
-                # to a signature one instruction shorter than the partial we
-                # emit, which means it is an UPPER BOUND on the partial's
-                # actual match count -- a useful number, not a meaningless 0.
+                # count it had so far (often 0). When the call was interrupted,
+                # keep last_match_count at its prior trustworthy value (issue
+                # #22): the reported number is an upper bound on the partial's
+                # actual match count rather than a meaningless 0.
                 if not idaapi_user_canceled():
-                    last_match_count = count
+                    progress.last_match_count = count
                     if count == 1:
                         sig.trim_signature()
                         return GeneratedSignature(sig, Match(ea))
-        except UserCanceledError:
-            # InstructionWalker raises UserCanceledError on cancel too (issue #18).
-            # Honor the policy here as well.
-            if policy.return_partial_on_cancel:
-                return _build_partial()
-            raise
 
+        if cancel.partial is not None:
+            return cancel.partial
         raise Unexpected("Signature not unique (reached end of analysis)")
 
 
@@ -1637,7 +1589,12 @@ class MinimalFunctionSignatureGenerator:
             UserCanceledError: If the progress reporter signals cancel.
         """
         candidates: list[GeneratedSignature] = []
-        best_size = cfg.max_single_signature_length
+        progress = _FunctionSigProgress(
+            pfn_start_ea=int(pfn.start_ea),
+            pfn_end_ea=int(pfn.end_ea),
+            candidates=candidates,
+            best_size=cfg.max_single_signature_length,
+        )
 
         decoded = _decode_function_for_anchors(pfn, self.processor, cfg)
         if not decoded:
@@ -1651,7 +1608,17 @@ class MinimalFunctionSignatureGenerator:
             with ProgressDialog("Please stand by, copying segments..."):
                 buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
 
-        for anchor_idx in range(len(decoded)):
+        # Iterate the pre-decoded anchors inside a ProgressBox so the wait
+        # box shows live progress (issue #27). enumerate() keeps the index
+        # for slicing while leaving the yielded item a non-int, so
+        # _FunctionSigProgress falls back to current_anchor_ea for display.
+        for anchor_idx, di in ProgressBox(
+            enumerate(decoded),
+            total=len(decoded),
+            initial_message="Finding shortest function signature...\n\n"
+                            "Press Cancel to stop",
+            format_message=progress,
+        ):
             if (
                 self.progress_reporter is not None
                 and self.progress_reporter.should_cancel()
@@ -1660,17 +1627,25 @@ class MinimalFunctionSignatureGenerator:
                     "Function signature search canceled by user"
                 )
 
+            # Reset the inner-state fields for this anchor so the wait-box
+            # display starts fresh rather than showing the previous anchor's
+            # final state.
+            progress.current_anchor_ea = di.ea
+            progress.inner_length = 0
+            progress.inner_matches = None
+
             sig = self._grow_unique_from_decoded(
-                decoded, anchor_idx, best_size, cfg, buf=buf,
+                decoded, anchor_idx, progress.best_size, cfg,
+                buf=buf, progress=progress,
             )
             if sig is None:
                 continue
             if len(sig) < self.MIN_USEFUL_SIG_BYTES:
                 continue
 
-            candidate = GeneratedSignature(sig, Match(decoded[anchor_idx].ea))
+            candidate = GeneratedSignature(sig, Match(di.ea))
             candidates.append(candidate)
-            best_size = min(best_size, len(sig))
+            progress.best_size = min(progress.best_size, len(sig))
 
             wildcard_count = sum(1 for b in sig if b.is_wildcard)
             if len(sig) <= self.MIN_USEFUL_SIG_BYTES and wildcard_count == 0:
@@ -1689,13 +1664,20 @@ class MinimalFunctionSignatureGenerator:
         max_len: int,
         cfg: SigMakerConfig,
         buf: typing.Optional["InMemoryBuffer"] = None,
+        progress: typing.Optional["_FunctionSigProgress"] = None,
     ) -> typing.Optional[Signature]:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
         Reads all instruction data from the pre-decoded list. The ``buf``
-        argument is forwarded to ``SignatureSearcher.is_unique`` so the
-        segment buffer is reused across all is_unique calls inside one
-        generate() session.
+        argument is forwarded to the searcher so the segment buffer is
+        reused across all uniqueness checks inside one generate() session.
+
+        Uniqueness is decided with an early-bail scan (bail at the second
+        match) rather than a full match count, so short common signatures
+        do not enumerate every hit. If ``progress`` is supplied, the
+        per-iteration sig length and the (capped) match count are written
+        into its ``inner_length`` / ``inner_matches`` fields for the live
+        wait-box display; ``inner_matches`` of 2 means "two or more".
         """
         sig = Signature()
         for i in range(anchor_idx, len(decoded)):
@@ -1712,7 +1694,14 @@ class MinimalFunctionSignatureGenerator:
             if len(sig) > max_len:
                 return None
 
-            if SignatureSearcher.is_unique(f"{sig:ida}", buf=buf):
+            unique = SignatureSearcher.is_unique(f"{sig:ida}", buf=buf)
+            if progress is not None:
+                progress.inner_length = len(sig)
+                # is_unique early-bails at the second match, so we cannot
+                # show an exact count here; 1 means unique, 2 means "2 or
+                # more, keep growing".
+                progress.inner_matches = 1 if unique else 2
+            if unique:
                 sig.trim_signature()
                 return sig
 
@@ -1784,19 +1773,7 @@ class RangeSignatureGenerator:
             if self.progress_reporter is not None and self.progress_reporter.should_cancel():
                 raise UserCanceledError("Signature generation canceled by user")
 
-            # Update progress periodically
             instruction_count += 1
-            progress_reporting = self.progress_reporter is not None and self.progress_reporter.enabled()
-            if progress_reporting and instruction_count % 50 == 0:
-                range_size = end_ea - start_ea
-                bytes_processed = cur_ea - start_ea
-                progress_pct = (bytes_processed / range_size * 100) if range_size > 0 else 0
-                self.progress_reporter.report_progress(
-                    message=f"Processing range at {hex(cur_ea)}",
-                    signature_length=len(sig),
-                    instructions_processed=instruction_count,
-                    progress_percent=f"{progress_pct:.1f}%",
-                )
 
             self.processor.append_instruction_to_sig(
                 sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
@@ -2337,9 +2314,6 @@ def stop_profiling(
     return output_path
 
 
-# no cover: start
-# we do not cover the below because this is mainly executing IDA GUI functionality.
-# any logic here should be pulled out into a separate class and tested separately.
 class ProgressDialog:
     """Context manager wrapping IDA wait boxes.
 
@@ -2396,6 +2370,157 @@ class ProgressDialog:
     user_cancelled = user_canceled
 
 
+@dataclasses.dataclass(slots=True)
+class ProgressBox:
+    """Wait-box-backed iteration progress reporter.
+
+    Wraps an iterable, opens an IDA wait box via ``dialog_factory`` on
+    iteration start, calls ``format_message(idx, item, elapsed, total)``
+    on each tick (throttled to ``throttle_seconds``), and exits the
+    dialog context manager on completion or cancel. Cancel via the
+    wait-box Cancel button raises ``UserCanceledError``.
+
+    ``clock`` and ``dialog_factory`` are injection points for testing:
+    the default ``clock=time.monotonic`` and ``dialog_factory=ProgressDialog``
+    give production behavior; tests pass fakes to drive throttling
+    deterministically and to record dialog calls without touching idaapi.
+    """
+
+    iterable: typing.Iterable
+    total: typing.Optional[int] = None
+    initial_message: str = "Executing..."
+    format_message: typing.Optional[
+        typing.Callable[[int, typing.Any, float, typing.Optional[int]], str]
+    ] = None
+    throttle_seconds: float = 0.1
+    clock: typing.Callable[[], float] = dataclasses.field(default=time.monotonic)
+    # default_factory (not default=ProgressDialog) so tests that monkey-patch
+    # sigmaker.ProgressDialog after class definition are honored: the lambda
+    # re-resolves the name from module scope at each ProgressBox() construction.
+    dialog_factory: typing.Callable[[str], typing.Any] = dataclasses.field(
+        default_factory=lambda: ProgressDialog
+    )
+
+    def __post_init__(self):
+        if self.total is None and self.iterable is not None:
+            try:
+                self.total = len(self.iterable)
+            except (TypeError, AttributeError):
+                self.total = None
+        if self.total == float("inf"):
+            self.total = None
+
+    def __iter__(self):
+        with self.dialog_factory(self.initial_message) as dialog:
+            start = self.clock()
+            last_update = 0.0
+            for idx, item in enumerate(self.iterable, start=1):
+                if idaapi_user_canceled():
+                    raise UserCanceledError("Canceled by user")
+                now = self.clock()
+                if now - last_update > self.throttle_seconds:
+                    elapsed = now - start
+                    if self.format_message is not None:
+                        msg = self.format_message(idx, item, elapsed, self.total)
+                    elif self.total:
+                        msg = f"Processing ({idx}/{self.total}) | Elapsed: {int(elapsed)}s"
+                    else:
+                        msg = f"Processing ({idx}) | Elapsed: {int(elapsed)}s"
+                    dialog.replace_message(msg)
+                    last_update = now
+                yield item
+
+
+@dataclasses.dataclass(slots=True)
+class _UniqueSigProgress:
+    """Formatter for the CREATE_UNIQUE wait-box message.
+
+    Holds a live reference to the generator's growing Signature plus the
+    most recently observed match count. ``__call__`` renders the template
+    using the current state on every invocation; the generator updates
+    ``last_match_count`` per iteration so the wait box stays current.
+    """
+
+    sig: "Signature"
+    last_match_count: typing.Optional[int] = None
+    _TEMPLATE: typing.ClassVar[str] = (
+        "Generating signature...\n\n"
+        "Length: {length} bytes\n"
+        "Matches: {matches}\n"
+        "Elapsed: {elapsed}s\n\n"
+        "Press Cancel to stop"
+    )
+
+    def __call__(self, idx, item, elapsed, total) -> str:
+        match_str = "?" if self.last_match_count is None else str(self.last_match_count)
+        return self._TEMPLATE.format(
+            length=len(self.sig),
+            matches=match_str,
+            elapsed=int(elapsed),
+        )
+
+
+@dataclasses.dataclass(slots=True)
+class _FunctionSigProgress:
+    """Formatter for the FIND_FUNCTION_SIG wait-box message.
+
+    Holds live references to the function bounds, the candidates list,
+    and the current best-size. The generator updates ``current_anchor_ea``
+    at the top of every outer iteration; the inner ``_grow_unique_from``
+    updates ``inner_length`` and ``inner_matches`` as the per-anchor
+    search grows. ``__call__`` renders the template using whatever state
+    is current at tick time (throttled by ProgressBox).
+    """
+
+    pfn_start_ea: int
+    pfn_end_ea: int
+    candidates: list
+    best_size: int
+    current_anchor_ea: int = 0
+    inner_length: int = 0
+    inner_matches: typing.Optional[int] = None
+    _TEMPLATE: typing.ClassVar[str] = (
+        "Finding shortest unique signature for this function.\n"
+        "For each instruction, grow a byte pattern until unique in the binary.\n"
+        "\n"
+        "Function:     {fn_bounds}  ({fn_size} bytes)\n"
+        "Anchor (#{idx}): {anchor:#x}\n"
+        "Inner search: {inner_bounds}  ({inner_length} bytes, {inner_matches_str})\n"
+        "Best found:   {best}\n"
+        "Candidates:   {candidates_count} unique so far\n"
+        "Elapsed:      {elapsed}s\n"
+        "\n"
+        "Press Cancel to stop"
+    )
+
+    def __call__(self, idx, item, elapsed, total) -> str:
+        fn_bounds = f"{self.pfn_start_ea:#x} .. {self.pfn_end_ea:#x}"
+        fn_size = self.pfn_end_ea - self.pfn_start_ea
+        anchor = item if isinstance(item, int) else self.current_anchor_ea
+        inner_end = anchor + self.inner_length
+        inner_bounds = f"{anchor:#x} .. {inner_end:#x}"
+        if self.inner_matches is None:
+            inner_matches_str = "scanning..."
+        else:
+            inner_matches_str = f"{self.inner_matches} matches so far"
+        best = f"{self.best_size} bytes" if self.candidates else "-"
+        return self._TEMPLATE.format(
+            fn_bounds=fn_bounds,
+            fn_size=fn_size,
+            idx=idx,
+            anchor=anchor,
+            inner_bounds=inner_bounds,
+            inner_length=self.inner_length,
+            inner_matches_str=inner_matches_str,
+            best=best,
+            candidates_count=len(self.candidates),
+            elapsed=int(elapsed),
+        )
+
+
+# no cover: start
+# we do not cover the below because this is mainly executing IDA GUI functionality.
+# any logic here should be pulled out into a separate class and tested separately.
 class Clipboard:
     """Cross platform utilities for setting text on the system clipboard."""
 
@@ -2846,12 +2971,11 @@ class SigMakerPlugin(idaapi.plugin_t):
                     if config.output_partial_on_cancel
                     else GenerationPolicy.strict()
                 )
-                with ProgressDialog(
-                    "Generating signature...\n\nPress Cancel to stop"
-                ):
-                    signature = SignatureMaker().make_signature(
-                        ea, config, policy=policy
-                    )
+                # ProgressBox inside UniqueSignatureGenerator.generate owns
+                # the wait box; no outer wrapper needed.
+                signature = SignatureMaker().make_signature(
+                    ea, config, policy=policy
+                )
                 signature.display(config)
             elif action == Action.FIND_XREF:
                 ea = idaapi.get_screen_ea()
@@ -2902,13 +3026,12 @@ class SigMakerPlugin(idaapi.plugin_t):
             return
 
         try:
-            with ProgressDialog(
-                "Finding shortest function signature...\n\nPress Cancel to stop"
-            ):
-                generator = MinimalFunctionSignatureGenerator(
-                    InstructionProcessor(OperandProcessor())
-                )
-                result = generator.generate(pfn, config)
+            # ProgressBox inside MinimalFunctionSignatureGenerator.generate
+            # owns the wait box; no outer wrapper needed.
+            generator = MinimalFunctionSignatureGenerator(
+                InstructionProcessor(OperandProcessor())
+            )
+            result = generator.generate(pfn, config)
             offset = int(result.address) - int(pfn.start_ea)
             idaapi.msg(
                 f"Function signature (offset +{hex(offset)} into function "

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1442,7 +1442,12 @@ class UniqueSignatureGenerator:
         with _CancelToPartial(policy, build_partial) as cancel:
             for cur_ea, ins, ins_len in ProgressBox(
                 InstructionWalker(ea),
-                initial_message="Generating signature...\n\nPress Cancel to stop",
+                initial_message=(
+                    "Create unique signature (from cursor address)\n\n"
+                    "Growing a pattern from the current address until it "
+                    "matches exactly one place in the binary.\n\n"
+                    "Press Cancel to stop"
+                ),
                 format_message=progress,
             ):
                 # Modal continue-prompt opt-in (issue #18) still goes through
@@ -1615,8 +1620,12 @@ class MinimalFunctionSignatureGenerator:
         for anchor_idx, di in ProgressBox(
             enumerate(decoded),
             total=len(decoded),
-            initial_message="Finding shortest function signature...\n\n"
-                            "Press Cancel to stop",
+            initial_message=(
+                "Find shortest function signature\n\n"
+                "Trying every instruction in the function as a start point; "
+                "growing each until unique and keeping the shortest.\n\n"
+                "Press Cancel to stop"
+            ),
             format_message=progress,
         ):
             if (
@@ -1943,6 +1952,7 @@ class XrefFinder:
                 break
 
             self.progress_dialog.replace_message(
+                f"Find shortest XREF signature\n\n"
                 f"Processing xref {i} of {total} ({(i / total) * 100.0:.1f}%)...\n\n"
                 f"Suitable Signatures: {len(xref_signatures)}\n"
                 f"Shortest Signature: {shortest_len if shortest_len <= cfg.max_xref_signature_length else 0} Bytes"
@@ -2113,7 +2123,11 @@ class SignatureSearcher:
             return SearchResults([], "")
 
         # Wrap the search in a ProgressDialog to allow cancellation
-        with ProgressDialog("Searching for signature...\n\nPress Cancel to stop"):
+        with ProgressDialog(
+            "Search for a signature\n\n"
+            "Scanning the whole database for your pattern.\n\n"
+            "Press Cancel to stop"
+        ):
             matches = self.find_all(sig_str)
 
         return SearchResults(matches, sig_str)
@@ -2392,7 +2406,7 @@ class ProgressBox:
     format_message: typing.Optional[
         typing.Callable[[int, typing.Any, float, typing.Optional[int]], str]
     ] = None
-    throttle_seconds: float = 0.1
+    throttle_seconds: float = 1.0
     clock: typing.Callable[[], float] = dataclasses.field(default=time.monotonic)
     # default_factory (not default=ProgressDialog) so tests that monkey-patch
     # sigmaker.ProgressDialog after class definition are honored: the lambda
@@ -2444,18 +2458,17 @@ class _UniqueSigProgress:
     sig: "Signature"
     last_match_count: typing.Optional[int] = None
     _TEMPLATE: typing.ClassVar[str] = (
-        "Generating signature...\n\n"
-        "Length: {length} bytes\n"
-        "Matches: {matches}\n"
+        "Create unique signature (from cursor address)\n"
+        "Growing a pattern from the current address until it matches\n"
+        "exactly one place in the binary.\n\n"
+        "Length:  {length} bytes\n"
         "Elapsed: {elapsed}s\n\n"
         "Press Cancel to stop"
     )
 
     def __call__(self, idx, item, elapsed, total) -> str:
-        match_str = "?" if self.last_match_count is None else str(self.last_match_count)
         return self._TEMPLATE.format(
             length=len(self.sig),
-            matches=match_str,
             elapsed=int(elapsed),
         )
 
@@ -2480,8 +2493,8 @@ class _FunctionSigProgress:
     inner_length: int = 0
     inner_matches: typing.Optional[int] = None
     _TEMPLATE: typing.ClassVar[str] = (
-        "Finding shortest unique signature for this function.\n"
-        "For each instruction, grow a byte pattern until unique in the binary.\n"
+        "Find shortest function signature\n"
+        "Trying every instruction as a start point; keeping the shortest unique one.\n"
         "\n"
         "Function:     {fn_bounds}  ({fn_size} bytes)\n"
         "Anchor (#{idx}): {anchor:#x}\n"
@@ -2989,7 +3002,10 @@ class SigMakerPlugin(idaapi.plugin_t):
                 start, end = self.get_selected_addresses(idaapi.get_current_viewer())
                 if start and end:
                     with ProgressDialog(
-                        "Generating range signature...\n\nPress Cancel to stop"
+                        "Copy selected code\n\n"
+                        "Building a signature for the selected address "
+                        "range.\n\n"
+                        "Press Cancel to stop"
                     ):
                         signature = SignatureMaker().make_signature(
                             start, config, end=end

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -1922,20 +1922,6 @@ class TestProgressReporter(CoveredUnitTest):
         sigmaker.idaapi.ask_yn = self.original_ask_yn
         sigmaker.idaapi_user_canceled = self.original_user_canceled
 
-    def test_check_continue_prompt_basic(self):
-        """Test basic CheckContinuePrompt functionality."""
-        prompt = sigmaker.CheckContinuePrompt(
-            enable_prompt=False  # Disable prompting for this test
-        )
-
-        # Check initial state
-        self.assertGreater(prompt.elapsed_time, 0)
-        self.assertFalse(prompt.should_cancel())
-
-        # Update progress
-        prompt.report_progress(message="Test message", test_key="test_value")
-        self.assertFalse(prompt.should_cancel())
-
     def test_check_continue_prompt_disabled(self):
         """Test that prompting can be disabled."""
         prompt = sigmaker.CheckContinuePrompt(enable_prompt=False)
@@ -1943,22 +1929,6 @@ class TestProgressReporter(CoveredUnitTest):
         # Should never cancel when prompting is disabled
         for _ in range(10):
             self.assertFalse(prompt.should_cancel())
-
-    def test_check_continue_prompt_metadata(self):
-        """Test progress metadata tracking."""
-        prompt = sigmaker.CheckContinuePrompt(
-            metadata={"static_key": "static_value"}, enable_prompt=False
-        )
-
-        # Add dynamic metadata
-        prompt.report_progress(
-            message="Processing...", dynamic_key="dynamic_value", count=42
-        )
-
-        # Check that metadata was stored
-        self.assertEqual(prompt._dynamic_metadata["dynamic_key"], "dynamic_value")
-        self.assertEqual(prompt._dynamic_metadata["count"], 42)
-        self.assertEqual(prompt._progress_message, "Processing...")
 
     def test_should_cancel_polls_idaapi_user_canceled(self):
         """Even with prompts disabled, the wait-box Cancel must propagate."""
@@ -2224,7 +2194,20 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         )
         self._is_code_patcher.start()
 
+        # Recording dialog factory so we can inspect ProgressBox's
+        # wait-box message activity without touching idaapi (issue #27).
+        self.recorded_dialogs: list[_FakeDialog] = []
+
+        def _factory(message):
+            d = _FakeDialog(message)
+            self.recorded_dialogs.append(d)
+            return d
+
+        self._dialog_patcher = patch.object(sigmaker, "ProgressDialog", _factory)
+        self._dialog_patcher.start()
+
     def tearDown(self):
+        self._dialog_patcher.stop()
         self._is_code_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
 
@@ -2388,6 +2371,44 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
             result.match_count,
             "match_count must be None when no prior trustworthy count exists",
         )
+
+    def test_progress_dialog_opens_with_generating_signature_message(self):
+        # Issue #27: ProgressBox-owned wait box should appear with the
+        # CREATE_UNIQUE-specific initial message.
+        gen = self._make_generator(cancel_after_iterations=99)
+        counts = iter([5, 5, 5, 5, 1])
+        with patch.object(
+            sigmaker.SignatureSearcher,
+            "count_matches",
+            side_effect=lambda *_: next(counts),
+        ):
+            gen.generate(
+                0x1000,
+                self._make_cfg(),
+                policy=sigmaker.GenerationPolicy.strict(),
+            )
+        self.assertEqual(len(self.recorded_dialogs), 1)
+        self.assertIn(
+            "Generating signature", self.recorded_dialogs[0].initial_message
+        )
+
+    def test_progress_dialog_lifecycle_on_cancel(self):
+        # Even when the search cancels, the dialog __exit__ must fire so
+        # the wait box closes cleanly.
+        gen = self._make_generator(cancel_after_iterations=2)
+        with patch.object(
+            sigmaker.SignatureSearcher, "count_matches", return_value=5
+        ):
+            try:
+                gen.generate(
+                    0x1000,
+                    self._make_cfg(),
+                    policy=sigmaker.GenerationPolicy.strict(),
+                )
+            except sigmaker.UserCanceledError:
+                pass
+        self.assertEqual(len(self.recorded_dialogs), 1)
+        self.assertEqual(self.recorded_dialogs[0].exit_count, 1)
 
 
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
@@ -2563,8 +2584,20 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         )
         self._load_patcher.start()
 
+        # Recording dialog factory (issue #27 progress display).
+        self.recorded_dialogs: list[_FakeDialog] = []
+
+        def _factory(message):
+            d = _FakeDialog(message)
+            self.recorded_dialogs.append(d)
+            return d
+
+        self._dialog_patcher = patch.object(sigmaker, "ProgressDialog", _factory)
+        self._dialog_patcher.start()
+
     def tearDown(self):
         self._load_patcher.stop()
+        self._dialog_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
 
     def _make_pfn(self, start_ea: int, end_ea: int):
@@ -2747,6 +2780,50 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
             gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertLessEqual(mp_load.call_count, 1)
+
+    def test_progress_dialog_opens_with_function_sig_message(self):
+        # Issue #27: ProgressBox-owned wait box should appear with the
+        # FIND_FUNCTION_SIG-specific initial message.
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1010)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            try:
+                gen.generate(pfn, self._make_cfg(max_len=10))
+            except sigmaker.Unexpected:
+                pass
+        # generate() may also open a short-lived "copying segments" wait box
+        # when SIMD is available, so assert the function-sig wait box is among
+        # the recorded dialogs rather than asserting an exact count.
+        messages = [d.initial_message for d in self.recorded_dialogs]
+        self.assertTrue(
+            any("Finding shortest function signature" in m for m in messages),
+            f"Expected a function-sig wait box; got {messages}",
+        )
+
+    def test_cancel_during_decode_raises_before_processing(self):
+        # Cancelling before the search starts must short-circuit promptly.
+        # InstructionWalker.__next__ checks cancel before decode_insn, so the
+        # pre-decode pass raises UserCanceledError without decoding the whole
+        # 256-byte function.
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1100)  # 256 instruction bytes
+
+        sigmaker.idaapi.decode_insn.reset_mock()
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=True)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            with self.assertRaises(sigmaker.UserCanceledError):
+                gen.generate(pfn, self._make_cfg(max_len=10))
+
+        self.assertLess(
+            sigmaker.idaapi.decode_insn.call_count,
+            20,
+            "Cancel should short-circuit pre-decode before walking the "
+            "whole function.",
+        )
 
 
 class TestSignatureSearcherBufferCache(CoveredUnitTest):
@@ -2983,6 +3060,344 @@ class TestDecodedInstruction(CoveredUnitTest):
         )
         self.assertTrue(hasattr(sigmaker._DecodedInstruction, "__slots__"))
         self.assertFalse(hasattr(di, "__dict__"))
+
+
+
+
+class TestProgressFormatters(CoveredUnitTest):
+    """The two __call__-able formatter dataclasses render their templates correctly."""
+
+    def _make_sig(self, n: int) -> sigmaker.Signature:
+        sig = sigmaker.Signature()
+        for i in range(n):
+            sig.append(sigmaker.SignatureByte(0x90 + i, False))
+        return sig
+
+    def test_unique_progress_reflects_sig_length(self):
+        sig = self._make_sig(5)
+        fmt = sigmaker._UniqueSigProgress(sig=sig)
+        msg = fmt(idx=1, item=None, elapsed=2.5, total=None)
+        self.assertIn("Length: 5 bytes", msg)
+        self.assertIn("Matches: ?", msg)
+        self.assertIn("Elapsed: 2s", msg)
+
+    def test_unique_progress_reflects_match_count_when_set(self):
+        sig = self._make_sig(8)
+        fmt = sigmaker._UniqueSigProgress(sig=sig, last_match_count=3)
+        msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
+        self.assertIn("Length: 8 bytes", msg)
+        self.assertIn("Matches: 3", msg)
+
+    def test_unique_progress_sig_is_live_reference(self):
+        sig = self._make_sig(2)
+        fmt = sigmaker._UniqueSigProgress(sig=sig)
+        sig.append(sigmaker.SignatureByte(0xCC, False))
+        sig.append(sigmaker.SignatureByte(0xCC, False))
+        msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
+        self.assertIn("Length: 4 bytes", msg)
+
+    def test_function_progress_renders_all_fields(self):
+        candidates: list = []
+        fmt = sigmaker._FunctionSigProgress(
+            pfn_start_ea=0x140001000,
+            pfn_end_ea=0x140001100,
+            candidates=candidates,
+            best_size=100,
+            current_anchor_ea=0x140001040,
+            inner_length=7,
+            inner_matches=3,
+        )
+        msg = fmt(idx=18, item=0x140001040, elapsed=4.0, total=None)
+        # Function bounds + size shown.
+        self.assertIn("0x140001000 .. 0x140001100", msg)
+        self.assertIn("(256 bytes)", msg)
+        # Anchor with idx.
+        self.assertIn("Anchor (#18):", msg)
+        self.assertIn("0x140001040", msg)
+        # Inner search bounds + length + matches.
+        self.assertIn("0x140001040 .. 0x140001047", msg)
+        self.assertIn("7 bytes", msg)
+        self.assertIn("3 matches", msg)
+        # Best so far + candidates + elapsed.
+        self.assertIn("Best found:   -", msg)
+        self.assertIn("0 unique so far", msg)
+        self.assertIn("Elapsed:      4s", msg)
+
+    def test_function_progress_inner_matches_none_renders_scanning(self):
+        fmt = sigmaker._FunctionSigProgress(
+            pfn_start_ea=0x1000,
+            pfn_end_ea=0x1100,
+            candidates=[],
+            best_size=50,
+            current_anchor_ea=0x1010,
+            inner_length=0,
+            inner_matches=None,
+        )
+        msg = fmt(idx=1, item=0x1010, elapsed=0.0, total=None)
+        self.assertIn("scanning...", msg)
+
+    def test_function_progress_reflects_best_and_candidates(self):
+        candidates: list = []
+        fmt = sigmaker._FunctionSigProgress(
+            pfn_start_ea=0x1000,
+            pfn_end_ea=0x1100,
+            candidates=candidates,
+            best_size=100,
+            current_anchor_ea=0x1010,
+        )
+        dummy_sig = sigmaker.Signature()
+        dummy_sig.append(sigmaker.SignatureByte(0x90, False))
+        candidates.append(
+            sigmaker.GeneratedSignature(dummy_sig, sigmaker.Match(0x1000))
+        )
+        fmt.best_size = 12
+        msg = fmt(idx=3, item=0x1010, elapsed=2.0, total=None)
+        self.assertIn("Best found:   12 bytes", msg)
+        self.assertIn("1 unique so far", msg)
+
+
+class TestCancelToPartial(CoveredUnitTest):
+    """Context manager that converts UserCanceledError into a partial per policy."""
+
+    def _sentinel_partial(self):
+        sig = sigmaker.Signature()
+        sig.append(sigmaker.SignatureByte(0x90, False))
+        return sigmaker.GeneratedSignature(
+            sig,
+            sigmaker.Match(0x1000),
+            status=sigmaker.GenerationStatus.PARTIAL_ON_CANCEL,
+            match_count=42,
+        )
+
+    def test_strict_propagates_cancel(self):
+        partial = self._sentinel_partial()
+        built = []
+
+        def build_partial():
+            built.append(True)
+            return partial
+
+        cancel = sigmaker._CancelToPartial(
+            sigmaker.GenerationPolicy.strict(), build_partial
+        )
+        with self.assertRaises(sigmaker.UserCanceledError):
+            with cancel:
+                raise sigmaker.UserCanceledError("test cancel")
+
+        self.assertIsNone(cancel.partial)
+        self.assertEqual(built, [])
+
+    def test_permissive_stashes_partial(self):
+        partial = self._sentinel_partial()
+        cancel = sigmaker._CancelToPartial(
+            sigmaker.GenerationPolicy.permissive(), lambda: partial
+        )
+        with cancel:
+            raise sigmaker.UserCanceledError("test cancel")
+        self.assertIs(cancel.partial, partial)
+
+    def test_permissive_propagates_when_build_partial_raises(self):
+        def build_partial():
+            raise sigmaker.UserCanceledError("empty sig, nothing to return")
+
+        cancel = sigmaker._CancelToPartial(
+            sigmaker.GenerationPolicy.permissive(), build_partial
+        )
+        with self.assertRaises(sigmaker.UserCanceledError) as ctx:
+            with cancel:
+                raise sigmaker.UserCanceledError("original cancel")
+
+        self.assertEqual(str(ctx.exception), "original cancel")
+        self.assertIsNone(cancel.partial)
+
+    def test_non_cancel_exceptions_propagate_unchanged(self):
+        cancel = sigmaker._CancelToPartial(
+            sigmaker.GenerationPolicy.permissive(),
+            lambda: self._sentinel_partial(),
+        )
+        with self.assertRaises(ValueError):
+            with cancel:
+                raise ValueError("some other error")
+        self.assertIsNone(cancel.partial)
+
+    def test_no_exception_no_partial(self):
+        cancel = sigmaker._CancelToPartial(
+            sigmaker.GenerationPolicy.permissive(),
+            lambda: self._sentinel_partial(),
+        )
+        with cancel:
+            pass
+        self.assertIsNone(cancel.partial)
+
+
+class _FakeDialog:
+    """Recording stand-in for sigmaker.ProgressDialog used in ProgressBox tests."""
+
+    def __init__(self, message: str):
+        self.initial_message = message
+        self.messages: list[str] = []
+        self.enter_count = 0
+        self.exit_count = 0
+        self.exit_exc_type = None
+
+    def __enter__(self):
+        self.enter_count += 1
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.exit_count += 1
+        self.exit_exc_type = exc_type
+        return False  # never suppress
+
+    def replace_message(self, msg: str, hide_cancel: bool = False):
+        self.messages.append(msg)
+
+
+class TestProgressBox(CoveredUnitTest):
+    """ProgressBox wraps iteration with a wait box and live message updates."""
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        self.dialogs: list[_FakeDialog] = []
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _factory(self, message):
+        d = _FakeDialog(message)
+        self.dialogs.append(d)
+        return d
+
+    def _clock(self, ticks):
+        """Return a callable that yields successive tick values, repeating the last."""
+        iterator = iter(ticks)
+        last = [ticks[-1]]
+
+        def call():
+            try:
+                v = next(iterator)
+                last[0] = v
+                return v
+            except StopIteration:
+                return last[0]
+
+        return call
+
+    def test_yields_all_items_in_order(self):
+        items = list(sigmaker.ProgressBox(
+            [1, 2, 3], dialog_factory=self._factory, clock=self._clock([0.0])
+        ))
+        self.assertEqual(items, [1, 2, 3])
+
+    def test_dialog_lifecycle(self):
+        list(sigmaker.ProgressBox(
+            [1, 2, 3], dialog_factory=self._factory, clock=self._clock([0.0])
+        ))
+        self.assertEqual(len(self.dialogs), 1)
+        self.assertEqual(self.dialogs[0].enter_count, 1)
+        self.assertEqual(self.dialogs[0].exit_count, 1)
+
+    def test_throttle_skips_redraws_when_clock_does_not_advance(self):
+        # Clock returns 0.0 always; throttle never elapses.
+        list(sigmaker.ProgressBox(
+            [1, 2, 3, 4, 5],
+            dialog_factory=self._factory,
+            clock=self._clock([0.0]),
+            throttle_seconds=10.0,
+        ))
+        self.assertEqual(len(self.dialogs[0].messages), 0)
+
+    def test_throttle_passes_when_clock_advances(self):
+        # Clock yields: start=0.0, then 0.05, 0.20, 0.30, 0.50, 0.55.
+        # With throttle_seconds=0.1, gaps > 0.1 from last_update pass:
+        #   call#1 last=0.0 now=0.05 -> gap 0.05, skip
+        #   call#2 last=0.0 now=0.20 -> gap 0.20, pass; last=0.20
+        #   call#3 last=0.20 now=0.30 -> gap 0.10, NOT >, skip
+        #   call#4 last=0.20 now=0.50 -> gap 0.30, pass; last=0.50
+        #   call#5 last=0.50 now=0.55 -> gap 0.05, skip
+        # = 2 redraws.
+        list(sigmaker.ProgressBox(
+            [1, 2, 3, 4, 5],
+            dialog_factory=self._factory,
+            clock=self._clock([0.0, 0.05, 0.20, 0.30, 0.50, 0.55]),
+            throttle_seconds=0.1,
+        ))
+        self.assertEqual(len(self.dialogs[0].messages), 2)
+
+    def test_format_message_receives_args(self):
+        received = []
+
+        def fmt(idx, item, elapsed, total):
+            received.append((idx, item, elapsed, total))
+            return f"item {idx}"
+
+        list(sigmaker.ProgressBox(
+            ["a", "b"],
+            format_message=fmt,
+            dialog_factory=self._factory,
+            clock=self._clock([0.0, 1.0, 2.0]),
+            throttle_seconds=0.0,
+        ))
+        self.assertEqual(received[0], (1, "a", 1.0, 2))
+        self.assertEqual(received[1], (2, "b", 2.0, 2))
+
+    def test_cancel_raises_user_canceled_error(self):
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=True)
+        with self.assertRaises(sigmaker.UserCanceledError):
+            list(sigmaker.ProgressBox(
+                [1, 2, 3], dialog_factory=self._factory, clock=self._clock([0.0])
+            ))
+        self.assertEqual(self.dialogs[0].exit_count, 1)
+        self.assertIs(self.dialogs[0].exit_exc_type, sigmaker.UserCanceledError)
+
+    def test_total_is_none_for_generator(self):
+        def gen():
+            yield 1
+            yield 2
+
+        received = []
+
+        def fmt(idx, item, elapsed, total):
+            received.append(total)
+            return ""
+
+        list(sigmaker.ProgressBox(
+            gen(),
+            format_message=fmt,
+            dialog_factory=self._factory,
+            clock=self._clock([0.0, 1.0, 2.0]),
+            throttle_seconds=0.0,
+        ))
+        self.assertEqual(received, [None, None])
+
+    def test_total_computed_from_len(self):
+        received = []
+
+        def fmt(idx, item, elapsed, total):
+            received.append(total)
+            return ""
+
+        list(sigmaker.ProgressBox(
+            [10, 20, 30],
+            format_message=fmt,
+            dialog_factory=self._factory,
+            clock=self._clock([0.0, 1.0, 2.0, 3.0]),
+            throttle_seconds=0.0,
+        ))
+        self.assertTrue(all(t == 3 for t in received))
+
+    def test_default_message_when_no_formatter(self):
+        list(sigmaker.ProgressBox(
+            [1, 2],
+            dialog_factory=self._factory,
+            clock=self._clock([0.0, 1.0, 2.0]),
+            throttle_seconds=0.0,
+        ))
+        self.assertEqual(self.dialogs[0].messages[0], "Processing (1/2) | Elapsed: 1s")
+        self.assertEqual(self.dialogs[0].messages[1], "Processing (2/2) | Elapsed: 2s")
 
 
 if __name__ == "__main__":

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3105,7 +3105,7 @@ class TestProgressFormatters(CoveredUnitTest):
             best_size=100,
             current_anchor_ea=0x140001040,
             inner_length=7,
-            inner_matches=3,
+            inner_matches=2,
         )
         msg = fmt(idx=18, item=0x140001040, elapsed=4.0, total=None)
         # Function bounds + size shown.
@@ -3114,10 +3114,11 @@ class TestProgressFormatters(CoveredUnitTest):
         # Anchor with idx.
         self.assertIn("Anchor (#18):", msg)
         self.assertIn("0x140001040", msg)
-        # Inner search bounds + length + matches.
+        # Inner search bounds + length + matches. Early-bail caps the count,
+        # so 2-or-more renders as "2+".
         self.assertIn("0x140001040 .. 0x140001047", msg)
         self.assertIn("7 bytes", msg)
-        self.assertIn("3 matches", msg)
+        self.assertIn("2+ matches", msg)
         # Best so far + candidates + elapsed.
         self.assertIn("Best found:   -", msg)
         self.assertIn("0 unique so far", msg)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2389,7 +2389,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
             )
         self.assertEqual(len(self.recorded_dialogs), 1)
         self.assertIn(
-            "Generating signature", self.recorded_dialogs[0].initial_message
+            "Create unique signature", self.recorded_dialogs[0].initial_message
         )
 
     def test_progress_dialog_lifecycle_on_cancel(self):
@@ -2798,7 +2798,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         # the recorded dialogs rather than asserting an exact count.
         messages = [d.initial_message for d in self.recorded_dialogs]
         self.assertTrue(
-            any("Finding shortest function signature" in m for m in messages),
+            any("Find shortest function signature" in m for m in messages),
             f"Expected a function-sig wait box; got {messages}",
         )
 
@@ -3077,16 +3077,8 @@ class TestProgressFormatters(CoveredUnitTest):
         sig = self._make_sig(5)
         fmt = sigmaker._UniqueSigProgress(sig=sig)
         msg = fmt(idx=1, item=None, elapsed=2.5, total=None)
-        self.assertIn("Length: 5 bytes", msg)
-        self.assertIn("Matches: ?", msg)
+        self.assertIn("Length:  5 bytes", msg)
         self.assertIn("Elapsed: 2s", msg)
-
-    def test_unique_progress_reflects_match_count_when_set(self):
-        sig = self._make_sig(8)
-        fmt = sigmaker._UniqueSigProgress(sig=sig, last_match_count=3)
-        msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
-        self.assertIn("Length: 8 bytes", msg)
-        self.assertIn("Matches: 3", msg)
 
     def test_unique_progress_sig_is_live_reference(self):
         sig = self._make_sig(2)
@@ -3094,7 +3086,7 @@ class TestProgressFormatters(CoveredUnitTest):
         sig.append(sigmaker.SignatureByte(0xCC, False))
         sig.append(sigmaker.SignatureByte(0xCC, False))
         msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
-        self.assertIn("Length: 4 bytes", msg)
+        self.assertIn("Length:  4 bytes", msg)
 
     def test_function_progress_renders_all_fields(self):
         candidates: list = []


### PR DESCRIPTION
Closes #27.

## Background

From [@OshidaBCF](https://github.com/OshidaBCF) on [issue thread #27](https://github.com/mahmoudimus/ida-sigmaker/issues/27): the wait box during long sigmaker runs has been a static "Generating signature... Press Cancel to stop" with no indication of progress. OshidaBCF asked for live updates of the current signature length and match count, ideally with a configurable update cadence. This PR adds that for the CREATE_UNIQUE and FIND_FUNCTION_SIG flows.

## Architecture

I added a new `ProgressBox` dataclass that wraps an iterable, opens an IDA wait box on iteration start, and calls a `format_message(idx, item, elapsed, total)` callable on each throttled tick. Two small `__slots__` formatter dataclasses (`_UniqueSigProgress` and `_FunctionSigProgress`) hold live references to the generator's state (the signature, the match count, the candidates list, the best size) and render templates on every call. The clock and dialog factory are both injectable so the throttle and wait-box lifecycle are testable without touching `idaapi`.

I also moved the per-flow try/except for partial-on-cancel into a `_CancelToPartial` context-manager dataclass so `UniqueSignatureGenerator.generate` reads top-to-bottom with a flat `with` block instead of nested try/except. And I replaced the materialized start-EA list in `MinimalFunctionSignatureGenerator` with a generator, so the ideal-candidate early exit pays only for the instruction starts it actually visits.

`CheckContinuePrompt.report_progress` and the corresponding Protocol method are gone, because ProgressBox now owns all per-iteration wait-box display. The modal-prompt opt-in from issue #18 still works via `should_cancel`.

## Net behavior

While a CREATE_UNIQUE search runs:

```
Generating signature...

Length: 47 bytes
Matches: 3
Elapsed: 2s

Press Cancel to stop
```

While a FIND_FUNCTION_SIG search runs (generator iteration, so no `of M` suffix; ETA is intentionally omitted because search-problem ETA is unreliable):

```
Finding shortest function signature...

Start 18
Best so far: 9 bytes
Candidates: 2
Elapsed: 4s

Press Cancel to stop
```

Cancel via the wait box still produces `Operation canceled by user` upstream. Issue-#18 modal-prompt opt-in still works. Issue-#22 partial-on-cancel opt-in still works. Issue-#17 xref fallback still fires when the function body has no unique signature.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit | 148 OK | 170 OK |
| Docker `idapro-tests` (9.0/9.1) | green | 188 OK |
| Docker `idapro-tests-9.2` | green | 188 OK |

Zero regressions. New test coverage:

- `TestProgressBox` (9 tests): iteration order, dialog lifecycle, throttling (with injected clock), format_message argument contract, cancel-raises-and-exits-cleanly, total resolution from generators and lists, default message.
- `TestCancelToPartial` (5 tests): strict propagates, permissive stashes, empty-sig propagates the original UserCanceledError, non-cancel exceptions propagate unchanged, no-exception leaves partial=None.
- `TestProgressFormatters` (6 tests): both formatters reflect their live state correctly, including `total=None` for generator iteration.
- Extended `TestUniqueSignatureGeneratorPartialOnCancel` (+2): wait box opens with the expected initial message, dialog `__exit__` fires on cancel.
- Extended `TestMinimalFunctionSignatureGenerator` (+2): wait box opens with the function-sig message, the outer iteration is lazy (cancel on iteration 1 short-circuits all subsequent decode_insn calls).

Two pre-existing `TestProgressReporter` tests (`test_check_continue_prompt_basic`, `test_check_continue_prompt_metadata`) were deleted because they exercised `report_progress`, which no longer exists.
