### PR TITLE
Release 1.7.3: CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.7.3] - 2026-05-28
+
+### Changed
+
+- **`Find shortest unique signature for current function` is dramatically faster on large databases.** The search now scans the database once per starting point to seed a set of candidate match offsets, then refines that set in memory as the signature grows, instead of re-scanning the whole database on every byte. A function that previously took minutes now finishes in seconds. ([#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+- **The live `Matches:` count is back, and exact.** Candidate refinement tracks the surviving match count for free at every step, so the `Create unique signature` wait box shows the real count again and the function-search wait box shows an exact inner count instead of the temporary `2+` placeholder. ([#27](https://github.com/mahmoudimus/ida-sigmaker/issues/27), [#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+
+### Fixed
+
+- **The `Start Profiling` / `Stop Profiling` menu items now appear.** They were attached at plugin init, before IDA builds its menus, so they silently never showed. They are now attached through the disassembly right-click popup, grouped with the main action under a `SigMaker` submenu. ([#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+
+### Internal
+
+- New `SignatureSearcher.find_all_offsets` (seed scan returning raw buffer offsets) and `_refine_offsets` (in-memory candidate refinement). Uniqueness checks below `MIN_USEFUL_SIG_BYTES` use a cheap early-bail probe so the enumerating seed scan is deferred until the pattern is long enough to be selective. ([#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+- Cancellation polling in the scan loops is throttled (every 65536 matches) so `idaapi.user_cancelled()`, which pumps the UI event loop, does not dominate a scan over a common pattern. ([#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+- Signatures produced are byte-identical to 1.7.2; the change is purely how quickly they are found and that exact match counts are restored. ([#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33))
+
+[1.7.3]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.7.2...v1.7.3
+
 ## [1.7.2] - 2026-05-28
 
 ### Added

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.7.2"
+        "version": "1.7.3"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -25,7 +25,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
Release 1.7.3.

## Summary

- Bumps the version to 1.7.3 in `src/sigmaker/__init__.py` and `ida-plugin.json`.
- Adds the `[1.7.3]` CHANGELOG entry covering PR #33 (Phase 1 candidate-refinement search).
- The release workflow embeds this section into the published release notes automatically.

## What ships in 1.7.3

- `Find shortest unique signature for current function` is dramatically faster on large databases (scan once per starting point, then refine candidates in memory instead of re-scanning per byte).
- The live `Matches:` count is back and exact (no more `2+` placeholder).
- The `Start Profiling` / `Stop Profiling` menu items now appear, under a `SigMaker` right-click submenu.
- Signatures produced are byte-identical to 1.7.2; only the speed and the restored exact counts change.
