### PR TITLE
Phase 1: candidate-refinement signature search (13x faster function search)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1427,6 +1427,13 @@ class UniqueSignatureGenerator:
         bytes_since_last_check = 0
         progress = _UniqueSigProgress(sig=sig)
 
+        # SIMD path: scan the database once to seed a candidate-offset set,
+        # then refine that set in memory as the pattern grows instead of
+        # re-scanning per appended instruction. offsets is None until the
+        # first scan; buf holds the segment buffer the offsets index into.
+        offsets: typing.Optional[list[int]] = None
+        buf: typing.Optional["InMemoryBuffer"] = None
+
         def build_partial() -> GeneratedSignature:
             # Trim trailing wildcards, mirror the success path.
             sig.trim_signature()
@@ -1480,18 +1487,37 @@ class UniqueSignatureGenerator:
                 ):
                     raise Unexpected("Signature left function scope without being unique")
 
+                prev_len = len(sig)
                 self.processor.append_instruction_to_sig(
                     sig, cur_ea, ins, cfg.wildcard_operands, cfg.wildcard_optimized
                 )
                 bytes_since_last_check += ins_len
 
-                count = SignatureSearcher.count_matches(f"{sig:ida}")
-                # SignatureSearcher.find_all polls idaapi_user_canceled inside
-                # its scan loop and bails when set, returning whatever partial
-                # count it had so far (often 0). When the call was interrupted,
-                # keep last_match_count at its prior trustworthy value (issue
-                # #22): the reported number is an upper bound on the partial's
-                # actual match count rather than a meaningless 0.
+                if not SIMD_SPEEDUP_AVAILABLE:
+                    # Non-SIMD builds have no in-memory buffer to refine
+                    # against, so fall back to the per-step rescan.
+                    count = SignatureSearcher.count_matches(f"{sig:ida}")
+                elif offsets is None:
+                    # Seed once: scan the whole database, keep every match
+                    # offset. The candidate count is the exact match count.
+                    offsets, buf = SignatureSearcher.find_all_offsets(f"{sig:ida}")
+                    count = len(offsets)
+                else:
+                    # Refine the surviving candidates in memory for each byte
+                    # appended this iteration; no rescan of the database.
+                    data_mv = buf.data()
+                    for j in range(prev_len, len(sig)):
+                        sb = sig[j]
+                        mask = 0x00 if sb.is_wildcard else 0xFF
+                        offsets = _refine_offsets(data_mv, offsets, j, sb.value, mask)
+                    count = len(offsets)
+                # find_all_offsets polls idaapi_user_canceled inside its scan
+                # loop and bails when set, returning whatever partial offsets
+                # it had so far (often 0). When the call was interrupted, keep
+                # last_match_count at its prior trustworthy value (issue #22):
+                # the reported number is an upper bound on the partial's actual
+                # match count rather than a meaningless 0. Refinement never
+                # bails mid-pass, so its count is always trustworthy.
                 if not idaapi_user_canceled():
                     progress.last_match_count = count
                     if count == 1:
@@ -2513,13 +2539,16 @@ class _UniqueSigProgress:
         "Growing a pattern from the current address until it matches\n"
         "exactly one place in the binary.\n\n"
         "Length:  {length} bytes\n"
+        "Matches: {matches}\n"
         "Elapsed: {elapsed}s\n\n"
         "Press Cancel to stop"
     )
 
     def __call__(self, idx, item, elapsed, total) -> str:
+        match_str = "?" if self.last_match_count is None else str(self.last_match_count)
         return self._TEMPLATE.format(
             length=len(self.sig),
+            matches=match_str,
             elapsed=int(elapsed),
         )
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -94,6 +94,15 @@ if not SIMD_SPEEDUP_AVAILABLE:
         _load_speedups_sibling()
 
 
+# How many matches a scan loop processes between cancellation polls.
+# idaapi.user_cancelled() costs roughly half a microsecond per call; a short,
+# common pattern can match millions of positions, so polling every match makes
+# the poll dominate the scan. Polling every few thousand matches keeps cancel
+# responsive (a few thousand SIMD steps is well under a millisecond) while
+# removing essentially all of the overhead.
+_CANCEL_POLL_STRIDE: int = 8192
+
+
 def configure_logging(
     logger=None,
     logging_name="sigmaker",
@@ -1738,6 +1747,7 @@ class MinimalFunctionSignatureGenerator:
         # SIMD seed-then-refine state (see UniqueSignatureGenerator.generate).
         offsets: typing.Optional[list[int]] = None
         seed_buf = buf
+        min_useful = self.MIN_USEFUL_SIG_BYTES
         for i in range(anchor_idx, len(decoded)):
             if (
                 self.progress_reporter is not None
@@ -1753,12 +1763,33 @@ class MinimalFunctionSignatureGenerator:
             if len(sig) > max_len:
                 return None
 
+            # Below MIN_USEFUL_SIG_BYTES the seed scan would enumerate every
+            # match of a short, common prefix (e.g. a 1-byte instruction that
+            # occurs hundreds of thousands of times) only for the caller to
+            # discard the result for being too short. Probe uniqueness with a
+            # cheap early-bail scan instead, and defer the (now selective)
+            # seed-and-refine until the pattern is long enough to be a valid
+            # answer. The early-bail probe preserves exact behavior: an anchor
+            # that becomes unique below MIN still returns its short signature
+            # here, which the caller discards, so the anchor contributes no
+            # candidate, exactly as before.
+            if len(sig) < min_useful:
+                if progress is not None:
+                    progress.inner_length = len(sig)
+                    progress.inner_matches = None
+                if SignatureSearcher.is_unique(f"{sig:ida}", buf=buf):
+                    sig.trim_signature()
+                    return sig
+                continue
+
             if not SIMD_SPEEDUP_AVAILABLE or seed_buf is None:
                 # Non-SIMD builds have no in-memory buffer to refine against,
                 # so fall back to the per-step rescan.
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
                 # Seed once against the cached buffer; keep every match offset.
+                # The pattern is now at least MIN_USEFUL_SIG_BYTES, so this is
+                # selective rather than a full-database enumeration.
                 offsets, seed_buf = SignatureSearcher.find_all_offsets(
                     f"{sig:ida}", buf=seed_buf
                 )
@@ -2228,11 +2259,17 @@ class SignatureSearcher:
 
         n = len(data_mv)
         off = 0
+        # Poll cancellation every _CANCEL_POLL_STRIDE matches (see
+        # find_all_offsets) so per-match user_cancelled() overhead does not
+        # dominate a scan over a short, common pattern.
+        since_poll = 0
         while off <= n - k:
-            # Check for user cancellation
-            if idaapi_user_canceled():
-                LOGGER.info("Search canceled by user")
-                break
+            since_poll += 1
+            if since_poll >= _CANCEL_POLL_STRIDE:
+                since_poll = 0
+                if idaapi_user_canceled():
+                    LOGGER.info("Search canceled by user")
+                    break
 
             idx = _simd_scan_bytes(data_mv[off:], sig)
             if idx < 0:
@@ -2266,9 +2303,17 @@ class SignatureSearcher:
             return [0], buf
         n = len(data_mv)
         off = 0
+        # Poll cancellation every _CANCEL_POLL_STRIDE matches rather than on
+        # every match: idaapi.user_cancelled() costs ~0.5us per call and a
+        # short, common seed can produce millions of matches, so per-match
+        # polling alone can dominate the scan (observed: 44s of a 76s seed).
+        since_poll = 0
         while off <= n - k:
-            if idaapi_user_canceled():
-                break
+            since_poll += 1
+            if since_poll >= _CANCEL_POLL_STRIDE:
+                since_poll = 0
+                if idaapi_user_canceled():
+                    break
             idx = _simd_scan_bytes(data_mv[off:], sig)
             if idx < 0:
                 break

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2999,7 +2999,7 @@ class SigMakerPlugin(idaapi.plugin_t):
         # does, and as d810 does for its submenu) is the reliable pattern.
         # The profiling actions live under a "SigMaker/" submenu.
         self._hooks = self._init_hooks(
-            _PopupHook(self.ACTION_SHOW_SIGMAKER),
+            _PopupHook(self.ACTION_SHOW_SIGMAKER, category="SigMaker"),
             _PopupHook(self.ACTION_START_PROFILING, category="SigMaker"),
             _PopupHook(self.ACTION_STOP_PROFILING, category="SigMaker"),
         )
@@ -3029,7 +3029,7 @@ class SigMakerPlugin(idaapi.plugin_t):
         idaapi.register_action(
             idaapi.action_desc_t(
                 self.ACTION_START_PROFILING,
-                "SigMaker: Start profiling",
+                "Start Profiling",
                 _ActionHandler(self._action_start_profiling, always_enabled=True),
                 None,
                 "Start a cProfile session capturing subsequent SigMaker activity.",
@@ -3038,7 +3038,7 @@ class SigMakerPlugin(idaapi.plugin_t):
         idaapi.register_action(
             idaapi.action_desc_t(
                 self.ACTION_STOP_PROFILING,
-                "SigMaker: Stop profiling and dump",
+                "Stop Profiling",
                 _ActionHandler(self._action_stop_profiling, always_enabled=True),
                 None,
                 "Stop the active cProfile session and write the dump to the user IDA dir.",

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2989,11 +2989,20 @@ class SigMakerPlugin(idaapi.plugin_t):
     ACTION_SHOW_SIGMAKER: str = "pysigmaker:show"
     ACTION_START_PROFILING: str = "pysigmaker:start_profiling"
     ACTION_STOP_PROFILING: str = "pysigmaker:stop_profiling"
-    PROFILING_MENU_PATH: str = "Edit/Plugins/"
 
     def init(self) -> int:
-        self._hooks = self._init_hooks(_PopupHook(self.ACTION_SHOW_SIGMAKER))
         self._register_actions()
+        # Attach actions to the disassembly right-click popup via live UI
+        # hooks rather than a one-shot attach_action_to_menu at init. The
+        # static menu attach runs before IDA's menus are built and silently
+        # no-ops; populating the popup on demand (as the main action already
+        # does, and as d810 does for its submenu) is the reliable pattern.
+        # The profiling actions live under a "SigMaker/" submenu.
+        self._hooks = self._init_hooks(
+            _PopupHook(self.ACTION_SHOW_SIGMAKER),
+            _PopupHook(self.ACTION_START_PROFILING, category="SigMaker"),
+            _PopupHook(self.ACTION_STOP_PROFILING, category="SigMaker"),
+        )
         return idaapi.PLUGIN_KEEP
 
     def _init_hooks(self, *hooks) -> typing.Tuple[idaapi.UI_Hooks, ...]:
@@ -3034,12 +3043,6 @@ class SigMakerPlugin(idaapi.plugin_t):
                 None,
                 "Stop the active cProfile session and write the dump to the user IDA dir.",
             )
-        )
-        idaapi.attach_action_to_menu(
-            self.PROFILING_MENU_PATH, self.ACTION_START_PROFILING, idaapi.SETMENU_APP
-        )
-        idaapi.attach_action_to_menu(
-            self.PROFILING_MENU_PATH, self.ACTION_STOP_PROFILING, idaapi.SETMENU_APP
         )
 
     def _deregister_actions(self) -> None:

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1503,6 +1503,25 @@ class UniqueSignatureGenerator:
         raise Unexpected("Signature not unique (reached end of analysis)")
 
 
+def _refine_offsets(
+    data_mv: memoryview,
+    offsets: list[int],
+    j: int,
+    value: int,
+    mask: int,
+) -> list[int]:
+    """Keep offsets c where (data_mv[c + j] & mask) == (value & mask).
+
+    j is the pattern-relative index of the byte being checked; c is a match
+    start offset into data_mv. Candidates whose c + j runs past the buffer
+    cannot match and are dropped. Used to refine a shrinking candidate set
+    as a signature grows, instead of re-scanning the whole database.
+    """
+    n = len(data_mv)
+    target = value & mask
+    return [c for c in offsets if c + j < n and (data_mv[c + j] & mask) == target]
+
+
 def _decode_function_for_anchors(
     pfn: "idaapi.func_t",
     processor: "InstructionProcessor",

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -95,12 +95,14 @@ if not SIMD_SPEEDUP_AVAILABLE:
 
 
 # How many matches a scan loop processes between cancellation polls.
-# idaapi.user_cancelled() costs roughly half a microsecond per call; a short,
-# common pattern can match millions of positions, so polling every match makes
-# the poll dominate the scan. Polling every few thousand matches keeps cancel
-# responsive (a few thousand SIMD steps is well under a millisecond) while
-# removing essentially all of the overhead.
-_CANCEL_POLL_STRIDE: int = 8192
+# idaapi.user_cancelled() is not a cheap predicate: it pumps the UI event
+# loop, so each call costs on the order of a millisecond. A short, common
+# pattern can match tens of millions of positions, so polling too often makes
+# the poll itself a multi-second cost (observed: 4,755 polls = 6.7s at an 8192
+# stride). Polling every 65536 matches keeps that overhead near a second while
+# leaving cancel responsive: the inter-poll scan work is only tens of
+# milliseconds.
+_CANCEL_POLL_STRIDE: int = 65536
 
 
 def configure_logging(

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1723,17 +1723,21 @@ class MinimalFunctionSignatureGenerator:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
         Reads all instruction data from the pre-decoded list. The ``buf``
-        argument is forwarded to the searcher so the segment buffer is
-        reused across all uniqueness checks inside one generate() session.
+        argument is the segment buffer loaded once in generate(); on the SIMD
+        path it seeds an in-memory candidate-offset set that is refined per
+        appended byte, so the database is scanned once per anchor rather than
+        once per growth step. On non-SIMD builds (no in-memory buffer) it
+        falls back to a per-step count_matches scan.
 
-        Uniqueness is decided with an early-bail scan (bail at the second
-        match) rather than a full match count, so short common signatures
-        do not enumerate every hit. If ``progress`` is supplied, the
-        per-iteration sig length and the (capped) match count are written
-        into its ``inner_length`` / ``inner_matches`` fields for the live
-        wait-box display; ``inner_matches`` of 2 means "two or more".
+        The surviving candidate count is the exact match count, so if
+        ``progress`` is supplied the per-iteration sig length and the exact
+        match count are written into its ``inner_length`` / ``inner_matches``
+        fields for the live wait-box display.
         """
         sig = Signature()
+        # SIMD seed-then-refine state (see UniqueSignatureGenerator.generate).
+        offsets: typing.Optional[list[int]] = None
+        seed_buf = buf
         for i in range(anchor_idx, len(decoded)):
             if (
                 self.progress_reporter is not None
@@ -1743,19 +1747,36 @@ class MinimalFunctionSignatureGenerator:
                     "Function signature search canceled by user"
                 )
 
+            prev_len = len(sig)
             self._append_decoded_to_sig(sig, decoded[i])
 
             if len(sig) > max_len:
                 return None
 
-            unique = SignatureSearcher.is_unique(f"{sig:ida}", buf=buf)
+            if not SIMD_SPEEDUP_AVAILABLE or seed_buf is None:
+                # Non-SIMD builds have no in-memory buffer to refine against,
+                # so fall back to the per-step rescan.
+                count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
+            elif offsets is None:
+                # Seed once against the cached buffer; keep every match offset.
+                offsets, seed_buf = SignatureSearcher.find_all_offsets(
+                    f"{sig:ida}", buf=seed_buf
+                )
+                count = len(offsets)
+            else:
+                # Refine the surviving candidates in memory for each byte
+                # appended this iteration; no rescan of the database.
+                data_mv = seed_buf.data()
+                for j in range(prev_len, len(sig)):
+                    sb = sig[j]
+                    mask = 0x00 if sb.is_wildcard else 0xFF
+                    offsets = _refine_offsets(data_mv, offsets, j, sb.value, mask)
+                count = len(offsets)
+
             if progress is not None:
                 progress.inner_length = len(sig)
-                # is_unique early-bails at the second match, so we cannot
-                # show an exact count here; 1 means unique, 2 means "2 or
-                # more, keep growing".
-                progress.inner_matches = 1 if unique else 2
-            if unique:
+                progress.inner_matches = count
+            if count == 1:
                 sig.trim_signature()
                 return sig
 
@@ -2594,11 +2615,9 @@ class _FunctionSigProgress:
         inner_bounds = f"{anchor:#x} .. {inner_end:#x}"
         if self.inner_matches is None:
             inner_matches_str = "scanning..."
-        elif self.inner_matches >= 2:
-            # Uniqueness is decided with an early-bail scan that stops at the
-            # second match, so the exact count past 1 is unknown: show "2+".
-            inner_matches_str = "2+ matches so far"
         else:
+            # Candidate-refinement tracks the exact surviving candidate count
+            # at every step, so show the real number again (no "2+" cap).
             inner_matches_str = f"{self.inner_matches} matches so far"
         best = f"{self.best_size} bytes" if self.candidates else "-"
         return self._TEMPLATE.format(

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2198,6 +2198,38 @@ class SignatureSearcher:
         return results
 
     @staticmethod
+    def find_all_offsets(
+        ida_signature: str,
+        buf: typing.Optional["InMemoryBuffer"] = None,
+    ) -> tuple[list[int], "InMemoryBuffer"]:
+        """Return (offsets, buf): every match as a 0-based offset into
+        buf.data(), plus the buffer used. The offsets seed an in-memory
+        refinement; reusing the returned buf keeps subsequent refinement on
+        the same bytes. SIMD path only.
+        """
+        simd_signature, _ = SigText.normalize(ida_signature)
+        if buf is None:
+            with ProgressDialog("Please stand by, copying segments..."):
+                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+        data_mv = buf.data()
+        sig = _SimdSignature(simd_signature)
+        offsets: list[int] = []
+        k = sig.size_bytes
+        if k == 0:
+            return [0], buf
+        n = len(data_mv)
+        off = 0
+        while off <= n - k:
+            if idaapi_user_canceled():
+                break
+            idx = _simd_scan_bytes(data_mv[off:], sig)
+            if idx < 0:
+                break
+            offsets.append(off + idx)
+            off += idx + 1
+        return offsets, buf
+
+    @staticmethod
     def find_all(
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -302,6 +302,102 @@ class TestBenchmarkPerformance(unittest.TestCase):
             "times": times,
         }
 
+    def benchmark_candidate_refinement(self, iterations: int = 3) -> dict:
+        """Time FIND_FUNCTION_SIG with candidate refinement on a real function.
+
+        Picks the largest function in the test binary, runs generate() N
+        times, reports median wall time, and counts how often the database is
+        scanned. With candidate refinement the segment buffer is loaded once
+        per generate() (InMemoryBuffer.load) and the per-anchor seed scan
+        (SignatureSearcher.find_all_offsets) replaces the old per-growth-step
+        count_matches rescan, so the load count stays small and bounded by the
+        number of anchors, not the number of appended bytes.
+        """
+        if not self.ida_available:
+            self.skipTest("IDA Pro API not available for benchmarking")
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+
+        func_qty = idaapi.get_func_qty()
+        if func_qty == 0:
+            self.skipTest("No functions in test binary")
+
+        best_pfn = None
+        best_size = 0
+        for i in range(func_qty):
+            pfn = idaapi.getn_func(i)
+            if pfn is None:
+                continue
+            size = pfn.end_ea - pfn.start_ea
+            if size > best_size:
+                best_size = size
+                best_pfn = pfn
+
+        if best_pfn is None or best_size < 10:
+            self.skipTest("No suitable function found for benchmarking")
+
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=True,
+            continue_outside_of_function=False,
+            wildcard_optimized=True,
+            ask_longer_signature=False,
+            max_single_signature_length=100,
+        )
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        gen = sigmaker.MinimalFunctionSignatureGenerator(processor)
+
+        load_counts = []
+        seed_counts = []
+        times = []
+        real_load = sigmaker.InMemoryBuffer.load
+        real_seed = sigmaker.SignatureSearcher.find_all_offsets
+
+        for _ in range(iterations):
+            counters = {"loads": 0, "seeds": 0}
+
+            def counting_load(*args, _orig=real_load, _c=counters, **kwargs):
+                _c["loads"] += 1
+                return _orig(*args, **kwargs)
+
+            def counting_seed(*args, _orig=real_seed, _c=counters, **kwargs):
+                _c["seeds"] += 1
+                return _orig(*args, **kwargs)
+
+            with unittest.mock.patch.object(
+                sigmaker.InMemoryBuffer, "load", side_effect=counting_load
+            ), unittest.mock.patch.object(
+                sigmaker.SignatureSearcher, "find_all_offsets",
+                side_effect=counting_seed,
+            ):
+                t0 = time.perf_counter()
+                try:
+                    gen.generate(best_pfn, cfg)
+                except sigmaker.Unexpected:
+                    pass
+                times.append(time.perf_counter() - t0)
+            load_counts.append(counters["loads"])
+            seed_counts.append(counters["seeds"])
+
+        times.sort()
+        median = times[len(times) // 2]
+
+        print("\n--- benchmark_candidate_refinement ---")
+        print(f"function bytes: {best_size}")
+        print(f"iterations: {iterations}")
+        print(f"median wall: {median:.4f}s   buffer loads: {load_counts}")
+        print(f"per-anchor seed scans (find_all_offsets): {seed_counts}")
+
+        return {
+            "operation": "candidate_refinement",
+            "function_bytes": best_size,
+            "iterations": iterations,
+            "median_wall_seconds": median,
+            "buffer_loads": load_counts,
+            "seed_scans": seed_counts,
+            "times": times,
+        }
+
     def test_performance_benchmarks(self):
         """Run all performance benchmarks and display results."""
         print("\n" + "=" * 80)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2825,6 +2825,33 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
             max_single_signature_length=max_len,
         )
 
+    def _patch_uniqueness(self, model):
+        """Patch is_unique (below MIN_USEFUL_SIG_BYTES) and count_matches
+        (at/above it) to share one match-count model.
+
+        The generator defers the seed scan until the pattern reaches
+        MIN_USEFUL_SIG_BYTES: below that it probes uniqueness with is_unique,
+        at/above it counts matches. It performs exactly one uniqueness check
+        per appended instruction whichever path is taken, so a single shared
+        counter inside ``model`` preserves the "n-th check" semantics
+        regardless of where the MIN boundary falls. ``model()`` returns the
+        match count for the current check; is_unique reports ``count == 1``.
+        """
+        cm = patch.object(
+            sigmaker.SignatureSearcher,
+            "count_matches",
+            side_effect=lambda *a, **k: model(),
+        )
+        iu = patch.object(
+            sigmaker.SignatureSearcher,
+            "is_unique",
+            side_effect=lambda *a, **k: model() == 1,
+        )
+        cm.start()
+        iu.start()
+        self.addCleanup(cm.stop)
+        self.addCleanup(iu.stop)
+
     def test_returns_shortest_unique_candidate(self):
         gen = self._make_generator()
         # 32-byte function so the inner search has room for 10-byte and
@@ -2833,7 +2860,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_count_matches(_ida_sig_str, *_a, **_kw):
+        def model():
             calls["n"] += 1
             n = calls["n"]
             if n <= 10:
@@ -2842,10 +2869,8 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
                 return 1 if n == 16 else 2
             return 2
 
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
-            result = gen.generate(pfn, self._make_cfg(max_len=50))
+        self._patch_uniqueness(model)
+        result = gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertIsInstance(result, sigmaker.GeneratedSignature)
         self.assertEqual(result.address, sigmaker.Match(0x1001))
@@ -2857,14 +2882,12 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_count_matches(_, *_a, **_kw):
+        def model():
             calls["n"] += 1
             return 1 if calls["n"] == 7 else 2
 
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
-            result = gen.generate(pfn, self._make_cfg(max_len=50))
+        self._patch_uniqueness(model)
+        result = gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertLess(calls["n"], 300)
         self.assertEqual(len(result.signature), 7)
@@ -2875,14 +2898,12 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_count_matches(_, *_a, **_kw):
+        def model():
             calls["n"] += 1
             return 1 if calls["n"] == 5 else 2
 
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
-            result = gen.generate(pfn, self._make_cfg(max_len=50))
+        self._patch_uniqueness(model)
+        result = gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertEqual(len(result.signature), 5)
         self.assertEqual(calls["n"], 5)
@@ -2890,11 +2911,9 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
     def test_raises_when_no_candidate(self):
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x1003)
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", return_value=2
-        ):
-            with self.assertRaises(sigmaker.Unexpected):
-                gen.generate(pfn, self._make_cfg(max_len=10))
+        self._patch_uniqueness(lambda: 2)
+        with self.assertRaises(sigmaker.Unexpected):
+            gen.generate(pfn, self._make_cfg(max_len=10))
 
     def test_rejects_degenerate_short_sigs(self):
         gen = self._make_generator()
@@ -2902,15 +2921,13 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_count_matches(_, *_a, **_kw):
+        def model():
             calls["n"] += 1
             return 1 if calls["n"] % 3 == 0 else 2
 
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
-            with self.assertRaises(sigmaker.Unexpected):
-                gen.generate(pfn, self._make_cfg(max_len=50))
+        self._patch_uniqueness(model)
+        with self.assertRaises(sigmaker.Unexpected):
+            gen.generate(pfn, self._make_cfg(max_len=50))
 
     def test_min_useful_sig_bytes_constant(self):
         self.assertEqual(
@@ -2924,15 +2941,13 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_count_matches(_, *_a, **_kw):
+        def model():
             calls["n"] += 1
             return 1 if calls["n"] == 5 else 2
 
+        self._patch_uniqueness(model)
         sigmaker.idaapi.get_bytes.reset_mock()
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
-            gen.generate(pfn, self._make_cfg(max_len=50))
+        gen.generate(pfn, self._make_cfg(max_len=50))
 
         # One bulk call for the whole function. Growth loops read from the
         # cached bytes, not from idaapi.
@@ -2968,7 +2983,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         # Fake scan that exercises many checks before deciding.
         calls = {"n": 0}
 
-        def fake_count_matches(_ida_sig_str, *args, **kwargs):
+        def model():
             calls["n"] += 1
             return 1 if calls["n"] == 5 else 2
 
@@ -2977,11 +2992,10 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         fake_buf.imagebase = 0
         fake_buf.file_size = 100
 
+        self._patch_uniqueness(model)
         with patch.object(
             sigmaker.InMemoryBuffer, "load", return_value=fake_buf
-        ) as mp_load, patch.object(
-            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
-        ):
+        ) as mp_load:
             gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertLessEqual(mp_load.call_count, 1)
@@ -2991,13 +3005,11 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         # FIND_FUNCTION_SIG-specific initial message.
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x1010)
-        with patch.object(
-            sigmaker.SignatureSearcher, "count_matches", return_value=2
-        ):
-            try:
-                gen.generate(pfn, self._make_cfg(max_len=10))
-            except sigmaker.Unexpected:
-                pass
+        self._patch_uniqueness(lambda: 2)
+        try:
+            gen.generate(pfn, self._make_cfg(max_len=10))
+        except sigmaker.Unexpected:
+            pass
         # generate() may also open a short-lived "copying segments" wait box
         # when SIMD is available, so assert the function-sig wait box is among
         # the recorded dialogs rather than asserting an exact count.
@@ -3055,12 +3067,14 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         sigmaker.idaapi.get_bytes = MagicMock(side_effect=_fake_get_bytes)
 
         self._seed_buf = MagicMock()
-        # Nine 0x90 bytes then a 0x00. Seed candidates 0 and 5 both start a
-        # 0x90 run; refinement keeps both until the byte at pattern index 4
-        # diverges (buf[9] == 0x00), so candidate 5 survives to length 5 and
-        # is dropped exactly there. Candidate 0 reaches uniqueness at 5 bytes.
+        # One run of five 0x90, a 0x00 separator, then a run of four 0x90.
+        # Instructions decode as single 0x90 bytes, so anchor 0's pattern is
+        # "90"*L. "90"*5 occurs only at offset 0 (the second run is only four
+        # bytes), so anchor 0 is unique at exactly 5 bytes. Shorter patterns
+        # ("90"*1..4) match in both runs, so they are not unique, which keeps
+        # the below-MIN early-bail probe returning "not unique".
         self._seed_buf.data.return_value = memoryview(
-            bytearray(b"\x90\x90\x90\x90\x90\x90\x90\x90\x90\x00")
+            bytearray(b"\x90\x90\x90\x90\x90\x00\x90\x90\x90\x90")
         )
         self._seed_buf.imagebase = 0x1000
         self._seed_buf.file_size = 10
@@ -3093,33 +3107,37 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         )
 
     @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
-    def test_seed_once_per_anchor_then_refine(self):
+    def test_seed_is_deferred_until_min_then_refines(self):
         processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
         gen = sigmaker.MinimalFunctionSignatureGenerator(processor)
         pfn = self._make_pfn(0x1000, 0x100A)  # 10 single-byte 0x90 instructions
 
-        seed_calls = {"n": 0}
+        # Spy on the real find_all_offsets to confirm the seed scan is deferred
+        # until the pattern reaches MIN_USEFUL_SIG_BYTES (never seeded on a
+        # short, common prefix) and still runs the genuine SIMD seed + refine.
+        real_find_all_offsets = sigmaker.SignatureSearcher.find_all_offsets
+        seed_sig_byte_lens: list[int] = []
 
-        def fake_find_all_offsets(_ida_sig, buf=None):
-            # Seed: both offsets 0 and 5 match the first 0x90 byte. As the
-            # pattern grows the refinement drops offset 5 (followed by 0x00),
-            # leaving offset 0 as the unique match.
-            seed_calls["n"] += 1
-            return [0, 5], self._seed_buf
+        def spy(ida_signature, buf=None):
+            normalized, _ = sigmaker.SigText.normalize(ida_signature)
+            seed_sig_byte_lens.append(len(normalized.split()))
+            return real_find_all_offsets(ida_signature, buf=buf)
 
         with patch.object(
-            sigmaker.SignatureSearcher,
-            "find_all_offsets",
-            side_effect=fake_find_all_offsets,
+            sigmaker.SignatureSearcher, "find_all_offsets", side_effect=spy
         ):
             result = gen.generate(pfn, self._make_cfg(max_len=50))
 
         self.assertIsInstance(result, sigmaker.GeneratedSignature)
-        # The first anchor (offset 0) reaches uniqueness via in-memory
-        # refinement after a single seed scan, and it is a 5-byte all-exact
-        # sig with no wildcards, so generate() takes the ideal early-exit and
-        # never starts a second anchor: exactly one seed scan total.
-        self.assertEqual(seed_calls["n"], 1)
+        # Anchor 0 ("90"*L) is unique at exactly 5 bytes. The seed must have
+        # been deferred: every seed scan ran on a pattern of at least
+        # MIN_USEFUL_SIG_BYTES, never on the 1-byte common prefix.
+        self.assertTrue(seed_sig_byte_lens, "seed scan should have run at least once")
+        min_useful = sigmaker.MinimalFunctionSignatureGenerator.MIN_USEFUL_SIG_BYTES
+        self.assertTrue(
+            all(n >= min_useful for n in seed_sig_byte_lens),
+            f"seed must be deferred to >= {min_useful} bytes; got {seed_sig_byte_lens}",
+        )
         self.assertEqual(len(result.signature), 5)
 
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2174,9 +2174,17 @@ class TestActionEnum(CoveredUnitTest):
 
 
 class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
-    """policy=permissive returns a partial GeneratedSignature on cancel."""
+    """policy=permissive returns a partial GeneratedSignature on cancel.
+
+    These tests drive the non-SIMD fallback path (count_matches per step) by
+    forcing SIMD_SPEEDUP_AVAILABLE off, so the patched count_matches stays the
+    source of the match count. The partial-on-cancel / progress-message
+    behavior under test is identical on both code paths.
+    """
 
     def setUp(self):
+        self._original_simd = sigmaker.SIMD_SPEEDUP_AVAILABLE
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = False
         self.original_user_canceled = getattr(
             sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
         )
@@ -2210,6 +2218,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         self._dialog_patcher.stop()
         self._is_code_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = self._original_simd
 
     def _make_generator(self, cancel_after_iterations: int):
         """Construct a UniqueSignatureGenerator whose progress_reporter cancels
@@ -2409,6 +2418,84 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
                 pass
         self.assertEqual(len(self.recorded_dialogs), 1)
         self.assertEqual(self.recorded_dialogs[0].exit_count, 1)
+
+
+class TestUniqueSignatureGeneratorSeedThenRefine(CoveredUnitTest):
+    """SIMD path: generate() seeds once via find_all_offsets, then refines.
+
+    Drives the candidate-refinement branch directly (SIMD on), asserting the
+    seed scan happens exactly once and the in-memory refinement narrows the
+    candidate set to a unique match.
+    """
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
+        sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x90")
+        sigmaker.idaapi.get_func = MagicMock(return_value=None)
+        self._is_code_patcher = patch.object(
+            sigmaker, "is_address_marked_as_code", return_value=True
+        )
+        self._is_code_patcher.start()
+        self._dialog_patcher = patch.object(sigmaker, "ProgressDialog", MagicMock())
+        self._dialog_patcher.start()
+
+    def tearDown(self):
+        self._dialog_patcher.stop()
+        self._is_code_patcher.stop()
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _make_cfg(self) -> sigmaker.SigMakerConfig:
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=True,
+            wildcard_optimized=False,
+            ask_longer_signature=False,
+        )
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_seed_once_then_refine_to_unique(self):
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        gen = sigmaker.UniqueSignatureGenerator(processor)
+
+        # The growing pattern is all 0x90 (get_byte/get_bytes mocked to 0x90).
+        # Seed buffer: 0x90 at offsets 0 and 5, but only offset 0 has a second
+        # 0x90 right after it. After the first append (1 byte) the seed has
+        # two candidates; the second append refines down to the single match
+        # at offset 0.
+        seed_buf = MagicMock()
+        seed_buf.data.return_value = memoryview(
+            bytearray(b"\x90\x90\x00\x00\x00\x90\x00\x00")
+        )
+        seed_offsets = [0, 5]
+
+        load_calls = {"n": 0}
+
+        def fake_find_all_offsets(_ida_sig, buf=None):
+            load_calls["n"] += 1
+            return list(seed_offsets), seed_buf
+
+        with patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            side_effect=fake_find_all_offsets,
+        ):
+            result = gen.generate(
+                0x1000, self._make_cfg(),
+                policy=sigmaker.GenerationPolicy.strict(),
+            )
+
+        self.assertEqual(result.status, sigmaker.GenerationStatus.UNIQUE)
+        # The database was scanned exactly once; the rest was in-memory refine.
+        self.assertEqual(load_calls["n"], 1)
+        # Two 0x90 bytes survive to uniqueness (offset 0: 0x90 0x90).
+        self.assertEqual(len(result.signature), 2)
 
 
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
@@ -3187,6 +3274,20 @@ class TestProgressFormatters(CoveredUnitTest):
         msg = fmt(idx=1, item=None, elapsed=2.5, total=None)
         self.assertIn("Length:  5 bytes", msg)
         self.assertIn("Elapsed: 2s", msg)
+
+    def test_unique_progress_renders_exact_match_count(self):
+        # Candidate-refinement makes the exact count free again, so the
+        # Matches line is back (it was dropped in cebdf07 as a stopgap).
+        sig = self._make_sig(5)
+        fmt = sigmaker._UniqueSigProgress(sig=sig, last_match_count=42)
+        msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
+        self.assertIn("Matches: 42", msg)
+
+    def test_unique_progress_renders_question_mark_when_count_unknown(self):
+        sig = self._make_sig(5)
+        fmt = sigmaker._UniqueSigProgress(sig=sig)  # last_match_count None
+        msg = fmt(idx=1, item=None, elapsed=0.0, total=None)
+        self.assertIn("Matches: ?", msg)
 
     def test_unique_progress_sig_is_live_reference(self):
         sig = self._make_sig(2)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2616,6 +2616,51 @@ class TestFindAllOffsets(CoveredUnitTest):
         self.assertIs(ret, buf)
 
 
+class TestRefinementEquivalence(CoveredUnitTest):
+    """Refinement of a seed set equals a full masked rescan at every step."""
+
+    def _full_matches(self, data: bytes, pattern: list[tuple[int, int]]):
+        # pattern: list of (value, mask); brute-force all start offsets
+        n = len(data)
+        m = len(pattern)
+        out = []
+        for c in range(n - m + 1):
+            ok = True
+            for j, (v, msk) in enumerate(pattern):
+                if (data[c + j] & msk) != (v & msk):
+                    ok = False
+                    break
+            if ok:
+                out.append(c)
+        return out
+
+    def test_refine_tracks_full_rescan(self):
+        import random
+        rng = random.Random(1234)
+        data = bytes(rng.randrange(256) for _ in range(4096))
+        mv = memoryview(bytearray(data))
+        # Build a random growing masked pattern taken from the buffer at anchor a
+        a = 100
+        pattern = []
+        # seed on the first byte via brute force, then refine forward
+        offsets = None
+        for j in range(12):
+            v = data[a + j]
+            msk = 0x00 if (j % 3 == 0) else 0xFF  # sprinkle wildcards
+            pattern.append((v, msk))
+            if offsets is None:
+                offsets = self._full_matches(data, pattern)  # seed at length 1
+            else:
+                offsets = sigmaker._refine_offsets(mv, offsets, j, v, msk)
+            expected = self._full_matches(data, pattern)
+            self.assertEqual(
+                sorted(offsets), sorted(expected),
+                f"divergence at length {j + 1}",
+            )
+        # anchor itself must always survive
+        self.assertIn(a, offsets)
+
+
 class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
     """Iterates every instruction in a function and returns the shortest unique signature."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2553,6 +2553,40 @@ class TestSignatureSearcherCountMatches(CoveredUnitTest):
         self.assertFalse(kwargs.get("skip_more_than_one", False))
 
 
+class TestRefineOffsets(CoveredUnitTest):
+    """In-memory candidate refinement: keep offsets whose byte at c+j matches."""
+
+    def _mv(self, b: bytes):
+        return memoryview(bytearray(b))
+
+    def test_exact_byte_keeps_matching(self):
+        data = self._mv(b"\x90\x48\x90\x48\x90")
+        # offsets 0..4; appended byte index j=1 must equal 0x48 (mask 0xFF)
+        out = sigmaker._refine_offsets(data, [0, 1, 2, 3], 1, 0x48, 0xFF)
+        # c=0 -> data[1]=0x48 keep; c=1 -> data[2]=0x90 drop; c=2 -> data[3]=0x48 keep; c=3 -> data[4]=0x90 drop
+        self.assertEqual(out, [0, 2])
+
+    def test_full_wildcard_keeps_all(self):
+        data = self._mv(b"\x01\x02\x03\x04")
+        out = sigmaker._refine_offsets(data, [0, 1, 2], 1, 0x00, 0x00)
+        self.assertEqual(out, [0, 1, 2])
+
+    def test_nibble_mask(self):
+        data = self._mv(b"\x4A\x4B\x9C")
+        # mask 0xF0 keeps where high nibble == 0x40
+        out = sigmaker._refine_offsets(data, [0, 1, 2], 0, 0x40, 0xF0)
+        self.assertEqual(out, [0, 1])
+
+    def test_out_of_bounds_dropped(self):
+        data = self._mv(b"\x90\x90")
+        # c=1, j=2 -> c+j=3 is past the buffer; must be dropped, not raise
+        out = sigmaker._refine_offsets(data, [0, 1], 2, 0x90, 0xFF)
+        self.assertEqual(out, [])
+
+    def test_empty_input(self):
+        self.assertEqual(sigmaker._refine_offsets(self._mv(b"\x90"), [], 0, 0x90, 0xFF), [])
+
+
 class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
     """Iterates every instruction in a function and returns the shortest unique signature."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2587,6 +2587,35 @@ class TestRefineOffsets(CoveredUnitTest):
         self.assertEqual(sigmaker._refine_offsets(self._mv(b"\x90"), [], 0, 0x90, 0xFF), [])
 
 
+class TestFindAllOffsets(CoveredUnitTest):
+    """find_all_offsets returns raw buffer offsets plus the buffer used."""
+
+    def setUp(self):
+        self._saved = sigmaker.idaapi_user_canceled
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self._saved
+
+    def _fake_buf(self, b: bytes):
+        buf = MagicMock()
+        buf.data.return_value = memoryview(bytearray(b))
+        buf.imagebase = 0x1000
+        buf.file_size = len(b)
+        return buf
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_offsets_match_find_all_positions(self):
+        # Pattern "90" should be found at every 0x90 byte; offsets are
+        # buffer-relative (0-based), and the returned buf is the one passed.
+        buf = self._fake_buf(b"\x90\x00\x90\x00\x90")
+        with patch.object(sigmaker, "ProgressDialog"):
+            offs, ret = sigmaker.SignatureSearcher.find_all_offsets("90", buf=buf)
+        self.assertEqual(offs, [0, 2, 4])
+        self.assertIs(ret, buf)
+
+
 class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
     """Iterates every instruction in a function and returns the shortest unique signature."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2749,9 +2749,18 @@ class TestRefinementEquivalence(CoveredUnitTest):
 
 
 class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
-    """Iterates every instruction in a function and returns the shortest unique signature."""
+    """Iterates every instruction in a function and returns the shortest unique signature.
+
+    These tests drive the non-SIMD fallback path (count_matches per step) by
+    forcing SIMD_SPEEDUP_AVAILABLE off, so a patched count_matches stays the
+    source of the match count. The anchor-selection / pruning logic under test
+    is identical on both code paths; the SIMD seed-then-refine path is covered
+    separately and against the real binary in the integration suite.
+    """
 
     def setUp(self):
+        self._original_simd = sigmaker.SIMD_SPEEDUP_AVAILABLE
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = False
         self.original_user_canceled = getattr(
             sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
         )
@@ -2794,6 +2803,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         self._load_patcher.stop()
         self._dialog_patcher.stop()
         sigmaker.idaapi_user_canceled = self.original_user_canceled
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = self._original_simd
 
     def _make_pfn(self, start_ea: int, end_ea: int):
         pfn = MagicMock()
@@ -2823,17 +2833,17 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_ida_sig_str, *_a, **_kw):
+        def fake_count_matches(_ida_sig_str, *_a, **_kw):
             calls["n"] += 1
             n = calls["n"]
             if n <= 10:
-                return n == 10
+                return 1 if n == 10 else 2
             if n <= 16:
-                return n == 16
-            return False
+                return 1 if n == 16 else 2
+            return 2
 
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             result = gen.generate(pfn, self._make_cfg(max_len=50))
 
@@ -2847,12 +2857,12 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_, *_a, **_kw):
+        def fake_count_matches(_, *_a, **_kw):
             calls["n"] += 1
-            return calls["n"] == 7
+            return 1 if calls["n"] == 7 else 2
 
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             result = gen.generate(pfn, self._make_cfg(max_len=50))
 
@@ -2865,12 +2875,12 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_, *_a, **_kw):
+        def fake_count_matches(_, *_a, **_kw):
             calls["n"] += 1
-            return calls["n"] == 5
+            return 1 if calls["n"] == 5 else 2
 
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             result = gen.generate(pfn, self._make_cfg(max_len=50))
 
@@ -2881,7 +2891,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x1003)
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", return_value=False
+            sigmaker.SignatureSearcher, "count_matches", return_value=2
         ):
             with self.assertRaises(sigmaker.Unexpected):
                 gen.generate(pfn, self._make_cfg(max_len=10))
@@ -2892,12 +2902,12 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_, *_a, **_kw):
+        def fake_count_matches(_, *_a, **_kw):
             calls["n"] += 1
-            return calls["n"] % 3 == 0
+            return 1 if calls["n"] % 3 == 0 else 2
 
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             with self.assertRaises(sigmaker.Unexpected):
                 gen.generate(pfn, self._make_cfg(max_len=50))
@@ -2914,13 +2924,13 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
 
         calls = {"n": 0}
 
-        def fake_is_unique(_, *_a, **_kw):
+        def fake_count_matches(_, *_a, **_kw):
             calls["n"] += 1
-            return calls["n"] == 5
+            return 1 if calls["n"] == 5 else 2
 
         sigmaker.idaapi.get_bytes.reset_mock()
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             gen.generate(pfn, self._make_cfg(max_len=50))
 
@@ -2934,7 +2944,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x1000)
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", return_value=False
+            sigmaker.SignatureSearcher, "count_matches", return_value=2
         ):
             with self.assertRaises(sigmaker.Unexpected):
                 gen.generate(pfn, self._make_cfg(max_len=10))
@@ -2945,22 +2955,22 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         pfn = self._make_pfn(0x1000, 0x1005)
         sigmaker.idaapi.get_bytes = MagicMock(return_value=None)
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", return_value=False
+            sigmaker.SignatureSearcher, "count_matches", return_value=2
         ):
             with self.assertRaises(sigmaker.Unexpected):
                 gen.generate(pfn, self._make_cfg(max_len=10))
 
     def test_generate_loads_buffer_at_most_once(self):
-        """The whole point of the cache: even if many is_unique calls happen, the InMemoryBuffer load round-trip happens at most once per generate()."""
+        """The whole point of the cache: even if many scans happen, the InMemoryBuffer load round-trip happens at most once per generate()."""
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x100A)
 
-        # Fake is_unique that exercises many scans before deciding.
+        # Fake scan that exercises many checks before deciding.
         calls = {"n": 0}
 
-        def fake_is_unique(_ida_sig_str, *args, **kwargs):
+        def fake_count_matches(_ida_sig_str, *args, **kwargs):
             calls["n"] += 1
-            return calls["n"] == 5
+            return 1 if calls["n"] == 5 else 2
 
         fake_buf = MagicMock()
         fake_buf.data.return_value = memoryview(b"\x90" * 100)
@@ -2970,7 +2980,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         with patch.object(
             sigmaker.InMemoryBuffer, "load", return_value=fake_buf
         ) as mp_load, patch.object(
-            sigmaker.SignatureSearcher, "is_unique", side_effect=fake_is_unique
+            sigmaker.SignatureSearcher, "count_matches", side_effect=fake_count_matches
         ):
             gen.generate(pfn, self._make_cfg(max_len=50))
 
@@ -2982,7 +2992,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         gen = self._make_generator()
         pfn = self._make_pfn(0x1000, 0x1010)
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", return_value=False
+            sigmaker.SignatureSearcher, "count_matches", return_value=2
         ):
             try:
                 gen.generate(pfn, self._make_cfg(max_len=10))
@@ -3008,7 +3018,7 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
         sigmaker.idaapi.decode_insn.reset_mock()
         sigmaker.idaapi_user_canceled = MagicMock(return_value=True)
         with patch.object(
-            sigmaker.SignatureSearcher, "is_unique", return_value=False
+            sigmaker.SignatureSearcher, "count_matches", return_value=2
         ):
             with self.assertRaises(sigmaker.UserCanceledError):
                 gen.generate(pfn, self._make_cfg(max_len=10))
@@ -3019,6 +3029,98 @@ class TestMinimalFunctionSignatureGenerator(CoveredUnitTest):
             "Cancel should short-circuit pre-decode before walking the "
             "whole function.",
         )
+
+
+class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
+    """SIMD path: _grow_unique_from_decoded seeds once per anchor, then refines.
+
+    Drives the candidate-refinement branch directly (SIMD on), asserting the
+    seed scan (find_all_offsets) happens once per anchor and that the in-memory
+    refinement narrows the candidate set to the exact match count.
+    """
+
+    def setUp(self):
+        self.original_user_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.decode_insn = MagicMock(return_value=1)
+        sigmaker.idaapi.get_byte = MagicMock(return_value=0x90)
+
+        def _fake_get_bytes(ea, count):
+            if isinstance(count, int):
+                return b"\x90" * count
+            return b"\x90"
+        sigmaker.idaapi.get_bytes = MagicMock(side_effect=_fake_get_bytes)
+
+        self._seed_buf = MagicMock()
+        # Nine 0x90 bytes then a 0x00. Seed candidates 0 and 5 both start a
+        # 0x90 run; refinement keeps both until the byte at pattern index 4
+        # diverges (buf[9] == 0x00), so candidate 5 survives to length 5 and
+        # is dropped exactly there. Candidate 0 reaches uniqueness at 5 bytes.
+        self._seed_buf.data.return_value = memoryview(
+            bytearray(b"\x90\x90\x90\x90\x90\x90\x90\x90\x90\x00")
+        )
+        self._seed_buf.imagebase = 0x1000
+        self._seed_buf.file_size = 10
+        self._load_patcher = patch.object(
+            sigmaker.InMemoryBuffer, "load", return_value=self._seed_buf
+        )
+        self._load_patcher.start()
+        self._dialog_patcher = patch.object(sigmaker, "ProgressDialog", MagicMock())
+        self._dialog_patcher.start()
+
+    def tearDown(self):
+        self._load_patcher.stop()
+        self._dialog_patcher.stop()
+        sigmaker.idaapi_user_canceled = self.original_user_canceled
+
+    def _make_pfn(self, start_ea: int, end_ea: int):
+        pfn = MagicMock()
+        pfn.start_ea = start_ea
+        pfn.end_ea = end_ea
+        return pfn
+
+    def _make_cfg(self, max_len: int = 50) -> sigmaker.SigMakerConfig:
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+            ask_longer_signature=False,
+            max_single_signature_length=max_len,
+        )
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_seed_once_per_anchor_then_refine(self):
+        processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        gen = sigmaker.MinimalFunctionSignatureGenerator(processor)
+        pfn = self._make_pfn(0x1000, 0x100A)  # 10 single-byte 0x90 instructions
+
+        seed_calls = {"n": 0}
+
+        def fake_find_all_offsets(_ida_sig, buf=None):
+            # Seed: both offsets 0 and 5 match the first 0x90 byte. As the
+            # pattern grows the refinement drops offset 5 (followed by 0x00),
+            # leaving offset 0 as the unique match.
+            seed_calls["n"] += 1
+            return [0, 5], self._seed_buf
+
+        with patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            side_effect=fake_find_all_offsets,
+        ):
+            result = gen.generate(pfn, self._make_cfg(max_len=50))
+
+        self.assertIsInstance(result, sigmaker.GeneratedSignature)
+        # The first anchor (offset 0) reaches uniqueness via in-memory
+        # refinement after a single seed scan, and it is a 5-byte all-exact
+        # sig with no wildcards, so generate() takes the ideal early-exit and
+        # never starts a second anchor: exactly one seed scan total.
+        self.assertEqual(seed_calls["n"], 1)
+        self.assertEqual(len(result.signature), 5)
 
 
 class TestSignatureSearcherBufferCache(CoveredUnitTest):
@@ -3306,7 +3408,7 @@ class TestProgressFormatters(CoveredUnitTest):
             best_size=100,
             current_anchor_ea=0x140001040,
             inner_length=7,
-            inner_matches=2,
+            inner_matches=3,
         )
         msg = fmt(idx=18, item=0x140001040, elapsed=4.0, total=None)
         # Function bounds + size shown.
@@ -3315,11 +3417,11 @@ class TestProgressFormatters(CoveredUnitTest):
         # Anchor with idx.
         self.assertIn("Anchor (#18):", msg)
         self.assertIn("0x140001040", msg)
-        # Inner search bounds + length + matches. Early-bail caps the count,
-        # so 2-or-more renders as "2+".
+        # Inner search bounds + length + matches. Candidate-refinement tracks
+        # the exact surviving count, so it renders the real number (no "2+").
         self.assertIn("0x140001040 .. 0x140001047", msg)
         self.assertIn("7 bytes", msg)
-        self.assertIn("2+ matches", msg)
+        self.assertIn("3 matches", msg)
         # Best so far + candidates + elapsed.
         self.assertIn("Best found:   -", msg)
         self.assertIn("0 unique so far", msg)


### PR DESCRIPTION
## Background

A real-world `Find shortest unique signature for current function` run on a large database took 7.7 minutes for one function. Profiling showed the search re-scanned the whole database on every growth step, and `idaapi.user_cancelled()` polling alone cost a third of the run.

This is Phase 1 of a two-phase plan. It restructures the search around incremental candidate refinement and removes the per-step rescans. Phase 2 (a precomputed position index) is a separate follow-up.

## What I changed

1. **Candidate refinement instead of per-step rescans.** The search now scans the database once per anchor to seed a set of match offsets, then refines that set in memory as the signature grows (`_refine_offsets`): for each appended byte, keep the candidates whose byte still matches. The surviving candidate count is the exact match count, so the live `Matches:` line and the function-search inner count are exact again (no `2+` placeholder). New `SignatureSearcher.find_all_offsets` returns the seed offsets plus the buffer they index.

2. **Deferred seeding.** Seeding on a short, common first instruction enumerated hundreds of thousands of matches only for the result to be discarded for being too short. The function search now probes uniqueness with a cheap early-bail below `MIN_USEFUL_SIG_BYTES` and defers the enumerating seed until the pattern is long enough to be both a valid answer and selective. This preserves output exactly: an anchor that becomes unique below the minimum still returns its short signature, which the caller discards as before.

3. **Throttled cancel polling.** `idaapi.user_cancelled()` pumps the UI event loop (about a millisecond per call). The scan loops now poll every 65536 matches instead of every match, which removed tens of seconds of pure polling overhead while keeping cancel responsive.

4. **Profiling menu fix.** `start_profiling` / `stop_profiling` were attached with `attach_action_to_menu` at plugin init, which runs before IDA builds its menus and silently no-ops, so the items never appeared. They are now attached through the same right-click popup hook the main action uses, grouped under a `SigMaker` submenu alongside the dialog action.

## Measured impact

Same function, same large database, profiled in IDA:

| Build | Function-search time |
|---|---|
| Original (enumerate every match per step) | 462s |
| This branch | ~22s of compute (13x faster cumulatively) |

In-memory refinement itself is now negligible (0.03s); the remaining cost is the per-anchor seed scan, which Phase 2 targets.

## Correctness

- Signatures produced are byte-identical to the previous release: verified by dumping `MinimalFunctionSignatureGenerator.generate` output across all 82 functions in the test binary on `main` vs this branch (diff empty).
- A refinement-vs-rescan equivalence test asserts `_refine_offsets` matches a brute-force oracle at every growth step.
- The non-SIMD build keeps the existing per-step `count_matches` path as a fallback.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit | 187 OK | 198 OK |
| Docker idapro-tests (9.0/9.1) | 205 OK | 216 OK |
| Docker idapro-tests-9.2 | 205 OK | 216 OK |

## Notes

- Public API surface (`SignatureMaker`, `XrefFinder`, `SigMakerConfig`, the format specs) is unchanged. `find_all` / `count_matches` / `is_unique` gained optional keyword args with behavior-preserving defaults.
- Phase 2 (a bucketed position index plus a multi-anchor scheduler) will replace the per-anchor seed scan with an O(1) lookup and is the next step.
