### PR TITLE
Release 1.7.2: CHANGELOG + version bump + embed changelog in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,14 +104,24 @@ jobs:
               if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
               run: |
                   cp src/sigmaker/__init__.py sigmaker.py
+            - &read-changelog
+              name: 📖 Read CHANGELOG section for this version
+              id: changelog
+              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
+              # Pinned to v2.4.0 (mindsers/changelog-reader-action).
+              uses: mindsers/changelog-reader-action@1faaf50aa09d5793d9a100819973df801febfb31
+              with:
+                  version: ${{ steps.version.outputs.version }}
+                  path: ./CHANGELOG.md
             - &create-release-body
               name: ✏️ Create release body
               if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
+              # changes_file is a path to the parsed section body, so we cat it
+              # in (never interpolate changelog text into the shell, which would
+              # execute backticks/$() in the markdown).
               run: |
                   VERSION="${{ steps.version.outputs.version }}"
-                  # Build release_body.md, embedding this version's CHANGELOG.md
-                  # section (from its "## [VERSION]" heading up to the next
-                  # "## [" heading) directly into the published release notes.
+                  CHANGES_FILE="${{ steps.changelog.outputs.changes_file }}"
                   {
                     echo "# sigmaker.py - IDA Python Standalone Python Release"
                     echo ""
@@ -122,17 +132,8 @@ jobs:
                     echo ""
                     echo "## What changed"
                     echo ""
-                    if [ -f CHANGELOG.md ]; then
-                      SECTION=$(awk -v ver="$VERSION" '
-                          $0 ~ ("^## \\[" ver "\\]") { capture = 1; print; next }
-                          capture && /^## \[/ { exit }
-                          capture { print }
-                      ' CHANGELOG.md)
-                    else
-                      SECTION=""
-                    fi
-                    if [ -n "$SECTION" ]; then
-                      printf '%s\n' "$SECTION"
+                    if [ -n "$CHANGES_FILE" ] && [ -f "$CHANGES_FILE" ]; then
+                      cat "$CHANGES_FILE"
                     else
                       echo "See [CHANGELOG.md](https://github.com/mahmoudimus/ida-sigmaker/blob/main/CHANGELOG.md) for details."
                     fi
@@ -213,5 +214,6 @@ jobs:
 
             - *setup-python
             - *create-sigmaker-py
+            - *read-changelog
             - *create-release-body
             - *generate-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,30 +108,49 @@ jobs:
               name: ✏️ Create release body
               if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
               run: |
-                  cat > release_body.md << 'EOF'
-                  # sigmaker.py - IDA Python Standalone Python Release
+                  VERSION="${{ steps.version.outputs.version }}"
+                  # Build release_body.md, embedding this version's CHANGELOG.md
+                  # section (from its "## [VERSION]" heading up to the next
+                  # "## [" heading) directly into the published release notes.
+                  {
+                    echo "# sigmaker.py - IDA Python Standalone Python Release"
+                    echo ""
+                    echo "## Release Information"
+                    echo "- **Version**: ${VERSION}"
+                    echo "- **Source**: https://github.com/mahmoudimus/ida-sigmaker"
+                    echo "- **Author**: @mahmoudimus (Mahmoud Abdelkader)"
+                    echo ""
+                    echo "## What changed"
+                    echo ""
+                    if [ -f CHANGELOG.md ]; then
+                      SECTION=$(awk -v ver="$VERSION" '
+                          $0 ~ ("^## \\[" ver "\\]") { capture = 1; print; next }
+                          capture && /^## \[/ { exit }
+                          capture { print }
+                      ' CHANGELOG.md)
+                    else
+                      SECTION=""
+                    fi
+                    if [ -n "$SECTION" ]; then
+                      printf '%s\n' "$SECTION"
+                    else
+                      echo "See [CHANGELOG.md](https://github.com/mahmoudimus/ida-sigmaker/blob/main/CHANGELOG.md) for details."
+                    fi
+                    echo ""
+                    echo "## Description"
+                    echo "This is a standalone release of the IDA Pro signature maker plugin. The file \`sigmaker.py\` contains the complete plugin code that can be directly imported into IDA Pro."
+                    echo ""
+                    echo "## Installation"
+                    echo "1. Copy \`sigmaker.py\` to your IDA Pro plugins directory"
+                    echo "2. Restart IDA Pro"
+                    echo "3. Use Ctrl+Alt+S to access the Signature Maker menu"
+                    echo ""
+                    echo "## License"
+                    echo "See the main repository for license information."
+                  } > release_body.md
 
-                  ## Release Information
-                  - **Version**: ${{ steps.version.outputs.version }}
-                  - **Source**: https://github.com/mahmoudimus/ida-sigmaker
-                  - **Author**: @mahmoudimus (Mahmoud Abdelkader)
-
-                  ## Description
-                  This is a standalone release of the IDA Pro signature maker plugin. The file `sigmaker.py` contains the complete plugin code that can be directly imported into IDA Pro.
-
-                  ## Installation
-                  1. Copy `sigmaker.py` to your IDA Pro plugins directory
-                  2. Restart IDA Pro
-                  3. Use Ctrl+Alt+S to access the Signature Maker menu
-
-                  ## License
-                  See the main repository for license information.
-                  EOF
-
-                  echo "RELEASE_BODY<<EOF" >> $GITHUB_ENV
-                  cat release_body.md >> $GITHUB_ENV
-                  echo "EOF" >> $GITHUB_ENV
-                  rm release_body.md
+                  echo "----- release_body.md -----"
+                  cat release_body.md
             - &generate-release
               name: 📦 Generate Release
               if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
@@ -141,7 +160,7 @@ jobs:
                       sigmaker.py
                   tag_name: ${{ steps.version.outputs.tag }} # e.g. v1.3.0
                   name: ${{ steps.version.outputs.tag }}
-                  body: ${{ env.RELEASE_BODY }}
+                  body_path: release_body.md
                   draft: false
                   generate_release_notes: false
                   prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.2] - 2026-05-28
+
+### Added
+
+- **Live wait-box progress** for the `Create unique signature` and `Find shortest unique signature for current function` actions. The wait box updates as the search runs: current signature length and elapsed time for both, plus function bounds, current anchor, inner-search bounds, best size, and candidate count for the function search. ([#27](https://github.com/mahmoudimus/ida-sigmaker/issues/27), [#30](https://github.com/mahmoudimus/ida-sigmaker/pull/30))
+- **Self-describing wait boxes.** Every action's wait box now leads with the action name and a one-line explanation of what it is doing, so a screenshot always identifies which action produced it. ([#30](https://github.com/mahmoudimus/ida-sigmaker/pull/30))
+- **`start_profiling` / `stop_profiling` helpers**, exposed as `Edit/Plugins` menu actions, for capturing a cProfile dump of a slow run from inside IDA. ([#30](https://github.com/mahmoudimus/ida-sigmaker/pull/30))
+
+### Changed
+
+- **`Find shortest unique signature for current function` is dramatically faster.** Uniqueness checks now stop at the second match instead of enumerating every match in the database, and the segment buffer is loaded once per search instead of once per growth step. A function search that previously took minutes on a large database now completes in seconds. ([#31](https://github.com/mahmoudimus/ida-sigmaker/pull/31))
+- **Wait-box refresh throttle default is now 1 second** (previously 100 ms), so the box does not repaint faster than it can be read. ([#27](https://github.com/mahmoudimus/ida-sigmaker/issues/27), [#30](https://github.com/mahmoudimus/ida-sigmaker/pull/30))
+
+### Removed
+
+- **The live `Matches:` count is temporarily removed from the `Create unique signature` wait box.** Counting every match on every growth step was the search's bottleneck; the wait box still shows the growing length and elapsed time. A future release restores an exact count cheaply via incremental candidate refinement. ([#27](https://github.com/mahmoudimus/ida-sigmaker/issues/27), [#30](https://github.com/mahmoudimus/ida-sigmaker/pull/30))
+
+### Internal
+
+- `MinimalFunctionSignatureGenerator` decodes each function instruction once up front and grows anchors over the cached data, instead of re-decoding per anchor. ([#31](https://github.com/mahmoudimus/ida-sigmaker/pull/31))
+- `SignatureSearcher.is_unique` stops at the second match; `count_matches` still enumerates fully for callers that need the exact count (such as partial-on-cancel). ([#31](https://github.com/mahmoudimus/ida-sigmaker/pull/31))
+- The compiled `_speedups` SIMD extension now loads from a sibling directory when the package-level import resolves to a namespace package without a matching compiled build (dev and symlink layouts). ([#31](https://github.com/mahmoudimus/ida-sigmaker/pull/31))
+
+[1.7.2]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.7.1...v1.7.2
+
 ## [1.7.1] - 2026-05-27
 
 ### Added

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.7.1"
+        "version": "1.7.2"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -25,7 +25,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
Release 1.7.2.

## Summary

- Bumps the version to 1.7.2 in `src/sigmaker/__init__.py` and `ida-plugin.json`.
- Adds the `[1.7.2]` CHANGELOG entry covering the two PRs merged since 1.7.1: live wait-box progress and self-describing wait boxes (#30), and the function-signature search speedup (#31).
- Teaches the release workflow to embed the matching CHANGELOG section into the published release notes. The `Create release body` step now extracts the `## [VERSION]` section from `CHANGELOG.md` and the release step publishes it via `body_path`, so each release's notes carry that version's changelog automatically instead of a static template.

## What ships in 1.7.2

- Live progress in the wait box for `Create unique signature` and `Find shortest unique signature for current function`.
- Every action's wait box names the action and explains what it is doing.
- The function-signature search is dramatically faster (uniqueness bails at the second match; segment buffer loaded once per search).
- Wait-box refresh throttle default raised to 1 second.
- The live `Matches:` count is temporarily removed from `Create unique signature`; a future release restores it cheaply via candidate refinement.
