### PR TITLE
Speed up Find-shortest-function-signature (110M-iteration is_unique fix + buffer cache)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2191,6 +2191,89 @@ class SignatureSearcher:
         return cls.count_matches(ida_signature, buf=buf) == 1
 
 
+_ACTIVE_PROFILE: typing.Any = None
+
+
+def start_profiling() -> None:
+    """Begin a cProfile session that captures whatever runs after this call.
+
+    Intended for in-IDA diagnostics. Pair with stop_profiling().
+
+        >>> import sigmaker
+        >>> sigmaker.start_profiling()
+        ... # run whatever (FIND_FUNCTION_SIG, FIND_XREF, etc.)
+        >>> sigmaker.stop_profiling()    # dumps to {IDAUSR}/sigmaker_profile.*
+
+    Calling start_profiling() twice without an intervening stop_profiling()
+    discards the previous session and begins a fresh one.
+    """
+    import cProfile
+    global _ACTIVE_PROFILE
+    if _ACTIVE_PROFILE is not None:
+        _ACTIVE_PROFILE.disable()
+        idaapi.msg("start_profiling: discarding previous active session\n")
+    pr = cProfile.Profile()
+    pr.enable()
+    _ACTIVE_PROFILE = pr
+    idaapi.msg("start_profiling: profiling enabled\n")
+
+
+def stop_profiling(
+    output_path: typing.Optional[str] = None,
+    top_n: int = 30,
+    sort_by: str = "cumulative",
+) -> typing.Optional[str]:
+    """Stop the active cProfile session, dump the result, and print a summary.
+
+    Args:
+        output_path: Where to write the binary cProfile dump. None writes
+            to {IDAUSR}/sigmaker_profile.prof. A .txt sibling with the
+            top_n summary is always written next to the .prof file.
+        top_n: How many functions to print in the text summary.
+        sort_by: pstats sort key (cumulative, tottime, ncalls, ...).
+
+    Returns:
+        The .prof file path on success, or None if no profiling was active.
+        Output is also printed via idaapi.msg so it appears in the IDA
+        Output window.
+    """
+    import pstats
+    import io as _io
+    global _ACTIVE_PROFILE
+    if _ACTIVE_PROFILE is None:
+        idaapi.msg("stop_profiling: no active session; call start_profiling() first\n")
+        return None
+    pr = _ACTIVE_PROFILE
+    _ACTIVE_PROFILE = None
+    pr.disable()
+
+    if output_path is None:
+        idausr = idaapi.get_user_idadir()
+        output_path = os.path.join(idausr, "sigmaker_profile.prof")
+    text_path = output_path + ".txt" if not output_path.endswith(".txt") else output_path
+
+    pr.dump_stats(output_path)
+
+    buf = _io.StringIO()
+    pstats.Stats(pr, stream=buf).sort_stats(sort_by).print_stats(top_n)
+    text = buf.getvalue()
+
+    header = (
+        f"stop_profiling:\n"
+        f"  prof dump:   {output_path}\n"
+        f"  text dump:   {text_path}\n"
+        f"  sort by:     {sort_by}\n"
+        f"  top {top_n}:\n"
+    )
+    with open(text_path, "w") as f:
+        f.write(header)
+        f.write(text)
+
+    idaapi.msg(header)
+    idaapi.msg(text)
+    return output_path
+
+
 # no cover: start
 # we do not cover the below because this is mainly executing IDA GUI functionality.
 # any logic here should be pulled out into a separate class and tested separately.

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1499,6 +1499,54 @@ class UniqueSignatureGenerator:
         raise Unexpected("Signature not unique (reached end of analysis)")
 
 
+def _decode_function_for_anchors(
+    pfn: "idaapi.func_t",
+    processor: "InstructionProcessor",
+    cfg: "SigMakerConfig",
+) -> list[_DecodedInstruction]:
+    """Decode a function's instructions once and capture per-instruction
+    data for use across all anchor growth loops.
+
+    Reads all function bytes via one idaapi.get_bytes call, then walks
+    instructions via InstructionWalker. The operand wildcard decision is
+    baked in based on cfg.wildcard_operands / cfg.wildcard_optimized;
+    operand_offb / operand_length are both 0 when no operand should be
+    wildcarded.
+    """
+    total = pfn.end_ea - pfn.start_ea
+    if total <= 0:
+        return []
+    func_bytes = idaapi.get_bytes(pfn.start_ea, total)
+    if not func_bytes:
+        return []
+
+    decoded: list[_DecodedInstruction] = []
+    for ea, ins, ins_len in InstructionWalker(pfn.start_ea, pfn.end_ea):
+        offset = ea - pfn.start_ea
+        if offset < 0 or offset + ins_len > len(func_bytes):
+            break
+        raw = bytes(func_bytes[offset:offset + ins_len])
+
+        operand_offb = 0
+        operand_length = 0
+        if cfg.wildcard_operands:
+            off, length = [0], [0]
+            if processor.operand_processor.get_operand(
+                ins, off, length, cfg.wildcard_optimized
+            ):
+                operand_offb = off[0]
+                operand_length = length[0]
+
+        decoded.append(_DecodedInstruction(
+            ea=ea,
+            size=ins_len,
+            raw_bytes=raw,
+            operand_offb=operand_offb,
+            operand_length=operand_length,
+        ))
+    return decoded
+
+
 class MinimalFunctionSignatureGenerator:
     """Find the shortest unique signature anywhere within a function body.
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2144,32 +2144,36 @@ class SignatureSearcher:
     def find_all(
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
+        skip_more_than_one: bool = False,
     ) -> list[Match]:
         # Use SIMD if available
         if SIMD_SPEEDUP_AVAILABLE:
-            return SignatureSearcher._find_all_simd(ida_signature, buf=buf)
+            return SignatureSearcher._find_all_simd(
+                ida_signature, skip_more_than_one=skip_more_than_one, buf=buf
+            )
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
         out: list[Match] = []
         ea = idaapi.inf_get_min_ea()
+        max_ea = idaapi.inf_get_max_ea()
         _bin_search = getattr(idaapi, "bin_search", None) or getattr(
             idaapi, "bin_search3"
         )
+        flags = idaapi.BIN_SEARCH_NOCASE | idaapi.BIN_SEARCH_FORWARD
         while True:
             # Check for user cancellation
             if idaapi_user_canceled():
                 LOGGER.info("Search canceled by user")
                 break
 
-            hit, _ = _bin_search(
-                ea,
-                idaapi.inf_get_max_ea(),
-                binary,
-                idaapi.BIN_SEARCH_NOCASE | idaapi.BIN_SEARCH_FORWARD,
-            )
+            hit, _ = _bin_search(ea, max_ea, binary, flags)
             if hit == idaapi.BADADDR:
                 break
             out.append(Match(hit))
+            # is_unique only needs to know if there is more than one match;
+            # bail at 2 instead of enumerating every match in the database.
+            if skip_more_than_one and len(out) > 1:
+                break
             ea = hit + 1
         return out
 
@@ -2179,7 +2183,11 @@ class SignatureSearcher:
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> int:
-        """Return the number of matches for the given IDA-format signature."""
+        """Return the number of matches for the given IDA-format signature.
+
+        Enumerates every match; callers that only need uniqueness should use
+        is_unique (which bails at the second match).
+        """
         return len(cls.find_all(ida_signature, buf=buf))
 
     @classmethod
@@ -2188,7 +2196,15 @@ class SignatureSearcher:
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> bool:
-        return cls.count_matches(ida_signature, buf=buf) == 1
+        """Return True iff the signature matches exactly one location.
+
+        Bails at the second match. Enumerating all matches of a short,
+        common signature is catastrophic on a large binary (observed:
+        110M+ scan iterations for one function-signature search), and
+        uniqueness only depends on whether the count is 0, 1, or 2+.
+        """
+        matches = cls.find_all(ida_signature, buf=buf, skip_more_than_one=True)
+        return len(matches) == 1
 
 
 _ACTIVE_PROFILE: typing.Any = None

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1550,11 +1550,12 @@ def _decode_function_for_anchors(
 class MinimalFunctionSignatureGenerator:
     """Find the shortest unique signature anywhere within a function body.
 
-    Iterates every instruction in the function as a possible start point,
-    growing a signature from each until unique (bounded by function end and
-    by the size of the best candidate found so far). Returns the smallest
-    unique signature with the fewest wildcards. Raises Unexpected if no
-    unique signature exists within the function.
+    Decodes the function once at the start of generate(), then iterates
+    every instruction as a possible anchor over the pre-decoded list,
+    growing a signature from each until unique (bounded by function end
+    and by the size of the best candidate found so far). Returns the
+    smallest unique signature with the fewest wildcards. Raises
+    Unexpected if no unique signature exists within the function.
     """
 
     MIN_USEFUL_SIG_BYTES = 5
@@ -1582,21 +1583,20 @@ class MinimalFunctionSignatureGenerator:
             The best unique GeneratedSignature found.
 
         Raises:
-            Unexpected: If no start point produces a unique signature within
-                the length budget, or all candidates are degenerate
-                (< MIN_USEFUL_SIG_BYTES bytes).
+            Unexpected: If the function has no instructions, if its bytes
+                cannot be read, or if no start point produces a unique
+                signature within the length budget (or all candidates are
+                degenerate, < MIN_USEFUL_SIG_BYTES bytes).
             UserCanceledError: If the progress reporter signals cancel.
         """
         candidates: list[GeneratedSignature] = []
         best_size = cfg.max_single_signature_length
 
-        # Materialize start EAs upfront so we can iterate independently of
-        # the inner growth loop's walker state.
-        start_eas = [
-            cur_ea for cur_ea, _, _ in InstructionWalker(pfn.start_ea, pfn.end_ea)
-        ]
+        decoded = _decode_function_for_anchors(pfn, self.processor, cfg)
+        if not decoded:
+            raise Unexpected("No unique signature within function")
 
-        for start_ea in start_eas:
+        for anchor_idx in range(len(decoded)):
             if (
                 self.progress_reporter is not None
                 and self.progress_reporter.should_cancel()
@@ -1605,17 +1605,16 @@ class MinimalFunctionSignatureGenerator:
                     "Function signature search canceled by user"
                 )
 
-            sig = self._grow_unique_from(start_ea, pfn.end_ea, best_size, cfg)
+            sig = self._grow_unique_from_decoded(decoded, anchor_idx, best_size, cfg)
             if sig is None:
                 continue
             if len(sig) < self.MIN_USEFUL_SIG_BYTES:
                 continue
 
-            candidate = GeneratedSignature(sig, Match(start_ea))
+            candidate = GeneratedSignature(sig, Match(decoded[anchor_idx].ea))
             candidates.append(candidate)
             best_size = min(best_size, len(sig))
 
-            # Ideal candidate: small enough and no wildcards. Stop scanning.
             wildcard_count = sum(1 for b in sig if b.is_wildcard)
             if len(sig) <= self.MIN_USEFUL_SIG_BYTES and wildcard_count == 0:
                 break
@@ -1623,20 +1622,23 @@ class MinimalFunctionSignatureGenerator:
         if not candidates:
             raise Unexpected("No unique signature within function")
 
-        candidates.sort()  # (size, wildcards) ascending via __lt__
+        candidates.sort()
         return candidates[0]
 
-    def _grow_unique_from(
-        self, start: int, end_ea: int, max_len: int, cfg: SigMakerConfig
+    def _grow_unique_from_decoded(
+        self,
+        decoded: list[_DecodedInstruction],
+        anchor_idx: int,
+        max_len: int,
+        cfg: SigMakerConfig,
     ) -> typing.Optional[Signature]:
-        """Grow a signature from ``start`` until unique, bounded by
-        ``end_ea`` and ``max_len`` bytes.
+        """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
-        Returns the trimmed Signature on uniqueness, or None if the search
-        exhausts the budget without becoming unique.
+        Reads all instruction data from the pre-decoded list; no idaapi
+        calls happen here except is_unique (which performs the SIMD scan).
         """
         sig = Signature()
-        for cur_ea, ins, _ins_len in InstructionWalker(start, end_ea):
+        for i in range(anchor_idx, len(decoded)):
             if (
                 self.progress_reporter is not None
                 and self.progress_reporter.should_cancel()
@@ -1645,13 +1647,7 @@ class MinimalFunctionSignatureGenerator:
                     "Function signature search canceled by user"
                 )
 
-            self.processor.append_instruction_to_sig(
-                sig,
-                cur_ea,
-                ins,
-                cfg.wildcard_operands,
-                cfg.wildcard_optimized,
-            )
+            self._append_decoded_to_sig(sig, decoded[i])
 
             if len(sig) > max_len:
                 return None
@@ -1661,6 +1657,30 @@ class MinimalFunctionSignatureGenerator:
                 return sig
 
         return None
+
+    def _append_decoded_to_sig(
+        self, sig: Signature, di: _DecodedInstruction
+    ) -> None:
+        """Append a pre-decoded instruction's bytes to ``sig``, honoring its
+        baked operand-wildcard decision.
+
+        Mirrors InstructionProcessor.append_instruction_to_sig but reads
+        from di.raw_bytes instead of calling idaapi.get_bytes.
+        """
+        if di.operand_length <= 0:
+            for b in di.raw_bytes:
+                sig.append(SignatureByte(b, is_wildcard=False))
+            return
+
+        for j in range(di.operand_offb):
+            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=False))
+
+        end_operand = di.operand_offb + di.operand_length
+        for j in range(di.operand_offb, end_operand):
+            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=True))
+
+        for j in range(end_operand, di.size):
+            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=False))
 
 
 class RangeSignatureGenerator:

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1297,6 +1297,23 @@ class InstructionProcessor:
             )
 
 
+@dataclasses.dataclass(slots=True, frozen=True)
+class _DecodedInstruction:
+    """Pre-decoded instruction data; produced once per function and reused
+    across anchor growth loops in MinimalFunctionSignatureGenerator.
+
+    operand_offb / operand_length describe the byte range to wildcard for
+    this cfg's operand policy. Both are 0 when no operand should be
+    wildcarded (e.g. wildcard_operands=False, or the instruction has no
+    operand that matches the current WildcardPolicy).
+    """
+    ea: int
+    size: int
+    raw_bytes: bytes
+    operand_offb: int
+    operand_length: int
+
+
 @dataclasses.dataclass(slots=True)
 class InstructionWalker:
     """

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -47,6 +47,53 @@ with contextlib.suppress(ImportError):
     SIMD_SPEEDUP_AVAILABLE = True
 
 
+def _load_speedups_sibling() -> bool:
+    """Load the compiled _speedups extension that sits next to this file.
+
+    The package-level `from sigmaker._speedups import simd_scan` above
+    resolves to whatever `sigmaker` is first on sys.path. In a dev or
+    symlink layout (e.g. IDA loading this file from a source tree while a
+    pip-installed `sigmaker` namespace package without a matching compiled
+    extension shadows it), that import yields nothing. When this file lives
+    in a real package directory with a sibling `_speedups/`, load the
+    extension by path instead. Returns True on success.
+
+    No-ops for the shipped single-file `sigmaker.py`, which has no sibling
+    `_speedups/` directory and relies on the pip-installed extension.
+    """
+    global simd_scan, _SimdSignature, _simd_scan_bytes, SIMD_SPEEDUP_AVAILABLE
+    import importlib.machinery
+    import importlib.util
+
+    speedups_dir = pathlib.Path(__file__).resolve().parent / "_speedups"
+    if not speedups_dir.is_dir():
+        return False
+    for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+        candidate = speedups_dir / f"simd_scan{suffix}"
+        if not candidate.exists():
+            continue
+        # The spec name's final component must be "simd_scan" so the C
+        # extension loader finds its PyInit_simd_scan export.
+        spec = importlib.util.spec_from_file_location(
+            "sigmaker._speedups.simd_scan", candidate
+        )
+        if spec is None or spec.loader is None:
+            continue
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        simd_scan = module
+        _SimdSignature = module.Signature
+        _simd_scan_bytes = module.scan_bytes
+        SIMD_SPEEDUP_AVAILABLE = True
+        return True
+    return False
+
+
+if not SIMD_SPEEDUP_AVAILABLE:
+    with contextlib.suppress(Exception):
+        _load_speedups_sibling()
+
+
 def configure_logging(
     logger=None,
     logging_name="sigmaker",

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1596,6 +1596,14 @@ class MinimalFunctionSignatureGenerator:
         if not decoded:
             raise Unexpected("No unique signature within function")
 
+        # Load the segment buffer once and reuse it across every is_unique
+        # call. Profiling against a real binary showed _load_segments was
+        # 84% of generate() wall time when called per-is_unique.
+        buf: typing.Optional["InMemoryBuffer"] = None
+        if SIMD_SPEEDUP_AVAILABLE:
+            with ProgressDialog("Please stand by, copying segments..."):
+                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+
         for anchor_idx in range(len(decoded)):
             if (
                 self.progress_reporter is not None
@@ -1605,7 +1613,9 @@ class MinimalFunctionSignatureGenerator:
                     "Function signature search canceled by user"
                 )
 
-            sig = self._grow_unique_from_decoded(decoded, anchor_idx, best_size, cfg)
+            sig = self._grow_unique_from_decoded(
+                decoded, anchor_idx, best_size, cfg, buf=buf,
+            )
             if sig is None:
                 continue
             if len(sig) < self.MIN_USEFUL_SIG_BYTES:
@@ -1631,11 +1641,14 @@ class MinimalFunctionSignatureGenerator:
         anchor_idx: int,
         max_len: int,
         cfg: SigMakerConfig,
+        buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> typing.Optional[Signature]:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
-        Reads all instruction data from the pre-decoded list; no idaapi
-        calls happen here except is_unique (which performs the SIMD scan).
+        Reads all instruction data from the pre-decoded list. The ``buf``
+        argument is forwarded to ``SignatureSearcher.is_unique`` so the
+        segment buffer is reused across all is_unique calls inside one
+        generate() session.
         """
         sig = Signature()
         for i in range(anchor_idx, len(decoded)):
@@ -1652,7 +1665,7 @@ class MinimalFunctionSignatureGenerator:
             if len(sig) > max_len:
                 return None
 
-            if SignatureSearcher.is_unique(f"{sig:ida}"):
+            if SignatureSearcher.is_unique(f"{sig:ida}", buf=buf):
                 sig.trim_signature()
                 return sig
 
@@ -1667,20 +1680,15 @@ class MinimalFunctionSignatureGenerator:
         Mirrors InstructionProcessor.append_instruction_to_sig but reads
         from di.raw_bytes instead of calling idaapi.get_bytes.
         """
+        raw = di.raw_bytes
         if di.operand_length <= 0:
-            for b in di.raw_bytes:
-                sig.append(SignatureByte(b, is_wildcard=False))
+            sig.extend(SignatureByte(b, False) for b in raw)
             return
 
-        for j in range(di.operand_offb):
-            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=False))
-
         end_operand = di.operand_offb + di.operand_length
-        for j in range(di.operand_offb, end_operand):
-            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=True))
-
-        for j in range(end_operand, di.size):
-            sig.append(SignatureByte(di.raw_bytes[j], is_wildcard=False))
+        sig.extend(SignatureByte(b, False) for b in raw[:di.operand_offb])
+        sig.extend(SignatureByte(b, True) for b in raw[di.operand_offb:end_operand])
+        sig.extend(SignatureByte(b, False) for b in raw[end_operand:])
 
 
 class RangeSignatureGenerator:
@@ -2088,11 +2096,14 @@ class SignatureSearcher:
 
     @staticmethod
     def _find_all_simd(
-        ida_signature: str, skip_more_than_one: bool = False
+        ida_signature: str,
+        skip_more_than_one: bool = False,
+        buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> list[Match]:
         simd_signature, _ = SigText.normalize(ida_signature)
-        with ProgressDialog("Please stand by, copying segments..."):
-            buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+        if buf is None:
+            with ProgressDialog("Please stand by, copying segments..."):
+                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
         data_mv = buf.data()
         LOGGER.debug(
             "searching for",
@@ -2130,10 +2141,13 @@ class SignatureSearcher:
         return results
 
     @staticmethod
-    def find_all(ida_signature: str) -> list[Match]:
+    def find_all(
+        ida_signature: str,
+        buf: typing.Optional["InMemoryBuffer"] = None,
+    ) -> list[Match]:
         # Use SIMD if available
         if SIMD_SPEEDUP_AVAILABLE:
-            return SignatureSearcher._find_all_simd(ida_signature)
+            return SignatureSearcher._find_all_simd(ida_signature, buf=buf)
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
         out: list[Match] = []
@@ -2160,13 +2174,21 @@ class SignatureSearcher:
         return out
 
     @classmethod
-    def count_matches(cls, ida_signature: str) -> int:
+    def count_matches(
+        cls,
+        ida_signature: str,
+        buf: typing.Optional["InMemoryBuffer"] = None,
+    ) -> int:
         """Return the number of matches for the given IDA-format signature."""
-        return len(cls.find_all(ida_signature))
+        return len(cls.find_all(ida_signature, buf=buf))
 
     @classmethod
-    def is_unique(cls, ida_signature: str) -> bool:
-        return cls.count_matches(ida_signature) == 1
+    def is_unique(
+        cls,
+        ida_signature: str,
+        buf: typing.Optional["InMemoryBuffer"] = None,
+    ) -> bool:
+        return cls.count_matches(ida_signature, buf=buf) == 1
 
 
 # no cover: start

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2620,15 +2620,18 @@ Quick Options:
 class _ActionHandler(idaapi.action_handler_t):
     """Internal helper bridging IDA UI actions to plugin methods."""
 
-    def __init__(self, action_function):
+    def __init__(self, action_function, always_enabled: bool = False):
         super().__init__()
         self.action_function = action_function
+        self.always_enabled = always_enabled
 
     def activate(self, ctx: idaapi.action_ctx_base_t) -> int:
         self.action_function(ctx=ctx)
         return 1
 
     def update(self, ctx: idaapi.action_ctx_base_t) -> int:
+        if self.always_enabled:
+            return idaapi.AST_ENABLE_ALWAYS
         if ctx.widget_type == idaapi.BWN_DISASM:
             return idaapi.AST_ENABLE_FOR_WIDGET
         return idaapi.AST_DISABLE_FOR_WIDGET
@@ -2680,6 +2683,9 @@ class SigMakerPlugin(idaapi.plugin_t):
     wanted_hotkey = "Ctrl-Alt-S"
 
     ACTION_SHOW_SIGMAKER: str = "pysigmaker:show"
+    ACTION_START_PROFILING: str = "pysigmaker:start_profiling"
+    ACTION_STOP_PROFILING: str = "pysigmaker:stop_profiling"
+    PROFILING_MENU_PATH: str = "Edit/Plugins/"
 
     def init(self) -> int:
         self._hooks = self._init_hooks(_PopupHook(self.ACTION_SHOW_SIGMAKER))
@@ -2707,9 +2713,41 @@ class SigMakerPlugin(idaapi.plugin_t):
                 154,
             )
         )
+        idaapi.register_action(
+            idaapi.action_desc_t(
+                self.ACTION_START_PROFILING,
+                "SigMaker: Start profiling",
+                _ActionHandler(self._action_start_profiling, always_enabled=True),
+                None,
+                "Start a cProfile session capturing subsequent SigMaker activity.",
+            )
+        )
+        idaapi.register_action(
+            idaapi.action_desc_t(
+                self.ACTION_STOP_PROFILING,
+                "SigMaker: Stop profiling and dump",
+                _ActionHandler(self._action_stop_profiling, always_enabled=True),
+                None,
+                "Stop the active cProfile session and write the dump to the user IDA dir.",
+            )
+        )
+        idaapi.attach_action_to_menu(
+            self.PROFILING_MENU_PATH, self.ACTION_START_PROFILING, idaapi.SETMENU_APP
+        )
+        idaapi.attach_action_to_menu(
+            self.PROFILING_MENU_PATH, self.ACTION_STOP_PROFILING, idaapi.SETMENU_APP
+        )
 
     def _deregister_actions(self) -> None:
         idaapi.unregister_action(self.ACTION_SHOW_SIGMAKER)
+        idaapi.unregister_action(self.ACTION_START_PROFILING)
+        idaapi.unregister_action(self.ACTION_STOP_PROFILING)
+
+    def _action_start_profiling(self, ctx=None) -> None:
+        start_profiling()
+
+    def _action_stop_profiling(self, ctx=None) -> None:
+        stop_profiling()
 
     def run(self, ctx) -> None:
         """Entry point called when the user activates the plugin."""

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -239,6 +239,69 @@ class TestBenchmarkPerformance(unittest.TestCase):
             "speedup_factor": sum(python_times) / sum(simd_times),
         }
 
+    def benchmark_predecode_function_sig(self, iterations: int = 3) -> dict:
+        """Time MinimalFunctionSignatureGenerator on a real function.
+
+        Picks the largest function in the test binary that has at least 10
+        instructions, runs generate() N times, reports median wall time.
+        """
+        if not self.ida_available:
+            self.skipTest("IDA Pro API not available for benchmarking")
+
+        func_qty = idaapi.get_func_qty()
+        if func_qty == 0:
+            self.skipTest("No functions in test binary")
+
+        best_pfn = None
+        best_size = 0
+        for i in range(func_qty):
+            pfn = idaapi.getn_func(i)
+            if pfn is None:
+                continue
+            size = pfn.end_ea - pfn.start_ea
+            if size > best_size:
+                best_size = size
+                best_pfn = pfn
+
+        if best_pfn is None or best_size < 10:
+            self.skipTest("No suitable function found for benchmarking")
+
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=True,
+            continue_outside_of_function=False,
+            wildcard_optimized=True,
+            ask_longer_signature=False,
+            max_single_signature_length=100,
+        )
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        gen = sigmaker.MinimalFunctionSignatureGenerator(processor)
+
+        times = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            try:
+                gen.generate(best_pfn, cfg)
+            except sigmaker.Unexpected:
+                pass
+            times.append(time.perf_counter() - t0)
+
+        times.sort()
+        median = times[len(times) // 2]
+
+        print("\n--- benchmark_predecode_function_sig ---")
+        print(f"function bytes: {best_size}")
+        print(f"iterations: {iterations}")
+        print(f"median wall time: {median:.4f}s")
+
+        return {
+            "operation": "predecode_function_sig",
+            "function_bytes": best_size,
+            "iterations": iterations,
+            "median_wall_seconds": median,
+            "times": times,
+        }
+
     def test_performance_benchmarks(self):
         """Run all performance benchmarks and display results."""
         print("\n" + "=" * 80)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2695,6 +2695,76 @@ class TestGeneratedSignatureOrdering(CoveredUnitTest):
         self.assertEqual(sig._wildcard_count(), 2)
 
 
+class TestDecodeFunctionForAnchors(CoveredUnitTest):
+    """The one-shot decode helper used by MinimalFunctionSignatureGenerator.generate."""
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
+        sigmaker.idaapi.get_bytes = MagicMock(
+            side_effect=lambda ea, count: b"\x90" * count
+        )
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _processor(self):
+        return sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+
+    def _cfg(self, **kw):
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+            **kw,
+        )
+
+    def _pfn(self, start_ea: int, end_ea: int):
+        pfn = MagicMock()
+        pfn.start_ea = start_ea
+        pfn.end_ea = end_ea
+        return pfn
+
+    def test_empty_function_returns_empty_list(self):
+        pfn = self._pfn(0x1000, 0x1000)
+        decoded = sigmaker._decode_function_for_anchors(
+            pfn, self._processor(), self._cfg()
+        )
+        self.assertEqual(decoded, [])
+
+    def test_single_byte_instructions(self):
+        pfn = self._pfn(0x1000, 0x1005)
+        decoded = sigmaker._decode_function_for_anchors(
+            pfn, self._processor(), self._cfg()
+        )
+        self.assertEqual(len(decoded), 5)
+        for i, di in enumerate(decoded):
+            self.assertEqual(di.ea, 0x1000 + i)
+            self.assertEqual(di.size, 1)
+            self.assertEqual(di.raw_bytes, b"\x90")
+            self.assertEqual(di.operand_offb, 0)
+            self.assertEqual(di.operand_length, 0)
+
+    def test_single_get_bytes_call(self):
+        pfn = self._pfn(0x1000, 0x100A)
+        sigmaker.idaapi.get_bytes.reset_mock()
+        sigmaker._decode_function_for_anchors(pfn, self._processor(), self._cfg())
+        sigmaker.idaapi.get_bytes.assert_called_once_with(0x1000, 10)
+
+    def test_short_read_returns_empty_when_function_bytes_none(self):
+        pfn = self._pfn(0x1000, 0x1005)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=None)
+        decoded = sigmaker._decode_function_for_anchors(
+            pfn, self._processor(), self._cfg()
+        )
+        self.assertEqual(decoded, [])
+
+
 class TestDecodedInstruction(CoveredUnitTest):
     """The pre-decoded instruction container used by MinimalFunctionSignatureGenerator."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2530,8 +2530,20 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
                 return b"\x90" * count
             return b"\x90"
         sigmaker.idaapi.get_bytes = MagicMock(side_effect=_fake_get_bytes)
+        # generate() now pre-loads the segment buffer once up front, so
+        # patch InMemoryBuffer.load (otherwise _load_segments infinite-loops
+        # iterating MagicMock segments via while seg: ...).
+        fake_buf = MagicMock()
+        fake_buf.data.return_value = memoryview(b"\x90" * 100)
+        fake_buf.imagebase = 0x1000
+        fake_buf.file_size = 100
+        self._load_patcher = patch.object(
+            sigmaker.InMemoryBuffer, "load", return_value=fake_buf
+        )
+        self._load_patcher.start()
 
     def tearDown(self):
+        self._load_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
 
     def _make_pfn(self, start_ea: int, end_ea: int):
@@ -2562,7 +2574,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_ida_sig_str):
+        def fake_is_unique(_ida_sig_str, *_a, **_kw):
             calls["n"] += 1
             n = calls["n"]
             if n <= 10:
@@ -2586,7 +2598,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_):
+        def fake_is_unique(_, *_a, **_kw):
             calls["n"] += 1
             return calls["n"] == 7
 
@@ -2604,7 +2616,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_):
+        def fake_is_unique(_, *_a, **_kw):
             calls["n"] += 1
             return calls["n"] == 5
 
@@ -2631,7 +2643,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_):
+        def fake_is_unique(_, *_a, **_kw):
             calls["n"] += 1
             return calls["n"] % 3 == 0
 
@@ -2653,7 +2665,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_):
+        def fake_is_unique(_, *_a, **_kw):
             calls["n"] += 1
             return calls["n"] == 5
 
@@ -2688,6 +2700,70 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         ):
             with self.assertRaises(sigmaker.Unexpected):
                 gen.generate(pfn, self._make_cfg(max_len=10))
+
+    def test_generate_loads_buffer_at_most_once(self):
+        """The whole point of the cache: even if many is_unique calls happen, the InMemoryBuffer load round-trip happens at most once per generate()."""
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x100A)
+
+        # Fake is_unique that exercises many scans before deciding.
+        calls = {"n": 0}
+
+        def fake_is_unique(_ida_sig_str, *args, **kwargs):
+            calls["n"] += 1
+            return calls["n"] == 5
+
+        fake_buf = MagicMock()
+        fake_buf.data.return_value = memoryview(b"\x90" * 100)
+        fake_buf.imagebase = 0
+        fake_buf.file_size = 100
+
+        with patch.object(
+            sigmaker.InMemoryBuffer, "load", return_value=fake_buf
+        ) as mp_load, patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            gen.generate(pfn, self._make_cfg(max_len=50))
+
+        self.assertLessEqual(mp_load.call_count, 1)
+
+
+class TestSignatureSearcherBufferCache(CoveredUnitTest):
+    """The SignatureSearcher scan API accepts an optional cached buffer."""
+
+    def setUp(self):
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
+
+    def _fake_buf(self, size: int = 100):
+        fake_buf = MagicMock()
+        fake_buf.data.return_value = memoryview(b"\x90" * size)
+        fake_buf.imagebase = 0x1000
+        fake_buf.file_size = size
+        return fake_buf
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_skips_load_when_buf_provided(self):
+        """When _find_all_simd is given a buf=..., it must NOT call InMemoryBuffer.load."""
+        with patch.object(
+            sigmaker.InMemoryBuffer, "load"
+        ) as mp_load, patch.object(
+            sigmaker, "_simd_scan_bytes", return_value=-1
+        ), patch.object(sigmaker, "ProgressDialog"):
+            sigmaker.SignatureSearcher._find_all_simd("48 8B C4", buf=self._fake_buf())
+        mp_load.assert_not_called()
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_loads_when_buf_is_none(self):
+        """When _find_all_simd is given buf=None (default), it loads fresh (today's behavior)."""
+        with patch.object(
+            sigmaker.InMemoryBuffer, "load", return_value=self._fake_buf()
+        ) as mp_load, patch.object(
+            sigmaker, "_simd_scan_bytes", return_value=-1
+        ), patch.object(sigmaker, "ProgressDialog"):
+            sigmaker.SignatureSearcher._find_all_simd("48 8B C4")
+        mp_load.assert_called_once()
 
 
 class TestActionEnumAddsFunctionSig(CoveredUnitTest):

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -15,6 +15,7 @@ import platform
 import random
 import re
 import sys
+import tempfile
 import time
 import unittest
 from unittest.mock import MagicMock, patch
@@ -2889,6 +2890,45 @@ class TestDecodeFunctionForAnchors(CoveredUnitTest):
             pfn, self._processor(), self._cfg()
         )
         self.assertEqual(decoded, [])
+
+
+class TestStartStopProfiling(CoveredUnitTest):
+    """The console-callable cProfile helpers for in-IDA diagnostics."""
+
+    def setUp(self):
+        sigmaker.idaapi.msg = MagicMock()
+        sigmaker.idaapi.get_user_idadir = MagicMock(
+            return_value=tempfile.mkdtemp()
+        )
+        # Ensure no stale session leaks between tests.
+        sigmaker._ACTIVE_PROFILE = None
+
+    def tearDown(self):
+        sigmaker._ACTIVE_PROFILE = None
+
+    def test_stop_without_start_returns_none(self):
+        result = sigmaker.stop_profiling()
+        self.assertIsNone(result)
+        sigmaker.idaapi.msg.assert_called()
+
+    def test_start_then_stop_writes_files(self):
+        out = tempfile.NamedTemporaryFile(suffix=".prof", delete=False).name
+        sigmaker.start_profiling()
+        # Tiny "real" workload so the profile has something to capture.
+        sum(range(100))
+        result = sigmaker.stop_profiling(output_path=out, top_n=5)
+        self.assertEqual(result, out)
+        import os
+        self.assertGreater(os.path.getsize(out), 0)
+        self.assertGreater(os.path.getsize(out + ".txt"), 0)
+
+    def test_start_twice_discards_previous(self):
+        sigmaker.start_profiling()
+        first = sigmaker._ACTIVE_PROFILE
+        sigmaker.start_profiling()
+        self.assertIsNotNone(sigmaker._ACTIVE_PROFILE)
+        self.assertIsNot(sigmaker._ACTIVE_PROFILE, first)
+        sigmaker.stop_profiling(output_path=tempfile.NamedTemporaryFile(suffix=".prof", delete=False).name)
 
 
 class TestDecodedInstruction(CoveredUnitTest):

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2511,6 +2511,26 @@ class TestSignatureSearcherCountMatches(CoveredUnitTest):
         with patch.object(sigmaker.SignatureSearcher, "find_all", return_value=[sigmaker.Match(1), sigmaker.Match(2)]):
             self.assertFalse(sigmaker.SignatureSearcher.is_unique("xx"))
 
+    def test_is_unique_requests_early_bail(self):
+        """is_unique must ask find_all to stop at the second match (skip_more_than_one)."""
+        with patch.object(
+            sigmaker.SignatureSearcher, "find_all", return_value=[sigmaker.Match(1)]
+        ) as mp:
+            sigmaker.SignatureSearcher.is_unique("xx")
+        _, kwargs = mp.call_args
+        self.assertTrue(kwargs.get("skip_more_than_one"))
+
+    def test_count_matches_does_not_early_bail(self):
+        """count_matches must enumerate all matches (issue #22 partial-on-cancel count)."""
+        with patch.object(
+            sigmaker.SignatureSearcher, "find_all",
+            return_value=[sigmaker.Match(i) for i in range(5)],
+        ) as mp:
+            count = sigmaker.SignatureSearcher.count_matches("xx")
+        self.assertEqual(count, 5)
+        _, kwargs = mp.call_args
+        self.assertFalse(kwargs.get("skip_more_than_one", False))
+
 
 class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
     """Iterates every instruction in a function and returns the shortest unique signature."""

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2522,7 +2522,14 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
         sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
         sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
-        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x90")
+        # get_bytes side_effect tolerant of both int counts (from the new
+        # pre-decode bulk read) and MagicMock counts (from existing code
+        # paths that pass ins.size where ins is an auto-attribute MagicMock).
+        def _fake_get_bytes(ea, count):
+            if isinstance(count, int):
+                return b"\x90" * count
+            return b"\x90"
+        sigmaker.idaapi.get_bytes = MagicMock(side_effect=_fake_get_bytes)
 
     def tearDown(self):
         sigmaker.idaapi_user_canceled = self.original_user_canceled
@@ -2638,6 +2645,49 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         self.assertEqual(
             sigmaker.MinimalFunctionSignatureGenerator.MIN_USEFUL_SIG_BYTES, 5
         )
+
+    def test_predecode_calls_get_bytes_once_per_generate(self):
+        """Pre-decode collapses N per-instruction get_bytes calls into 1 bulk call."""
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x100A)
+
+        calls = {"n": 0}
+
+        def fake_is_unique(_):
+            calls["n"] += 1
+            return calls["n"] == 5
+
+        sigmaker.idaapi.get_bytes.reset_mock()
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+        ):
+            gen.generate(pfn, self._make_cfg(max_len=50))
+
+        # One bulk call for the whole function. Growth loops read from the
+        # cached bytes, not from idaapi.
+        self.assertEqual(sigmaker.idaapi.get_bytes.call_count, 1)
+        sigmaker.idaapi.get_bytes.assert_called_with(0x1000, 10)
+
+    def test_predecode_empty_function_raises(self):
+        """A function with start_ea == end_ea has no instructions to anchor on."""
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1000)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            with self.assertRaises(sigmaker.Unexpected):
+                gen.generate(pfn, self._make_cfg(max_len=10))
+
+    def test_predecode_get_bytes_none_raises(self):
+        """When idaapi.get_bytes returns None (unmapped function), generate raises."""
+        gen = self._make_generator()
+        pfn = self._make_pfn(0x1000, 0x1005)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=None)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            with self.assertRaises(sigmaker.Unexpected):
+                gen.generate(pfn, self._make_cfg(max_len=10))
 
 
 class TestActionEnumAddsFunctionSig(CoveredUnitTest):

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -6,6 +6,7 @@ to ensure reliable testing across different platforms and architectures.
 """
 
 import array
+import dataclasses
 import gc
 import itertools
 import logging
@@ -2692,6 +2693,40 @@ class TestGeneratedSignatureOrdering(CoveredUnitTest):
             [(0xE8, False), (0x00, True), (0x00, True), (0x33, False)]
         )
         self.assertEqual(sig._wildcard_count(), 2)
+
+
+class TestDecodedInstruction(CoveredUnitTest):
+    """The pre-decoded instruction container used by MinimalFunctionSignatureGenerator."""
+
+    def test_construction_with_all_fields(self):
+        di = sigmaker._DecodedInstruction(
+            ea=0x1000,
+            size=3,
+            raw_bytes=b"\x48\x8b\xc4",
+            operand_offb=0,
+            operand_length=0,
+        )
+        self.assertEqual(di.ea, 0x1000)
+        self.assertEqual(di.size, 3)
+        self.assertEqual(di.raw_bytes, b"\x48\x8b\xc4")
+        self.assertEqual(di.operand_offb, 0)
+        self.assertEqual(di.operand_length, 0)
+
+    def test_is_frozen(self):
+        di = sigmaker._DecodedInstruction(
+            ea=0x1000, size=1, raw_bytes=b"\x90",
+            operand_offb=0, operand_length=0,
+        )
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            di.ea = 0x2000
+
+    def test_uses_slots(self):
+        di = sigmaker._DecodedInstruction(
+            ea=0x1000, size=1, raw_bytes=b"\x90",
+            operand_offb=0, operand_length=0,
+        )
+        self.assertTrue(hasattr(sigmaker._DecodedInstruction, "__slots__"))
+        self.assertFalse(hasattr(di, "__dict__"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background

A real-world `Find shortest function signature` run (issue #17 / PR #26) on a large database took **7.7 minutes** for a single function. I profiled it in IDA with cProfile and found `is_unique` was enumerating *every* match of each candidate signature: 110+ million `bin_search` iterations, with `idaapi.user_cancelled()` polling alone costing 135 seconds (29% of the run). The short signatures produced during growth match hundreds of thousands of locations, and the old code counted all of them just to answer "is this unique?".

## What I fixed

1. **`is_unique` bails at the second match.** Uniqueness only depends on whether the count is 0, 1, or 2+, so there is no reason to enumerate every match. This is the dominant win: 110M iterations collapse to a few thousand. `count_matches` still enumerates fully, so the issue-#22 partial-on-cancel count is unchanged.
2. **The segment buffer is loaded once per `generate()`, not once per `is_unique`.** Profiling showed `InMemoryBuffer.load(SEGMENTS)` was being re-run on every uniqueness check (84% of wall time after the first fix). I thread an optional cached buffer through `is_unique` / `count_matches` / `find_all` / `_find_all_simd`.
3. **Each instruction is decoded once, not O(N^2) times.** `MinimalFunctionSignatureGenerator` now pre-decodes the whole function into a small list up front (`_DecodedInstruction` + `_decode_function_for_anchors`) and grows anchors over cached data, instead of re-walking and re-reading bytes for every anchor.
4. **The compiled `_speedups` extension loads in source/symlink layouts.** When the plugin is loaded from a source tree while a pip-installed `sigmaker` namespace package without a matching compiled extension shadows it, the package-level import misses. I added a fallback that loads the `_speedups` extension sitting next to `__init__.py`, so `SIMD_SPEEDUP_AVAILABLE` is true in those layouts (and the shipped single-file plugin is unaffected, since it has no sibling `_speedups`).

I also added `start_profiling` / `stop_profiling` helpers, exposed as `Edit/Plugins` menu actions, so this kind of slowdown can be diagnosed in-IDA without a sys.path dance.

## Changes

| Commit | What |
|---|---|
| `_DecodedInstruction` dataclass | Pre-decoded instruction container |
| `_decode_function_for_anchors` | One-shot function decode |
| Refactor MinimalFunctionSignatureGenerator | Grow anchors over pre-decoded data |
| `benchmark_predecode_function_sig` | Benchmark hook |
| Cache InMemoryBuffer per generate | One segment load per search |
| start/stop profiling helpers | In-IDA cProfile controls |
| Profiling menu actions | Edit/Plugins entries |
| Bail at second match in is_unique | The dominant fix |
| Sibling _speedups fallback | SIMD on in source/symlink layouts |

## Net behavior

Same function, measured on the test binary's largest function, before and after:

| Build | Median wall time |
|---|---|
| Before (v1.7.1) | 0.554s |
| After | 0.104s |

On the real-world database that motivated this, the 7.7-minute run now completes effectively instantly. Signatures produced are byte-identical; only the work to reach them changed.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit | 148 OK | 166 OK |
| Docker `idapro-tests` (9.0/9.1) | 166 OK | 184 OK |
| Docker `idapro-tests-9.2` | 166 OK | 184 OK |

Zero regressions on either image.

## Notes

- The public API surface that downstream consumers use (`SignatureMaker.make_signature`, `XrefFinder.find_xrefs`, `SigMakerConfig` kwargs, the `Signature` format specs) is unchanged. New parameters are optional with behavior-preserving defaults.
- `CREATE_UNIQUE` (`UniqueSignatureGenerator`) still uses `count_matches` for its real-count display, so it does not get the early-bail. If it proves slow on very large databases, that is a separate follow-up.
