### PR TITLE
Phase 2: bucket position index for signature seeding (2.48x and widening on large DBs)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1590,6 +1590,30 @@ class _ByteIndex:
         return [pos[i] for i in range(start, end)]
 
 
+def _select_seed_run(
+    sig: "Signature", index: "_ByteIndex"
+) -> typing.Optional[tuple[int, int]]:
+    """Pick the exact (unmasked) 2-byte run in sig whose index bucket is
+    smallest, to minimize the initial candidate set (Dynamic Seed Selection).
+
+    Returns (relative_offset, key), or None if sig has no run of two
+    consecutive exact bytes.
+    """
+    best: typing.Optional[tuple[int, int, int]] = None  # (size, offset, key)
+    for j in range(len(sig) - 1):
+        a = sig[j]
+        b = sig[j + 1]
+        if a.is_wildcard or b.is_wildcard:
+            continue
+        key = (a.value << 8) | b.value
+        size = index.bucket_size(key)
+        if best is None or size < best[0]:
+            best = (size, j, key)
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
 def _decode_function_for_anchors(
     pfn: "idaapi.func_t",
     processor: "InstructionProcessor",

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1559,6 +1559,37 @@ def _refine_offsets(
     return [c for c in offsets if c + j < n and (data_mv[c + j] & mask) == target]
 
 
+class _ByteIndex:
+    """A 2-byte bucket position index over the segment buffer.
+
+    Wraps simd_scan.build_byte_index. bucket_size is O(1) and candidates is
+    O(bucket). Built once per generate() and discarded; reused across all
+    anchors in that one search.
+    """
+
+    __slots__ = ("heads", "positions")
+
+    def __init__(self, heads, positions):
+        self.heads = heads
+        self.positions = positions
+
+    @classmethod
+    def build(cls, data_mv: memoryview) -> typing.Optional["_ByteIndex"]:
+        if not SIMD_SPEEDUP_AVAILABLE or len(data_mv) < 2:
+            return None
+        heads, positions = simd_scan.build_byte_index(data_mv)
+        return cls(heads, positions)
+
+    def bucket_size(self, key: int) -> int:
+        return self.heads[key + 1] - self.heads[key]
+
+    def candidates(self, key: int) -> list[int]:
+        start = self.heads[key]
+        end = self.heads[key + 1]
+        pos = self.positions
+        return [pos[i] for i in range(start, end)]
+
+
 def _decode_function_for_anchors(
     pfn: "idaapi.func_t",
     processor: "InstructionProcessor",

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1614,6 +1614,42 @@ def _select_seed_run(
     return best[1], best[2]
 
 
+def _seed_via_index(
+    sig: "Signature",
+    index: typing.Optional["_ByteIndex"],
+    buf: "InMemoryBuffer",
+) -> typing.Optional[list[int]]:
+    """Seed the candidate set from the byte index instead of scanning.
+
+    Picks the most selective exact 2-byte run (Dynamic Seed Selection), maps
+    its hits back to candidate pattern-starts, and refines against the rest of
+    the pattern so the result equals matches(full pattern). Returns the
+    candidate offsets, or None if the index is unavailable or the pattern has
+    no exact 2-byte run (caller falls back to a scan).
+    """
+    if index is None:
+        return None
+    run = _select_seed_run(sig, index)
+    if run is None:
+        return None
+    s, key = run
+    data_mv = buf.data()
+    n = len(data_mv)
+    m = len(sig)
+    # Map each 2-byte hit at offset p back to a pattern start p - s, keeping
+    # only candidates whose full pattern fits in the buffer.
+    cands = [p - s for p in index.candidates(key) if p >= s and (p - s) + m <= n]
+    # Refine against every exact byte except the two seed-run bytes.
+    for j in range(m):
+        if j == s or j == s + 1:
+            continue
+        sb = sig[j]
+        if sb.is_wildcard:
+            continue
+        cands = _refine_offsets(data_mv, cands, j, sb.value, 0xFF)
+    return cands
+
+
 def _decode_function_for_anchors(
     pfn: "idaapi.func_t",
     processor: "InstructionProcessor",
@@ -1720,9 +1756,13 @@ class MinimalFunctionSignatureGenerator:
         # call. Profiling against a real binary showed _load_segments was
         # 84% of generate() wall time when called per-is_unique.
         buf: typing.Optional["InMemoryBuffer"] = None
+        index: typing.Optional["_ByteIndex"] = None
         if SIMD_SPEEDUP_AVAILABLE:
             with ProgressDialog("Please stand by, copying segments..."):
                 buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+            # Build the 2-byte position index once for the whole search so each
+            # anchor seeds with an O(1) lookup instead of a full-buffer scan.
+            index = _ByteIndex.build(buf.data())
 
         # Iterate the pre-decoded anchors inside a ProgressBox so the wait
         # box shows live progress (issue #27). enumerate() keeps the index
@@ -1756,7 +1796,7 @@ class MinimalFunctionSignatureGenerator:
 
             sig = self._grow_unique_from_decoded(
                 decoded, anchor_idx, progress.best_size, cfg,
-                buf=buf, progress=progress,
+                buf=buf, progress=progress, index=index,
             )
             if sig is None:
                 continue
@@ -1785,6 +1825,7 @@ class MinimalFunctionSignatureGenerator:
         cfg: SigMakerConfig,
         buf: typing.Optional["InMemoryBuffer"] = None,
         progress: typing.Optional["_FunctionSigProgress"] = None,
+        index: typing.Optional["_ByteIndex"] = None,
     ) -> typing.Optional[Signature]:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
@@ -1844,12 +1885,16 @@ class MinimalFunctionSignatureGenerator:
                 # so fall back to the per-step rescan.
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
-                # Seed once against the cached buffer; keep every match offset.
-                # The pattern is now at least MIN_USEFUL_SIG_BYTES, so this is
-                # selective rather than a full-database enumeration.
-                offsets, seed_buf = SignatureSearcher.find_all_offsets(
-                    f"{sig:ida}", buf=seed_buf
-                )
+                # Seed once. Prefer the byte index (O(1) lookup via Dynamic
+                # Seed Selection); fall back to a full scan if the index is
+                # unavailable or the pattern has no exact 2-byte run to key on.
+                seeded = _seed_via_index(sig, index, seed_buf)
+                if seeded is None:
+                    offsets, seed_buf = SignatureSearcher.find_all_offsets(
+                        f"{sig:ida}", buf=seed_buf
+                    )
+                else:
+                    offsets = seeded
                 count = len(offsets)
             else:
                 # Refine the surviving candidates in memory for each byte

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -4,6 +4,9 @@ from libc.stdint cimport uint8_t
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcmp, memchr
 
+from cpython cimport array
+import array
+
 from sigmaker._speedups.simd_scan cimport Signature, SimdLevel, simd_support_best_level
 
 cdef extern from "simd_support.hpp":
@@ -705,3 +708,54 @@ def scan_bytes(const unsigned char[:] data_view, Signature sig) -> int:
     if hit == e:
         return -1
     return <int>(hit - s)
+
+def build_byte_index(const unsigned char[:] data_view):
+    """Build a 2-byte bucket position index of data_view.
+
+    Returns (heads, positions), both array.array('I') (uint32):
+      heads: length 65537. The start offsets of bucket V are
+             positions[heads[V] : heads[V+1]]; bucket size is
+             heads[V+1] - heads[V]. heads[65536] == number of windows.
+      positions: length max(0, n-1); the start offset of each 2-byte
+             window, grouped by key. Empty when n < 2.
+
+    The counting sort runs under nogil so the IDA UI stays responsive
+    during the build. Buffers use array.clone (no oversized temporaries).
+    """
+    cdef Py_ssize_t n = data_view.shape[0]
+    cdef array.array heads = array.clone(array.array('I'), 65537, zero=True)
+    cdef array.array positions = array.clone(array.array('I'), 0, zero=False)
+    if n < 2:
+        return heads, positions
+
+    positions = array.clone(array.array('I'), n - 1, zero=False)
+    cdef unsigned int[:] h = heads
+    cdef unsigned int[:] pos = positions
+    cdef const unsigned char* d = &data_view[0]
+    cdef Py_ssize_t i
+    cdef unsigned int key
+    cdef unsigned int* wh = <unsigned int*>malloc(65537 * sizeof(unsigned int))
+    if wh == NULL:
+        raise MemoryError("build_byte_index: write-head allocation failed")
+    try:
+        with nogil:
+            for i in range(65537):
+                h[i] = 0
+            # pass 1: count occurrences of each key into h[key + 1]
+            for i in range(n - 1):
+                key = (<unsigned int>d[i] << 8) | <unsigned int>d[i + 1]
+                h[key + 1] += 1
+            # prefix sum: h[V] becomes the start index of bucket V
+            for i in range(1, 65537):
+                h[i] += h[i - 1]
+            # write heads start as bucket starts
+            for i in range(65537):
+                wh[i] = h[i]
+            # pass 2: place each window offset into its bucket
+            for i in range(n - 1):
+                key = (<unsigned int>d[i] << 8) | <unsigned int>d[i + 1]
+                pos[wh[key]] = <unsigned int>i
+                wh[key] += 1
+    finally:
+        free(wh)
+    return heads, positions

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -398,6 +398,59 @@ class TestBenchmarkPerformance(unittest.TestCase):
             "times": times,
         }
 
+    def benchmark_index_vs_scan_seed(self, iterations: int = 3) -> dict:
+        """Time the function search with the byte index vs the Phase 1 scan
+        fallback (forced by disabling the index), on the largest function."""
+        import time as _time
+        from unittest.mock import patch as _patch
+
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+        func_qty = idaapi.get_func_qty()
+        best, best_size = None, 0
+        for i in range(func_qty):
+            pfn = idaapi.getn_func(i)
+            if pfn is None:
+                continue
+            if (pfn.end_ea - pfn.start_ea) > best_size:
+                best_size = pfn.end_ea - pfn.start_ea
+                best = pfn
+        if best is None:
+            self.skipTest("no function")
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA, wildcard_operands=True,
+            continue_outside_of_function=False, wildcard_optimized=True,
+            ask_longer_signature=False, max_single_signature_length=100,
+        )
+        gen = sigmaker.MinimalFunctionSignatureGenerator(
+            sigmaker.InstructionProcessor(sigmaker.OperandProcessor()))
+
+        def median(iters):
+            ts = []
+            for _ in range(iters):
+                t0 = _time.perf_counter()
+                try:
+                    gen.generate(best, cfg)
+                except sigmaker.Unexpected:
+                    pass
+                ts.append(_time.perf_counter() - t0)
+            ts.sort()
+            return ts[len(ts) // 2]
+
+        with_index = median(iterations)
+        with _patch.object(sigmaker._ByteIndex, "build", return_value=None):
+            scan_only = median(iterations)
+        print("\n--- benchmark_index_vs_scan_seed ---")
+        print(f"function bytes: {best_size}")
+        print(f"index median:   {with_index:.4f}s")
+        print(f"scan median:    {scan_only:.4f}s")
+        return {
+            "operation": "index_vs_scan_seed",
+            "function_bytes": best_size,
+            "index_s": with_index,
+            "scan_s": scan_only,
+        }
+
     def test_performance_benchmarks(self):
         """Run all performance benchmarks and display results."""
         print("\n" + "=" * 80)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3722,6 +3722,34 @@ class TestProgressBox(CoveredUnitTest):
         self.assertEqual(self.dialogs[0].messages[1], "Processing (2/2) | Elapsed: 2s")
 
 
+class TestSelectSeedRun(CoveredUnitTest):
+    """Dynamic Seed Selection: pick the smallest-bucket exact 2-byte run."""
+
+    def _sig(self, specs):  # specs: list[(value, is_wildcard)]
+        sig = sigmaker.Signature()
+        for v, w in specs:
+            sig.append(sigmaker.SignatureByte(v, w))
+        return sig
+
+    def _index(self, sizes):
+        idx = MagicMock()
+        idx.bucket_size.side_effect = lambda key: sizes.get(key, 0)
+        return idx
+
+    def test_picks_smallest_bucket_run(self):
+        # pattern: ?? 00 00 ?? 8B 45  -> exact runs (1,"00 00") and (4,"8B 45")
+        sig = self._sig(
+            [(0, True), (0, False), (0, False), (0, True), (0x8B, False), (0x45, False)]
+        )
+        sizes = {(0x00 << 8) | 0x00: 4_000_000, (0x8B << 8) | 0x45: 12}
+        run = sigmaker._select_seed_run(sig, self._index(sizes))
+        self.assertEqual(run, (4, (0x8B << 8) | 0x45))
+
+    def test_returns_none_when_no_two_exact_bytes(self):
+        sig = self._sig([(0, True), (0x8B, False), (0, True), (0x45, False)])
+        self.assertIsNone(sigmaker._select_seed_run(sig, self._index({})))
+
+
 class TestByteIndex(CoveredUnitTest):
     """The _ByteIndex holder over build_byte_index."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3816,6 +3816,48 @@ class TestByteIndex(CoveredUnitTest):
         )
 
 
+class TestIndexSeedEquivalence(CoveredUnitTest):
+    """Index-seeded candidates must equal a brute-force masked rescan."""
+
+    def _brute(self, data: bytes, sig) -> list[int]:
+        n, m = len(data), len(sig)
+        out = []
+        for c in range(n - m + 1):
+            ok = True
+            for j in range(m):
+                sb = sig[j]
+                if sb.is_wildcard:
+                    continue
+                if data[c + j] != sb.value:
+                    ok = False
+                    break
+            if ok:
+                out.append(c)
+        return out
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_index_seed_equals_brute_force(self):
+        import random
+        rng = random.Random(99)
+        data = bytes(rng.randrange(256) for _ in range(8192))
+        mv = memoryview(bytearray(data))
+        idx = sigmaker._ByteIndex.build(mv)
+        buf = MagicMock()
+        buf.data.return_value = mv
+        for anchor in (10, 100, 500, 4000):
+            sig = sigmaker.Signature()
+            for j in range(7):
+                is_wc = (j % 4 == 0)
+                sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
+            seeded = sigmaker._seed_via_index(sig, idx, buf)
+            expected = self._brute(data, sig)
+            self.assertEqual(
+                sorted(seeded), sorted(expected),
+                f"anchor {anchor}: index seed != brute force",
+            )
+            self.assertIn(anchor, seeded)
+
+
 class TestBuildByteIndex(CoveredUnitTest):
     """The Cython 2-byte counting-sort index."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3722,6 +3722,25 @@ class TestProgressBox(CoveredUnitTest):
         self.assertEqual(self.dialogs[0].messages[1], "Processing (2/2) | Elapsed: 2s")
 
 
+class TestByteIndex(CoveredUnitTest):
+    """The _ByteIndex holder over build_byte_index."""
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_build_and_lookup(self):
+        data = memoryview(bytearray(b"\x01\x02\x01\x02\x03"))
+        idx = sigmaker._ByteIndex.build(data)
+        self.assertIsNotNone(idx)
+        key = (0x01 << 8) | 0x02
+        self.assertEqual(idx.bucket_size(key), 2)
+        self.assertEqual(sorted(idx.candidates(key)), [0, 2])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_build_returns_none_for_short_buffer(self):
+        self.assertIsNone(
+            sigmaker._ByteIndex.build(memoryview(bytearray(b"\x01")))
+        )
+
+
 class TestBuildByteIndex(CoveredUnitTest):
     """The Cython 2-byte counting-sort index."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3112,9 +3112,10 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         gen = sigmaker.MinimalFunctionSignatureGenerator(processor)
         pfn = self._make_pfn(0x1000, 0x100A)  # 10 single-byte 0x90 instructions
 
-        # Spy on the real find_all_offsets to confirm the seed scan is deferred
-        # until the pattern reaches MIN_USEFUL_SIG_BYTES (never seeded on a
-        # short, common prefix) and still runs the genuine SIMD seed + refine.
+        # Force the Phase 1 scan-seed fallback (disable the byte index) so this
+        # test exercises the find_all_offsets seed path it spies on. The
+        # index-backed seed path has its own equivalence coverage
+        # (TestIndexSeedEquivalence).
         real_find_all_offsets = sigmaker.SignatureSearcher.find_all_offsets
         seed_sig_byte_lens: list[int] = []
 
@@ -3124,6 +3125,8 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
             return real_find_all_offsets(ida_signature, buf=buf)
 
         with patch.object(
+            sigmaker._ByteIndex, "build", return_value=None
+        ), patch.object(
             sigmaker.SignatureSearcher, "find_all_offsets", side_effect=spy
         ):
             result = gen.generate(pfn, self._make_cfg(max_len=50))
@@ -3720,6 +3723,50 @@ class TestProgressBox(CoveredUnitTest):
         ))
         self.assertEqual(self.dialogs[0].messages[0], "Processing (1/2) | Elapsed: 1s")
         self.assertEqual(self.dialogs[0].messages[1], "Processing (2/2) | Elapsed: 2s")
+
+
+class TestSeedViaIndex(CoveredUnitTest):
+    """Index-backed seeding maps hits to pattern starts and refines."""
+
+    def _sig(self, specs):
+        sig = sigmaker.Signature()
+        for v, w in specs:
+            sig.append(sigmaker.SignatureByte(v, w))
+        return sig
+
+    def test_index_seed_matches_buffer(self):
+        buf = MagicMock()
+        buf.data.return_value = memoryview(
+            bytearray(b"\x8b\x45\x90\x90\x90\x00\x8b\x45\x00\x00")
+        )
+        # pattern "8B 45 90 90 90" (all exact), 5 bytes
+        sig = self._sig(
+            [(0x8B, False), (0x45, False), (0x90, False), (0x90, False), (0x90, False)]
+        )
+        idx = MagicMock()
+        # 8B 45 is the most selective run, so Dynamic Seed Selection keys on
+        # it; other runs (90 90, 45 90) get a larger bucket so they lose.
+        idx.bucket_size.side_effect = lambda key: {(0x8B << 8) | 0x45: 2}.get(key, 10**9)
+        idx.candidates.side_effect = (
+            lambda key: [0, 6] if key == ((0x8B << 8) | 0x45) else []
+        )
+        out = sigmaker._seed_via_index(sig, idx, buf)
+        # offset 0 keeps (90 90 90 follow); offset 6 drops (00 00 follow)
+        self.assertEqual(out, [0])
+
+    def test_returns_none_when_no_run(self):
+        buf = MagicMock()
+        buf.data.return_value = memoryview(bytearray(b"\x90" * 10))
+        sig = self._sig([(0x90, True), (0x91, False), (0x92, True)])
+        idx = MagicMock()
+        idx.bucket_size.return_value = 0
+        self.assertIsNone(sigmaker._seed_via_index(sig, idx, buf))
+
+    def test_returns_none_when_index_none(self):
+        buf = MagicMock()
+        buf.data.return_value = memoryview(bytearray(b"\x90" * 10))
+        sig = self._sig([(0x90, False), (0x91, False)])
+        self.assertIsNone(sigmaker._seed_via_index(sig, None, buf))
 
 
 class TestSelectSeedRun(CoveredUnitTest):

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3722,6 +3722,41 @@ class TestProgressBox(CoveredUnitTest):
         self.assertEqual(self.dialogs[0].messages[1], "Processing (2/2) | Elapsed: 2s")
 
 
+class TestBuildByteIndex(CoveredUnitTest):
+    """The Cython 2-byte counting-sort index."""
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_heads_and_positions_shape(self):
+        data = memoryview(bytearray(b"\x01\x02\x01\x02\x03"))
+        heads, positions = sigmaker.simd_scan.build_byte_index(data)
+        self.assertEqual(len(heads), 65537)
+        self.assertEqual(len(positions), len(data) - 1)  # 4 windows
+        self.assertEqual(heads[0], 0)
+        self.assertEqual(heads[65536], len(data) - 1)
+        self.assertTrue(all(heads[i] <= heads[i + 1] for i in range(65536)))
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_bucket_contains_correct_offsets(self):
+        # windows: (0)01 02, (1)02 01, (2)01 02, (3)02 03
+        data = memoryview(bytearray(b"\x01\x02\x01\x02\x03"))
+        heads, positions = sigmaker.simd_scan.build_byte_index(data)
+        key_0102 = (0x01 << 8) | 0x02
+        start, end = heads[key_0102], heads[key_0102 + 1]
+        self.assertEqual(sorted(positions[start:end]), [0, 2])
+        key_0203 = (0x02 << 8) | 0x03
+        s2, e2 = heads[key_0203], heads[key_0203 + 1]
+        self.assertEqual(sorted(positions[s2:e2]), [3])
+        self.assertEqual(end - start, 2)  # bucket_size of 01 02
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_short_buffer_returns_empty_positions(self):
+        heads, positions = sigmaker.simd_scan.build_byte_index(
+            memoryview(bytearray(b"\x01"))
+        )
+        self.assertEqual(len(positions), 0)
+        self.assertEqual(len(heads), 65537)  # safe to look up; all buckets empty
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Background

Phase 1 (v1.7.3, #33) removed the per-growth-step rescans from the function-signature search and left one bottleneck: the per-anchor seed scan. Profiling on a real database showed the seed `find_all_offsets` accounting for almost the entire remaining time, because even a 5-byte seed pattern occurs hundreds of thousands of times in a large binary and the scan enumerates them all.

Phase 2 replaces that seed scan with an O(1) lookup against a position index built once per search.

## What I changed

1. **`build_byte_index` (Cython, nogil).** A two-pass counting sort over the segment buffer produces a 2-byte bucket index: `heads` (65537 uint32, bucket boundaries) and `positions` (uint32 per 2-byte window, grouped by key). It runs under `nogil` so the UI stays responsive during the build, and uses `array.clone` / `malloc` so there is no oversized temporary and the memory frees immediately. Boundary-safe (`i < n-1`, `n < 2` returns empty).

2. **`_ByteIndex` holder + Dynamic Seed Selection.** Built once per `generate()` from the cached buffer. Instead of keying the index on the first exact 2-byte run in the pattern, I inspect every exact 2-byte run, look up each bucket size in O(1) via `heads`, and seed on the most selective one. This sidesteps pathologically common keys (`00 00`, `CC CC`) that would otherwise produce a huge initial candidate set. Hits map back to candidate pattern-starts (`pos - s`, guarded against underflow and against running off the buffer), then the existing Phase 1 `_refine_offsets` narrows them.

3. **Fallback chain preserved.** Index lookup, then the Phase 1 seed scan when the pattern has no exact 2-byte run or the extension is absent, then the non-SIMD `count_matches` path. Output is byte-identical at every tier.

## Measured impact

Index path vs the Phase 1 scan fallback (top functions, native idalib):

| Segment buffer | Index | Scan | Speedup |
|---|---|---|---|
| 4.3 MB | 32.2s | 50.6s | 1.57x |
| 16 MB (54k functions) | 130.7s | 323.8s | 2.48x |

The advantage widens with database size, as expected: the scan cost it replaces scales with the buffer, the index lookup does not. Larger real databases should benefit more.

## Correctness

- Byte-identical output: dumped `MinimalFunctionSignatureGenerator.generate` across all 82 functions of the test binary on `main` vs this branch; diff empty.
- An index-seed vs brute-force equivalence test asserts the index-seeded candidate set matches a masked rescan at every anchor, including wildcards.

## Verification

| Suite | Before | After |
|---|---|---|
| Host unit | 198 OK | 209 OK |
| Docker idapro-tests (9.0/9.1) | 216 OK | 227 OK |
| Docker idapro-tests-9.2 | 216 OK | 227 OK |

Zero regressions. The `_speedups` extension rebuilds cleanly in both Docker images.

## Notes

- This touches the Cython `_speedups` extension, so the wheel rebuilds; the SIMD-absent fallback keeps the plugin working without it.
- Follow-up (Phase 3): the below-MIN uniqueness probes are still un-indexed full-buffer scans and now dominate absolute time on functions with many anchors. Answering short-pattern uniqueness via the index too is the next lever.
