### PR TITLE
Phase 3 + 4: dynamic seed selection + Cython in-place refine

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -287,12 +287,14 @@ plugin still works, just without the speedups.
 In `simd_scan.pyx` you will see both, sharing the name `array`:
 
 ```cython
-from cpython cimport array   # compile-time: C declarations
-import array                 # run-time: the Python module
+from cpython cimport array       # compile-time: C-level array.array type + array.clone
+import array as py_arr_mod        # run-time: the Python array module (constructor)
 ```
 
 This is **not** a collision or a bug; it is the documented Cython idiom for
-working with `array.array` efficiently, and the two lines do different jobs:
+working with `array.array` efficiently, and the two lines do different jobs. We
+give the run-time module the alias `py_arr_mod` to make the split obvious at
+every call site:
 
 - `from cpython cimport array` is **compile-time only**. It pulls in the C-level
   declarations from Cython's bundled `cpython/array.pxd`: the `array.array`
@@ -301,13 +303,12 @@ working with `array.array` efficiently, and the two lines do different jobs:
   going through the Python constructor). A `cimport` creates **no runtime name
   binding**.
 
-- `import array` is the ordinary **run-time** import of the Python `array`
-  module. It is what makes the *constructor call* `array.array('I')` resolve at
-  run time (for example, the template argument to `array.clone`).
+- `import array as py_arr_mod` is the ordinary **run-time** import of the Python
+  `array` module. It is what makes the *constructor call* `py_arr_mod.array('I')`
+  resolve at run time (for example, the template argument to `array.clone`).
 
-Cython resolves each use of `array` in the right namespace: in a `cdef` type
-position or a C-function call (`array.clone(...)`) it uses the cimported C
-declarations; in a run-time expression (`array.array('I')`) it uses the imported
-module. Because the cimport contributes no runtime binding, there is nothing for
-the import to "override", they coexist by design. This is exactly the pattern
-shown in the Cython array tutorial.
+So every use is unambiguous by name: `array.*` (`cdef array.array`,
+`array.clone(...)`) is the cimported C-level API, and `py_arr_mod.array(...)` is
+the run-time Python constructor. They no longer share a name, so there is nothing
+to "override". (The canonical Cython array tutorial shows both lines sharing the
+name `array`; aliasing one side is the same idiom, just spelled out.)

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -1,0 +1,313 @@
+# The shortest-unique-signature algorithm
+
+This document explains the math behind the "find shortest unique signature for
+the current function" search, why the approach is novel, and how the Cython
+`_speedups` extension is what makes it practical. It is written for someone who
+wants to understand *why* the search is fast, not just *what* the code does.
+
+GitHub renders LaTeX in Markdown, so the math below is in `$...$` (inline) and
+`$$...$$` (block) form.
+
+---
+
+## 1. The problem
+
+A database $D$ is the concatenation of the analyzed program's segment bytes,
+of total length $N$ (tens of MB, so $N \sim 10^7$). A **pattern**
+$P = (t_0, t_1, \dots, t_{\ell-1})$ is a sequence of tokens; each token $t_j$ is
+either an exact byte (value $v_j$, mask $m_j = \text{0xFF}$) or a wildcard
+(mask $m_j = \text{0x00}$, matches anything). $P$ **matches** $D$ at position
+$p$ when
+
+$$
+\forall j \in [0, \ell): \quad (D[p + j] \mathbin{\&} m_j) = (v_j \mathbin{\&} m_j).
+$$
+
+Let the match set be
+
+$$
+M(P) = \{\, p \in [0,\, N - \ell] : P \text{ matches } D \text{ at } p \,\}.
+$$
+
+For a function at address $a$, we decode its instructions, turn operands into
+wildcards according to the wildcard policy, and obtain a growing pattern
+$P_\ell$ (the first $\ell$ tokens). We want the **shortest** $\ell$ such that
+$P_\ell$ is unique:
+
+$$
+\ell^* = \min \{\, \ell : |M(P_\ell)| = 1 \,\}.
+$$
+
+## 2. The naive cost, and where 462 seconds went
+
+The obvious method: for $\ell = \ell_{\min}, \ell_{\min}+1, \dots$, scan all of
+$D$ and count matches of $P_\ell$, stop when the count reaches 1. Even with a
+SIMD-accelerated scan that costs $O(N)$ per length, this performs $L = \ell^* -
+\ell_{\min} + 1$ **independent full scans**:
+
+$$
+T_{\text{naive}} = O(L \cdot N).
+$$
+
+When the search has to consider several anchors (growing outside the function
+boundary, or comparing several candidate start points), it becomes
+$O(A \cdot L \cdot N)$ for $A$ anchors. On a real 16 MB module a single function
+took **462 s**. The whole optimization is about removing the two multiplicative
+factors $L$ and $A$ from the $N$ term.
+
+## 3. Monotonic shrinkage: seed once, then refine
+
+The match set is **monotonically non-increasing** in $\ell$. Appending a token
+adds a constraint, which can only remove positions, never add them:
+
+$$
+M(P_{\ell+1}) \subseteq M(P_\ell).
+$$
+
+So there is no reason to recompute $M(P_{\ell+1})$ from scratch. Given $M(P_\ell)$,
+the next set is just a **filter** of the previous one:
+
+$$
+M(P_{\ell+1}) = \{\, p \in M(P_\ell) : (D[p + \ell] \mathbin{\&} m_\ell) = (v_\ell \mathbin{\&} m_\ell) \,\}.
+$$
+
+This is the *seed-then-refine* recurrence. We pay for **one** initial match set
+(the "seed"), then each subsequent length is
+
+$$
+O(|M(P_\ell)|)
+$$
+
+work, proportional to the *current candidate count*, not $N$. Candidate counts
+collapse fast (each added exact byte divides the set by roughly $256$ for random
+data), so the entire refine chain telescopes:
+
+$$
+\sum_{\ell} |M(P_\ell)| = O(|M(P_{\ell_{\min}})|) = O(C_0),
+$$
+
+where $C_0$ is the seed size. The total per-anchor cost is now
+$O(\text{seed} + C_0)$. The remaining question is: **how cheaply can we build the
+seed?**
+
+## 4. The 2-byte position index (counting sort)
+
+Building the seed by scanning $D$ is still $O(N)$, and doing it per anchor brings
+back the $A \cdot N$ blowup. We precompute, **once per search**, an index that
+answers "where does this 2-byte run occur?" in time proportional to the answer
+size.
+
+For each 2-byte key $k \in [0, 2^{16})$ define its bucket
+
+$$
+B_k = \{\, p \in [0,\, N-1) : D[p] = (k \gg 8) \ \wedge\ D[p+1] = (k \mathbin{\&} \text{0xFF}) \,\}.
+$$
+
+We store every window start grouped by key in one flat array `positions`, with a
+`heads` offset array (a CSR / counting-sort layout):
+
+- `heads[k]` is the start of bucket $k$ inside `positions`;
+- bucket $k$ is the slice `positions[heads[k] : heads[k+1]]`;
+- $|B_k| = $ `heads[k+1] - heads[k]`, available in $O(1)$.
+
+Construction is a textbook **counting sort** over the $N-1$ adjacent-byte windows,
+two passes over $D$:
+
+1. **Count.** For each window key $k$, increment `heads[k+1]`.
+2. **Prefix-sum** `heads` so `heads[k]` becomes bucket $k$'s start, then
+   **scatter**: place each window offset $i$ at `positions[w[k]++]` using a copy
+   $w$ of the bucket starts.
+
+$$
+T_{\text{build}} = O(N), \qquad S_{\text{build}} = O(N + 2^{16}).
+$$
+
+Built once, amortized across **all** anchors. With the index in hand, seeding a
+pattern that contains an exact 2-byte run at offset $s$ with key $k$ costs only
+
+$$
+O(|B_k|): \quad M_{\text{seed}} = \{\, p - s : p \in B_k,\ \text{pattern fits} \,\},
+$$
+
+and then we refine against the remaining tokens (Section 3). The full $O(N)$ seed
+scan is gone, replaced by a bucket read.
+
+## 5. Dynamic Seed Selection (1-byte *or* 2-byte) from one index
+
+The seed cost is $O(|B_k|)$, so we want the **rarest** run. Two refinements:
+
+**(a) Choose the smallest bucket.** A pattern usually has several exact 2-byte
+runs. Pick the one minimizing bucket size.
+
+**(b) A single rare byte can beat a common pair.** `e8` (a `call` opcode) is
+everywhere; a lone `0f` followed by a common byte may be more selective as just
+the rare byte alone. We therefore also consider **1-byte** runs, and we get them
+*for free* from the same index. Because keys are ordered $k = (b \ll 8) \mid c$
+and the counting sort lays buckets out in key order, all 256 two-byte keys whose
+high byte is $b$ occupy a **contiguous** block of `positions`. Hence the 1-byte
+bucket is a telescoping sum that collapses to a single subtraction:
+
+$$
+\bigl|B^{(1)}_b\bigr| = \sum_{c=0}^{255} \bigl|B_{(b \ll 8)\,\mid\, c}\bigr|
+= \texttt{heads}[(b{+}1)\ll 8] - \texttt{heads}[b \ll 8],
+$$
+
+and the 1-byte candidate list is the single slice
+`positions[heads[b<<8] : heads[(b+1)<<8]]`. No second index, no extra memory, no
+rescan. (One boundary fix: position $N-1$ is never a 2-byte window *start*, so a
+1-byte hit on the final database byte is added explicitly when it can yield a
+valid pattern start.)
+
+Seed selection then minimizes selectivity over the union of both widths:
+
+$$
+(s^*, w^*) = \arg\min_{(s,\, w) \in \text{exact runs}} \bigl|B^{(w)}_{\text{key}(s,w)}\bigr|.
+$$
+
+Since the 1-byte options are a *superset* of the candidate seeds, the chosen seed
+bucket is never worse than a 2-byte-only choice:
+
+$$
+C_0 = \bigl|B^{(w^*)}\bigr| \le \min_{\text{2-byte runs}} |B_k|.
+$$
+
+A smaller seed means fewer candidates entering the refine chain, which (Section 3)
+bounds the whole per-anchor cost.
+
+**Deferred seeding.** For a pattern shorter than `MIN_USEFUL_SIG_BYTES` $= 5$, even
+the rarest run is too common (the seed would enumerate a large fraction of $D$),
+so seeding is deferred and a direct scan is used until the pattern is long enough
+to be selective. This avoids materializing a multi-million-entry seed for a 2-byte
+pattern.
+
+## 6. In-place refinement on a typed buffer
+
+Each refine step (Section 3) is a filter over the candidate array. We represent
+candidates as a typed `uint32` buffer and compact survivors **in place** with a
+two-pointer scan. With read index $r$, write index $w \le r$, target
+$\tau = v \mathbin{\&} m$:
+
+```
+for r in 0 .. count-1:
+    c = cands[r]
+    if c + j < N and (D[c + j] & m) == τ:
+        cands[w] = cands[r]   # keep
+        w += 1
+return w                      # new count
+```
+
+Because $w \le r$ at all times, a survivor is never overwritten before it is read.
+The buffer is allocated **once** at seed time and only shrinks; the ~165k refine
+calls of a large function perform **zero allocation**.
+
+## 7. Complexity summary
+
+| Stage | Cost | Frequency |
+|------|------|-----------|
+| Index build (counting sort) | $O(N)$ | once per search |
+| Seed selection | $O(\ell)$ over tokens | per anchor |
+| Seed enumeration | $O(C_0)$ | per anchor |
+| Refine, all lengths | $O(C_0)$ (telescoping) | per anchor |
+
+Per search:
+
+$$
+T = \underbrace{O(N)}_{\text{one index build}} + \sum_{\text{anchors}} O\bigl(\ell + C_0\bigr)
+$$
+
+versus the naive $O(A \cdot L \cdot N)$. The $N$ term is paid **once** and shared;
+all per-anchor work is proportional to the chosen seed bucket $C_0$, which the
+selection step drives toward the rarest run in the pattern.
+
+## 8. What is novel here
+
+Signature scanners typically do one of two things: rescan the whole database for
+each candidate length, or build a heavy general-purpose substring index (suffix
+automaton / suffix array / large $q$-gram table). This algorithm instead exploits
+the *specific* structure of the masked-signature problem:
+
+1. **Wildcards mean we never need general substring search.** We only need to
+   anchor on the rarest *exact* run and then verify the rest token-by-token. That
+   turns "find the shortest unique pattern" into "pick the most selective seed,
+   then refine."
+
+2. **One counting-sort index serves both 1-byte and 2-byte selectivity.** The
+   key-ordered bucket layout makes the 1-byte index a *range view* of the 2-byte
+   index (a single subtraction for size, a single slice for contents). Dynamic
+   Seed Selection compares mixed-width runs with a closed-form selectivity
+   measure from one structure, with no extra memory.
+
+3. **Monotone shrinkage turns length growth into in-place filtering.** Because
+   $M(P_{\ell+1}) \subseteq M(P_\ell)$, the candidate set is a single buffer that
+   only ever shrinks; after the seed we never touch the database again, only the
+   handful of bytes at the growing frontier of the surviving candidates.
+
+The combination, a rarest-run seed chosen from a dual-width counting-sort index,
+feeding a monotone in-place refine, is what collapses $O(L \cdot N)$ per anchor
+into $O(C_0)$ per anchor on top of a single shared $O(N)$ build.
+
+## 9. How Cython makes it work
+
+The math above is correct in pure Python too, but it would not be *fast* in pure
+Python. The two hot kernels, the index build and the per-step refine, are
+memory-bound, branchy loops over millions of bytes. That is precisely the
+workload where CPython's per-element overhead (boxed integers, attribute lookups,
+interpreter dispatch, dynamic bounds checks) costs 50-100x. The `_speedups`
+extension compiles them to tight C:
+
+- **`build_byte_index`** is the counting sort of Section 4, written as C loops
+  over a `const unsigned char[:]` typed memoryview, running under `nogil` so the
+  IDA UI stays responsive during the $O(N)$ build.
+
+- **`refine_offsets`** is the in-place compaction of Section 6: a `nogil`
+  two-pointer loop over a `unsigned int[:]` candidate view and the
+  `const unsigned char[:]` data view, with no allocation. Moving this one
+  function into Cython dropped the refinement time on the largest test module
+  from **~14 s** (a Python list comprehension called ~165k times) to **~0.28 s**,
+  roughly **50x**.
+
+- **`array.array('I')` is the bridge.** A candidate set is simultaneously a
+  first-class Python object the orchestration layer can slice and return, *and*
+  a zero-copy `unsigned int[:]` typed memoryview inside Cython. The same buffer
+  is the Python-visible candidate list and the C-level `uint32*` that
+  `refine_offsets` compacts in place, so candidates cross the Python/C boundary
+  with no marshalling and no per-call allocation. This is the crux that makes
+  Section 6's "allocate once, only shrink" actually hold across the whole search.
+
+- **`nogil`** on both kernels means the heavy work runs without holding the
+  interpreter lock, which keeps the UI live and leaves headroom for the
+  SIMD scan path used when the index is unavailable.
+
+When the extension is absent, `SIMD_SPEEDUP_AVAILABLE` is `False` and pure-Python
+fallbacks produce **identical** results (cross-checked in the test suite); the
+plugin still works, just without the speedups.
+
+### A note on `cimport array` vs `import array`
+
+In `simd_scan.pyx` you will see both, sharing the name `array`:
+
+```cython
+from cpython cimport array   # compile-time: C declarations
+import array                 # run-time: the Python module
+```
+
+This is **not** a collision or a bug; it is the documented Cython idiom for
+working with `array.array` efficiently, and the two lines do different jobs:
+
+- `from cpython cimport array` is **compile-time only**. It pulls in the C-level
+  declarations from Cython's bundled `cpython/array.pxd`: the `array.array`
+  extension type (so `cdef array.array x` is a statically typed C variable) and
+  inline C functions such as `array.clone` (allocate a sibling buffer without
+  going through the Python constructor). A `cimport` creates **no runtime name
+  binding**.
+
+- `import array` is the ordinary **run-time** import of the Python `array`
+  module. It is what makes the *constructor call* `array.array('I')` resolve at
+  run time (for example, the template argument to `array.clone`).
+
+Cython resolves each use of `array` in the right namespace: in a `cdef` type
+position or a C-function call (`array.clone(...)`) it uses the cimported C
+declarations; in a run-time expression (`array.array('I')`) it uses the imported
+module. Because the cimport contributes no runtime binding, there is nothing for
+the import to "override", they coexist by design. This is exactly the pattern
+shown in the Cython array tutorial.

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -288,12 +288,12 @@ In `simd_scan.pyx` you will see both, sharing the name `array`:
 
 ```cython
 from cpython cimport array       # compile-time: C-level array.array type + array.clone
-import array as py_arr_mod        # run-time: the Python array module (constructor)
+import array as py_stdlib_arr_mod        # run-time: the Python array module (constructor)
 ```
 
 This is **not** a collision or a bug; it is the documented Cython idiom for
 working with `array.array` efficiently, and the two lines do different jobs. We
-give the run-time module the alias `py_arr_mod` to make the split obvious at
+give the run-time module the alias `py_stdlib_arr_mod` to make the split obvious at
 every call site:
 
 - `from cpython cimport array` is **compile-time only**. It pulls in the C-level
@@ -303,12 +303,12 @@ every call site:
   going through the Python constructor). A `cimport` creates **no runtime name
   binding**.
 
-- `import array as py_arr_mod` is the ordinary **run-time** import of the Python
-  `array` module. It is what makes the *constructor call* `py_arr_mod.array('I')`
+- `import array as py_stdlib_arr_mod` is the ordinary **run-time** import of the Python
+  `array` module. It is what makes the *constructor call* `py_stdlib_arr_mod.array('I')`
   resolve at run time (for example, the template argument to `array.clone`).
 
 So every use is unambiguous by name: `array.*` (`cdef array.array`,
-`array.clone(...)`) is the cimported C-level API, and `py_arr_mod.array(...)` is
+`array.clone(...)`) is the cimported C-level API, and `py_stdlib_arr_mod.array(...)` is
 the run-time Python constructor. They no longer share a name, so there is nothing
 to "override". (The canonical Cython array tutorial shows both lines sharing the
 name `array`; aliasing one side is the same idiom, just spelled out.)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@
 
 An IDA Pro 9.0+ zero-dependency cross-platform signature maker plugin with optional SIMD (e.g. AVX2/NEON/SSE2) speedups that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions.
 
+## Table of contents
+
+- [Installation](#installation)
+  - [Quick Install](#quick-install)
+  - [From Releases](#from-releases)
+  - [Need to find your plugin directory?](#need-to-find-your-plugin-directory)
+  - [Where and what is my default user directory?](#where-and-what-is-my-default-user-directory)
+- [SIMD Speedups](#simd-speedups)
+- [Requirements](#requirements)
+- [What is a "sigmaker"?](#what-is-a-sigmaker)
+- [Usage](#usage)
+  - [Finding XREFs](#finding-xrefs)
+  - [Signature searching](#signature-searching)
+  - [Signature Configuration](#signature-configuration)
+- [Performance](#performance)
+  - [Benchmarks](#benchmarks)
+  - [How it works](#how-it-works)
+- [Using SigMaker as a library](#using-sigmaker-as-a-library)
+  - [Stability contract](#stability-contract)
+- [Acknowledgements](#acknowledgements)
+- [Development & Releases](#development--releases)
+  - [Contributing](#contributing)
+- [Contact](#contact)
+
 ## Installation
 
 sigmaker's main value proposition is its cross-platform (Windows, macOS, Linux) Python 3 support. It uses zero third party dependencies, making the code both portable and easy to install.
@@ -131,6 +155,67 @@ If the matched address is not a function name or has no function name, it falls 
 There are also various options that be configured via the `Other options` button:
 
 ![](./assets/optional_configuration.png)
+
+## Performance
+
+SigMaker's "find the shortest unique signature for the current function" search has been heavily optimized. On a real 16 MB module, a single worst-case function search once took **462 seconds (7.7 minutes)**. A stack of four optimizations brought the heaviest searches down to the tens-of-seconds range and typical ones to near-instant. One user [reported](https://github.com/mahmoudimus/ida-sigmaker/issues/27#issuecomment-4577775008) the progress wait-box now "barely show[s] up for a 26 byte signature."
+
+The full derivation, including the match-set math, the counting-sort index, the selectivity proof, and what is novel about the approach, is written up in **[ALGORITHM.md](./ALGORITHM.md)**.
+
+### Benchmarks
+
+Measured on the largest function (8486 bytes) of a 16 MB module via native idalib on Apple Silicon. The effects are cumulative across the four phases:
+
+| Optimization | Effect | PR |
+| --- | --- | --- |
+| Phase 1: seed-then-refine candidate refinement | ~13x faster function search | [#33](https://github.com/mahmoudimus/ida-sigmaker/pull/33) |
+| Phase 2: 2-byte bucket position index | additional ~2.48x on large databases, widening as the database grows | [#35](https://github.com/mahmoudimus/ida-sigmaker/pull/35) |
+| Phase 3: dynamic seed selection (1- or 2-byte) | per-anchor seed scans cut from 206 to 2 | [#36](https://github.com/mahmoudimus/ida-sigmaker/pull/36) |
+| Phase 4: Cython in-place refinement | per-byte refinement ~14 s to ~0.28 s (~50x); function total ~24 s to ~15.6 s | [#36](https://github.com/mahmoudimus/ida-sigmaker/pull/36) |
+
+Signature output is byte-identical before and after every optimization. The test suite cross-checks each fast path against a brute-force oracle and diffs the generated signatures across the entire test binary.
+
+### How it works
+
+A short tour (see [ALGORITHM.md](./ALGORITHM.md) for the math):
+
+- **Seed, then refine.** The set of database matches can only shrink as a signature grows, so instead of rescanning the whole database for every candidate length, SigMaker scans once to seed a candidate set and then filters that set in place as each byte is appended.
+- **Index the database once.** A counting-sort index over every adjacent byte pair lets the seed be drawn from the *rarest* exact run in the pattern, in time proportional to that run's frequency rather than to the database size. The same index serves both 1-byte and 2-byte runs for free, so the most selective anchor is always chosen.
+- **Push the hot loops into C.** With the optional `pip install sigmaker` SIMD wheel, the index build and the per-byte refinement run as `nogil` C over typed buffers with zero per-call allocation, and the raw byte scan uses AVX2/NEON/SSE2. Without the wheel, pure-Python fallbacks produce identical results.
+
+## Using SigMaker as a library
+
+Beyond the IDA plugin, `sigmaker` is imported directly as a Python library by other tools (for example, batch signature-generation pipelines). The core types are usable from any IDAPython or idalib context:
+
+```python
+import sigmaker
+
+cfg = sigmaker.SigMakerConfig(
+    output_format=sigmaker.SignatureType.IDA,
+    wildcard_operands=True,
+    continue_outside_of_function=False,
+    wildcard_optimized=True,
+    ask_longer_signature=False,
+)
+result = sigmaker.SignatureMaker().make_signature(ea, cfg)
+print(f"{result.signature:ida}")   # IDA-style string
+print(len(result.signature))       # byte length
+
+# Cross-references:
+xrefs = sigmaker.XrefFinder().find_xrefs(ea, cfg)
+for gen in xrefs.signatures:
+    print(str(gen.address), f"{gen.signature:ida}")
+```
+
+### Stability contract
+
+If you embed `sigmaker`, you can rely on the following. These are treated as a contract and are checked before any change to the public surface:
+
+1. **Append-only config.** `SigMakerConfig` fields are never reordered or removed. New behavior arrives as new fields with safe defaults, so existing constructions keep working.
+2. **Stable public names.** These names and their documented attributes are not renamed or removed: `SignatureMaker`, `SigMakerConfig`, `SignatureType` (`IDA`, `x64Dbg`, `Mask`, `BitMask`), `XrefFinder`, `GeneratedSignature` (`signature`, `address`, `status`, `match_count`), `XrefGeneratedSignature` (`signatures`), `Match` (`__str__` returns the hex address), `Signature` (`__len__`, `__format__`), `GenerationPolicy`, `GenerationStatus`.
+3. **Stable method signatures.** `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict())`, `XrefFinder.find_xrefs(ea, cfg)`, `XrefFinder.count_code_xrefs_to(ea)`, and `XrefFinder.iter_code_xrefs_to(ea)`.
+4. **Stable format specs.** `f"{sig:ida}"`, `f"{sig:x64dbg}"`, `f"{sig:mask}"`, and `f"{sig:bitmask}"` keep producing their current output exactly.
+5. **Byte-identical defaults.** Production defaults are unchanged across optimizations: a script that does not opt into a new flag gets byte-identical signatures to previous versions.
 
 ## Acknowledgements
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1586,6 +1586,7 @@ def _refine_offsets_into(
     return w
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
 class _ByteIndex:
     """A 2-byte bucket position index over the segment buffer.
 
@@ -1594,11 +1595,8 @@ class _ByteIndex:
     anchors in that one search.
     """
 
-    __slots__ = ("heads", "positions")
-
-    def __init__(self, heads, positions):
-        self.heads = heads
-        self.positions = positions
+    heads: "array.array"
+    positions: "array.array"
 
     @classmethod
     def build(cls, data_mv: memoryview) -> typing.Optional["_ByteIndex"]:

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1589,6 +1589,17 @@ class _ByteIndex:
         pos = self.positions
         return [pos[i] for i in range(start, end)]
 
+    def bucket_size1(self, b: int) -> int:
+        # 1-byte bucket for b: all 2-byte keys (b<<8)..((b+1)<<8 - 1) telescope
+        # into one contiguous range, so its size is heads[(b+1)<<8]-heads[b<<8].
+        return self.heads[(b + 1) << 8] - self.heads[b << 8]
+
+    def candidates1(self, b: int) -> list[int]:
+        start = self.heads[b << 8]
+        end = self.heads[(b + 1) << 8]
+        pos = self.positions
+        return [pos[i] for i in range(start, end)]
+
 
 def _select_seed_run(
     sig: "Signature", index: "_ByteIndex"

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -7,6 +7,7 @@ by @mahmoudimus (Mahmoud Abdelkader)
 
 from __future__ import annotations
 
+import array
 import contextlib
 import contextvars
 import dataclasses
@@ -1559,6 +1560,32 @@ def _refine_offsets(
     return [c for c in offsets if c + j < n and (data_mv[c + j] & mask) == target]
 
 
+def _refine_offsets_into(
+    data_mv: memoryview,
+    cands: "array.array",
+    count: int,
+    j: int,
+    value: int,
+    mask: int,
+) -> int:
+    """Refine the first ``count`` entries of the uint32 array ``cands`` in
+    place (Cython when available), returning the new count. The function-sig
+    path only reaches this on the SIMD path; the Python branch is a defensive
+    fallback that mirrors _refine_offsets.
+    """
+    if SIMD_SPEEDUP_AVAILABLE:
+        return simd_scan.refine_offsets(data_mv, cands, count, j, value, mask)
+    n = len(data_mv)
+    target = value & mask
+    w = 0
+    for r in range(count):
+        c = cands[r]
+        if c + j < n and (data_mv[c + j] & mask) == target:
+            cands[w] = cands[r]
+            w += 1
+    return w
+
+
 class _ByteIndex:
     """A 2-byte bucket position index over the segment buffer.
 
@@ -1583,22 +1610,17 @@ class _ByteIndex:
     def bucket_size(self, key: int) -> int:
         return self.heads[key + 1] - self.heads[key]
 
-    def candidates(self, key: int) -> list[int]:
-        start = self.heads[key]
-        end = self.heads[key + 1]
-        pos = self.positions
-        return [pos[i] for i in range(start, end)]
+    def candidates(self, key: int) -> "array.array":
+        # positions is array.array('I'), so slicing yields array.array('I').
+        return self.positions[self.heads[key]:self.heads[key + 1]]
 
     def bucket_size1(self, b: int) -> int:
         # 1-byte bucket for b: all 2-byte keys (b<<8)..((b+1)<<8 - 1) telescope
         # into one contiguous range, so its size is heads[(b+1)<<8]-heads[b<<8].
         return self.heads[(b + 1) << 8] - self.heads[b << 8]
 
-    def candidates1(self, b: int) -> list[int]:
-        start = self.heads[b << 8]
-        end = self.heads[(b + 1) << 8]
-        pos = self.positions
-        return [pos[i] for i in range(start, end)]
+    def candidates1(self, b: int) -> "array.array":
+        return self.positions[self.heads[b << 8]:self.heads[(b + 1) << 8]]
 
 
 def _select_seed_run(
@@ -1639,14 +1661,14 @@ def _seed_via_index(
     sig: "Signature",
     index: typing.Optional["_ByteIndex"],
     buf: "InMemoryBuffer",
-) -> typing.Optional[list[int]]:
+) -> typing.Optional[tuple["array.array", int]]:
     """Seed the candidate set from the byte index instead of scanning.
 
     Picks the most selective unmasked run (1-byte or 2-byte) via Dynamic Seed
     Selection, maps its hits back to candidate pattern-starts, and refines
     against the rest of the pattern so the result equals matches(full pattern).
-    Returns the candidate offsets, or None if the index is unavailable or the
-    pattern has no exact byte at all (caller falls back to a scan).
+    Returns (candidates_array, count), or None if the index is unavailable or
+    the pattern has no exact byte at all (caller falls back to a scan).
     """
     if index is None:
         return None
@@ -1660,16 +1682,17 @@ def _seed_via_index(
     raw = index.candidates(key) if width == 2 else index.candidates1(key)
     # Map each hit at offset p back to a pattern start p - s, keeping only
     # candidates whose full pattern fits in the buffer.
-    cands = [p - s for p in raw if p >= s and (p - s) + m <= n]
+    cands = array.array("I", (p - s for p in raw if p >= s and (p - s) + m <= n))
     # n-1 boundary: candidates1 is derived from 2-byte windows, which never see
     # offset n-1 as a window start, so a 1-byte hit at the final buffer byte is
     # missing. It can only yield a valid pattern start when the seed byte is the
     # pattern's last byte (s == m-1, giving start n-m). Add it explicitly and
-    # let _refine_offsets validate.
+    # let the refine validate.
     if width == 1 and n >= 1 and data_mv[n - 1] == key:
         p = n - 1 - s
         if 0 <= p and p + m <= n:
             cands.append(p)
+    count = len(cands)
     # Refine against every exact byte except the seed run's byte(s).
     seed_span = (s, s + 1) if width == 2 else (s,)
     for j in range(m):
@@ -1678,8 +1701,8 @@ def _seed_via_index(
         sb = sig[j]
         if sb.is_wildcard:
             continue
-        cands = _refine_offsets(data_mv, cands, j, sb.value, 0xFF)
-    return cands
+        count = _refine_offsets_into(data_mv, cands, count, j, sb.value, 0xFF)
+    return cands, count
 
 
 def _decode_function_for_anchors(
@@ -1874,8 +1897,10 @@ class MinimalFunctionSignatureGenerator:
         fields for the live wait-box display.
         """
         sig = Signature()
-        # SIMD seed-then-refine state (see UniqueSignatureGenerator.generate).
-        offsets: typing.Optional[list[int]] = None
+        # SIMD seed-then-refine state: candidates as a uint32 array.array plus a
+        # live count, refined in place by the Cython refine_offsets.
+        offsets: typing.Optional["array.array"] = None
+        ocount = 0
         seed_buf = buf
         min_useful = self.MIN_USEFUL_SIG_BYTES
         for i in range(anchor_idx, len(decoded)):
@@ -1917,26 +1942,30 @@ class MinimalFunctionSignatureGenerator:
                 # so fall back to the per-step rescan.
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
-                # Seed once. Prefer the byte index (O(1) lookup via Dynamic
-                # Seed Selection); fall back to a full scan if the index is
-                # unavailable or the pattern has no exact 2-byte run to key on.
+                # Seed once. Prefer the byte index (Dynamic Seed Selection);
+                # fall back to a full scan only when the pattern has no exact
+                # byte to key on.
                 seeded = _seed_via_index(sig, index, seed_buf)
                 if seeded is None:
-                    offsets, seed_buf = SignatureSearcher.find_all_offsets(
+                    lst, seed_buf = SignatureSearcher.find_all_offsets(
                         f"{sig:ida}", buf=seed_buf
                     )
+                    offsets = array.array("I", lst)
+                    ocount = len(offsets)
                 else:
-                    offsets = seeded
-                count = len(offsets)
+                    offsets, ocount = seeded
+                count = ocount
             else:
-                # Refine the surviving candidates in memory for each byte
+                # Refine the surviving candidates in place for each byte
                 # appended this iteration; no rescan of the database.
                 data_mv = seed_buf.data()
                 for j in range(prev_len, len(sig)):
                     sb = sig[j]
                     mask = 0x00 if sb.is_wildcard else 0xFF
-                    offsets = _refine_offsets(data_mv, offsets, j, sb.value, mask)
-                count = len(offsets)
+                    ocount = _refine_offsets_into(
+                        data_mv, offsets, ocount, j, sb.value, mask
+                    )
+                count = ocount
 
             if progress is not None:
                 progress.inner_length = len(sig)

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1603,15 +1603,18 @@ class _ByteIndex:
 
 def _select_seed_run(
     sig: "Signature", index: "_ByteIndex"
-) -> typing.Optional[tuple[int, int]]:
-    """Pick the exact (unmasked) 2-byte run in sig whose index bucket is
-    smallest, to minimize the initial candidate set (Dynamic Seed Selection).
+) -> typing.Optional[tuple[int, int, int]]:
+    """Pick the unmasked run (2-byte or single byte) with the smallest index
+    bucket (Dynamic Seed Selection), returning (offset, width, key).
 
-    Returns (relative_offset, key), or None if sig has no run of two
-    consecutive exact bytes.
+    Minimizing over both widths is a superset of the 2-byte-only choice, so
+    the chosen bucket is always <= a 2-byte-only pick: C0 is strictly
+    smaller-or-equal. A rare single byte can beat a common 2-byte run.
+    Returns None only when sig has no exact byte at all.
     """
-    best: typing.Optional[tuple[int, int, int]] = None  # (size, offset, key)
-    for j in range(len(sig) - 1):
+    best: typing.Optional[tuple[int, int, int, int]] = None  # (size, offset, width, key)
+    m = len(sig)
+    for j in range(m - 1):
         a = sig[j]
         b = sig[j + 1]
         if a.is_wildcard or b.is_wildcard:
@@ -1619,10 +1622,17 @@ def _select_seed_run(
         key = (a.value << 8) | b.value
         size = index.bucket_size(key)
         if best is None or size < best[0]:
-            best = (size, j, key)
+            best = (size, j, 2, key)
+    for j in range(m):
+        sb = sig[j]
+        if sb.is_wildcard:
+            continue
+        size = index.bucket_size1(sb.value)
+        if best is None or size < best[0]:
+            best = (size, j, 1, sb.value)
     if best is None:
         return None
-    return best[1], best[2]
+    return best[1], best[2], best[3]
 
 
 def _seed_via_index(
@@ -1632,27 +1642,38 @@ def _seed_via_index(
 ) -> typing.Optional[list[int]]:
     """Seed the candidate set from the byte index instead of scanning.
 
-    Picks the most selective exact 2-byte run (Dynamic Seed Selection), maps
-    its hits back to candidate pattern-starts, and refines against the rest of
-    the pattern so the result equals matches(full pattern). Returns the
-    candidate offsets, or None if the index is unavailable or the pattern has
-    no exact 2-byte run (caller falls back to a scan).
+    Picks the most selective unmasked run (1-byte or 2-byte) via Dynamic Seed
+    Selection, maps its hits back to candidate pattern-starts, and refines
+    against the rest of the pattern so the result equals matches(full pattern).
+    Returns the candidate offsets, or None if the index is unavailable or the
+    pattern has no exact byte at all (caller falls back to a scan).
     """
     if index is None:
         return None
     run = _select_seed_run(sig, index)
     if run is None:
         return None
-    s, key = run
+    s, width, key = run
     data_mv = buf.data()
     n = len(data_mv)
     m = len(sig)
-    # Map each 2-byte hit at offset p back to a pattern start p - s, keeping
-    # only candidates whose full pattern fits in the buffer.
-    cands = [p - s for p in index.candidates(key) if p >= s and (p - s) + m <= n]
-    # Refine against every exact byte except the two seed-run bytes.
+    raw = index.candidates(key) if width == 2 else index.candidates1(key)
+    # Map each hit at offset p back to a pattern start p - s, keeping only
+    # candidates whose full pattern fits in the buffer.
+    cands = [p - s for p in raw if p >= s and (p - s) + m <= n]
+    # n-1 boundary: candidates1 is derived from 2-byte windows, which never see
+    # offset n-1 as a window start, so a 1-byte hit at the final buffer byte is
+    # missing. It can only yield a valid pattern start when the seed byte is the
+    # pattern's last byte (s == m-1, giving start n-m). Add it explicitly and
+    # let _refine_offsets validate.
+    if width == 1 and n >= 1 and data_mv[n - 1] == key:
+        p = n - 1 - s
+        if 0 <= p and p + m <= n:
+            cands.append(p)
+    # Refine against every exact byte except the seed run's byte(s).
+    seed_span = (s, s + 1) if width == 2 else (s,)
     for j in range(m):
-        if j == s or j == s + 1:
+        if j in seed_span:
             continue
         sb = sig[j]
         if sb.is_wildcard:

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -5,7 +5,7 @@ from libc.stdlib cimport malloc, free
 from libc.string cimport memcmp, memchr
 
 from cpython cimport array       # compile-time: C-level array.array type + array.clone
-import array as py_arr_mod        # run-time: the Python array module (constructor)
+import array as py_stdlib_arr_mod        # run-time: the Python array module (constructor)
 
 from sigmaker._speedups.simd_scan cimport Signature, SimdLevel, simd_support_best_level
 
@@ -723,12 +723,12 @@ def build_byte_index(const unsigned char[:] data_view):
     during the build. Buffers use array.clone (no oversized temporaries).
     """
     cdef Py_ssize_t n = data_view.shape[0]
-    cdef array.array heads = array.clone(py_arr_mod.array('I'), 65537, zero=True)
-    cdef array.array positions = array.clone(py_arr_mod.array('I'), 0, zero=False)
+    cdef array.array heads = array.clone(py_stdlib_arr_mod.array('I'), 65537, zero=True)
+    cdef array.array positions = array.clone(py_stdlib_arr_mod.array('I'), 0, zero=False)
     if n < 2:
         return heads, positions
 
-    positions = array.clone(py_arr_mod.array('I'), n - 1, zero=False)
+    positions = array.clone(py_stdlib_arr_mod.array('I'), n - 1, zero=False)
     cdef unsigned int[:] h = heads
     cdef unsigned int[:] pos = positions
     cdef const unsigned char* d = &data_view[0]

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -4,8 +4,8 @@ from libc.stdint cimport uint8_t
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcmp, memchr
 
-from cpython cimport array
-import array
+from cpython cimport array       # compile-time: C-level array.array type + array.clone
+import array as py_arr_mod        # run-time: the Python array module (constructor)
 
 from sigmaker._speedups.simd_scan cimport Signature, SimdLevel, simd_support_best_level
 
@@ -723,12 +723,12 @@ def build_byte_index(const unsigned char[:] data_view):
     during the build. Buffers use array.clone (no oversized temporaries).
     """
     cdef Py_ssize_t n = data_view.shape[0]
-    cdef array.array heads = array.clone(array.array('I'), 65537, zero=True)
-    cdef array.array positions = array.clone(array.array('I'), 0, zero=False)
+    cdef array.array heads = array.clone(py_arr_mod.array('I'), 65537, zero=True)
+    cdef array.array positions = array.clone(py_arr_mod.array('I'), 0, zero=False)
     if n < 2:
         return heads, positions
 
-    positions = array.clone(array.array('I'), n - 1, zero=False)
+    positions = array.clone(py_arr_mod.array('I'), n - 1, zero=False)
     cdef unsigned int[:] h = heads
     cdef unsigned int[:] pos = positions
     cdef const unsigned char* d = &data_view[0]

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -759,3 +759,28 @@ def build_byte_index(const unsigned char[:] data_view):
     finally:
         free(wh)
     return heads, positions
+
+
+def refine_offsets(const unsigned char[:] data_view,
+                   unsigned int[:] cands,
+                   Py_ssize_t count,
+                   Py_ssize_t j,
+                   unsigned int value,
+                   unsigned int mask):
+    """Keep cands[0:count] entries c where (data_view[c+j] & mask) ==
+    (value & mask) and c + j < n, compacting survivors to the front of cands
+    in place. Returns the new count. nogil; no allocation.
+    """
+    cdef Py_ssize_t n = data_view.shape[0]
+    cdef unsigned int target = value & mask
+    cdef Py_ssize_t r = 0
+    cdef Py_ssize_t w = 0
+    cdef Py_ssize_t c
+    with nogil:
+        while r < count:
+            c = <Py_ssize_t>cands[r]
+            if c + j < n and (data_view[c + j] & mask) == target:
+                cands[w] = cands[r]
+                w += 1
+            r += 1
+    return w

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3797,6 +3797,31 @@ class TestSelectSeedRun(CoveredUnitTest):
         self.assertIsNone(sigmaker._select_seed_run(sig, self._index({})))
 
 
+class TestByteIndexOneByte(CoveredUnitTest):
+    """1-byte bucket accessors derived from the 2-byte index."""
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_bucket_size1_and_candidates1(self):
+        # 0x90 appears at offsets 0,2,4,6 but only 0,2,4 are 2-byte-window
+        # starts (offset 6 is the last byte, n-1, not a window start).
+        data = memoryview(bytearray(b"\x90\x01\x90\x02\x90\x03\x90"))
+        idx = sigmaker._ByteIndex.build(data)
+        self.assertEqual(sorted(idx.candidates1(0x90)), [0, 2, 4])
+        self.assertEqual(idx.bucket_size1(0x90), 3)
+        self.assertEqual(idx.bucket_size1(0xEE), 0)
+        self.assertEqual(idx.candidates1(0xEE), [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_bucket_size1_equals_sum_of_two_byte_buckets(self):
+        import random
+        rng = random.Random(7)
+        data = memoryview(bytearray(rng.randrange(256) for _ in range(4096)))
+        idx = sigmaker._ByteIndex.build(data)
+        for b in (0x00, 0x41, 0xFF):
+            two_byte_sum = sum(idx.bucket_size((b << 8) | x) for x in range(256))
+            self.assertEqual(idx.bucket_size1(b), two_byte_sum)
+
+
 class TestByteIndex(CoveredUnitTest):
     """The _ByteIndex holder over build_byte_index."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3753,9 +3753,9 @@ class TestSeedViaIndex(CoveredUnitTest):
             lambda key: [0, 6] if key == ((0x8B << 8) | 0x45) else []
         )
         idx.candidates1.side_effect = lambda b: []
-        out = sigmaker._seed_via_index(sig, idx, buf)
+        arr, cnt = sigmaker._seed_via_index(sig, idx, buf)
         # offset 0 keeps (90 90 90 follow); offset 6 drops (00 00 follow)
-        self.assertEqual(out, [0])
+        self.assertEqual(list(arr[:cnt]), [0])
 
     def test_one_byte_seed_path(self):
         # buffer: F3 at offsets 0 and 8; no 2-byte run is selectable, so the
@@ -3772,8 +3772,8 @@ class TestSeedViaIndex(CoveredUnitTest):
         idx.bucket_size.side_effect = lambda key: 10**9   # no 2-byte run chosen
         idx.bucket_size1.side_effect = lambda b: {0xF3: 2}.get(b, 10**9)
         idx.candidates1.side_effect = lambda b: [0, 8] if b == 0xF3 else []
-        out = sigmaker._seed_via_index(sig, idx, buf)
-        self.assertEqual(out, [0])
+        arr, cnt = sigmaker._seed_via_index(sig, idx, buf)
+        self.assertEqual(list(arr[:cnt]), [0])
 
     def test_returns_none_when_all_wildcard(self):
         buf = MagicMock()
@@ -3842,7 +3842,7 @@ class TestByteIndexOneByte(CoveredUnitTest):
         self.assertEqual(sorted(idx.candidates1(0x90)), [0, 2, 4])
         self.assertEqual(idx.bucket_size1(0x90), 3)
         self.assertEqual(idx.bucket_size1(0xEE), 0)
-        self.assertEqual(idx.candidates1(0xEE), [])
+        self.assertEqual(list(idx.candidates1(0xEE)), [])
 
     @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
     def test_bucket_size1_equals_sum_of_two_byte_buckets(self):
@@ -3907,7 +3907,8 @@ class TestIndexSeedEquivalence(CoveredUnitTest):
             for j in range(7):
                 is_wc = (j % 4 == 0)
                 sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
-            seeded = sigmaker._seed_via_index(sig, idx, buf)
+            _arr, _cnt = sigmaker._seed_via_index(sig, idx, buf)
+            seeded = list(_arr[:_cnt])
             expected = self._brute(data, sig)
             self.assertEqual(
                 sorted(seeded), sorted(expected),
@@ -3931,7 +3932,8 @@ class TestIndexSeedEquivalence(CoveredUnitTest):
             for j in range(7):
                 is_wc = (j % 2 == 1)
                 sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
-            seeded = sigmaker._seed_via_index(sig, idx, buf)
+            _arr, _cnt = sigmaker._seed_via_index(sig, idx, buf)
+            seeded = list(_arr[:_cnt])
             expected = self._brute(data, sig)
             self.assertEqual(sorted(seeded), sorted(expected),
                              f"anchor {anchor}: 1-byte path != brute force")
@@ -3953,7 +3955,8 @@ class TestIndexSeedEquivalence(CoveredUnitTest):
         for j in range(m):
             is_wc = (j != m - 1)  # only the last byte exact -> seed at s == m-1
             sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
-        seeded = sigmaker._seed_via_index(sig, idx, buf)
+        _arr, _cnt = sigmaker._seed_via_index(sig, idx, buf)
+        seeded = list(_arr[:_cnt])
         expected = self._brute(data, sig)
         self.assertEqual(sorted(seeded), sorted(expected))
         self.assertIn(anchor, seeded)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3959,6 +3959,68 @@ class TestIndexSeedEquivalence(CoveredUnitTest):
         self.assertIn(anchor, seeded)
 
 
+class TestRefineOffsetsCython(CoveredUnitTest):
+    """The in-place Cython candidate-refinement compactor."""
+
+    def _arr(self, items):
+        import array
+        return array.array("I", items)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_exact_byte_compacts_in_place(self):
+        data = memoryview(bytearray(b"\x90\x48\x90\x48\x90"))
+        cands = self._arr([0, 1, 2, 3])
+        n = sigmaker.simd_scan.refine_offsets(data, cands, 4, 1, 0x48, 0xFF)
+        self.assertEqual(n, 2)
+        self.assertEqual(list(cands[:n]), [0, 2])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_full_wildcard_keeps_all(self):
+        data = memoryview(bytearray(b"\x01\x02\x03\x04"))
+        cands = self._arr([0, 1, 2])
+        n = sigmaker.simd_scan.refine_offsets(data, cands, 3, 1, 0x00, 0x00)
+        self.assertEqual(n, 3)
+        self.assertEqual(list(cands[:n]), [0, 1, 2])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_nibble_mask(self):
+        data = memoryview(bytearray(b"\x4A\x4B\x9C"))
+        cands = self._arr([0, 1, 2])
+        n = sigmaker.simd_scan.refine_offsets(data, cands, 3, 0, 0x40, 0xF0)
+        self.assertEqual(n, 2)
+        self.assertEqual(list(cands[:n]), [0, 1])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_out_of_bounds_dropped(self):
+        data = memoryview(bytearray(b"\x90\x90"))
+        cands = self._arr([0, 1])
+        n = sigmaker.simd_scan.refine_offsets(data, cands, 2, 2, 0x90, 0xFF)
+        self.assertEqual(n, 0)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_empty(self):
+        data = memoryview(bytearray(b"\x90"))
+        cands = self._arr([])
+        n = sigmaker.simd_scan.refine_offsets(data, cands, 0, 0, 0x90, 0xFF)
+        self.assertEqual(n, 0)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_matches_python_refine(self):
+        import array, random
+        rng = random.Random(11)
+        data = bytes(rng.randrange(256) for _ in range(2048))
+        mv = memoryview(bytearray(data))
+        for _ in range(50):
+            cand_list = sorted(rng.sample(range(2000), 64))
+            j = rng.randrange(8)
+            value = rng.randrange(256)
+            mask = rng.choice([0x00, 0x0F, 0xF0, 0xFF])
+            py = sigmaker._refine_offsets(mv, list(cand_list), j, value, mask)
+            arr = array.array("I", cand_list)
+            n = sigmaker.simd_scan.refine_offsets(mv, arr, len(cand_list), j, value, mask)
+            self.assertEqual(sorted(arr[:n]), sorted(py))
+
+
 class TestBuildByteIndex(CoveredUnitTest):
     """The Cython 2-byte counting-sort index."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3745,21 +3745,43 @@ class TestSeedViaIndex(CoveredUnitTest):
         )
         idx = MagicMock()
         # 8B 45 is the most selective run, so Dynamic Seed Selection keys on
-        # it; other runs (90 90, 45 90) get a larger bucket so they lose.
+        # it; other runs (90 90, 45 90) and all 1-byte buckets get a larger
+        # bucket so they lose.
         idx.bucket_size.side_effect = lambda key: {(0x8B << 8) | 0x45: 2}.get(key, 10**9)
+        idx.bucket_size1.side_effect = lambda b: 10**9
         idx.candidates.side_effect = (
             lambda key: [0, 6] if key == ((0x8B << 8) | 0x45) else []
         )
+        idx.candidates1.side_effect = lambda b: []
         out = sigmaker._seed_via_index(sig, idx, buf)
         # offset 0 keeps (90 90 90 follow); offset 6 drops (00 00 follow)
         self.assertEqual(out, [0])
 
-    def test_returns_none_when_no_run(self):
+    def test_one_byte_seed_path(self):
+        # buffer: F3 at offsets 0 and 8; no 2-byte run is selectable, so the
+        # single byte F3 is the seed. offset 0 fits a 5-byte pattern; offset 8
+        # does not (8 + 5 > 10) and is dropped by the fit guard.
+        buf = MagicMock()
+        buf.data.return_value = memoryview(
+            bytearray(b"\xf3\x90\x90\x90\x90\x00\x00\x00\xf3\x00")
+        )
+        sig = self._sig(
+            [(0xF3, False), (0x90, True), (0x90, True), (0x90, True), (0x90, True)]
+        )
+        idx = MagicMock()
+        idx.bucket_size.side_effect = lambda key: 10**9   # no 2-byte run chosen
+        idx.bucket_size1.side_effect = lambda b: {0xF3: 2}.get(b, 10**9)
+        idx.candidates1.side_effect = lambda b: [0, 8] if b == 0xF3 else []
+        out = sigmaker._seed_via_index(sig, idx, buf)
+        self.assertEqual(out, [0])
+
+    def test_returns_none_when_all_wildcard(self):
         buf = MagicMock()
         buf.data.return_value = memoryview(bytearray(b"\x90" * 10))
-        sig = self._sig([(0x90, True), (0x91, False), (0x92, True)])
+        sig = self._sig([(0x90, True), (0x91, True)])  # no exact byte at all
         idx = MagicMock()
-        idx.bucket_size.return_value = 0
+        idx.bucket_size.return_value = 10**9
+        idx.bucket_size1.return_value = 10**9
         self.assertIsNone(sigmaker._seed_via_index(sig, idx, buf))
 
     def test_returns_none_when_index_none(self):
@@ -3770,7 +3792,7 @@ class TestSeedViaIndex(CoveredUnitTest):
 
 
 class TestSelectSeedRun(CoveredUnitTest):
-    """Dynamic Seed Selection: pick the smallest-bucket exact 2-byte run."""
+    """Dynamic Seed Selection across 1-byte and 2-byte runs."""
 
     def _sig(self, specs):  # specs: list[(value, is_wildcard)]
         sig = sigmaker.Signature()
@@ -3778,22 +3800,33 @@ class TestSelectSeedRun(CoveredUnitTest):
             sig.append(sigmaker.SignatureByte(v, w))
         return sig
 
-    def _index(self, sizes):
+    def _index(self, two_byte_sizes, one_byte_sizes=None):
+        one_byte_sizes = one_byte_sizes or {}
         idx = MagicMock()
-        idx.bucket_size.side_effect = lambda key: sizes.get(key, 0)
+        idx.bucket_size.side_effect = lambda key: two_byte_sizes.get(key, 10**9)
+        idx.bucket_size1.side_effect = lambda b: one_byte_sizes.get(b, 10**9)
         return idx
 
-    def test_picks_smallest_bucket_run(self):
-        # pattern: ?? 00 00 ?? 8B 45  -> exact runs (1,"00 00") and (4,"8B 45")
+    def test_picks_smallest_two_byte_run(self):
+        # ?? 00 00 ?? 8B 45 ; 8B 45 is the most selective run -> width 2
         sig = self._sig(
             [(0, True), (0, False), (0, False), (0, True), (0x8B, False), (0x45, False)]
         )
-        sizes = {(0x00 << 8) | 0x00: 4_000_000, (0x8B << 8) | 0x45: 12}
-        run = sigmaker._select_seed_run(sig, self._index(sizes))
-        self.assertEqual(run, (4, (0x8B << 8) | 0x45))
+        two = {(0x00 << 8) | 0x00: 4_000_000, (0x8B << 8) | 0x45: 12}
+        run = sigmaker._select_seed_run(sig, self._index(two))
+        self.assertEqual(run, (4, 2, (0x8B << 8) | 0x45))
 
-    def test_returns_none_when_no_two_exact_bytes(self):
-        sig = self._sig([(0, True), (0x8B, False), (0, True), (0x45, False)])
+    def test_rare_one_byte_beats_common_two_byte(self):
+        # 00 00 ?? F3 : the only 2-byte run is 00 00 (common); F3 is a rare
+        # single byte -> selection prefers the 1-byte key (width 1).
+        sig = self._sig([(0x00, False), (0x00, False), (0, True), (0xF3, False)])
+        two = {(0x00 << 8) | 0x00: 1_500_000}
+        one = {0x00: 3_000_000, 0xF3: 800}
+        run = sigmaker._select_seed_run(sig, self._index(two, one))
+        self.assertEqual(run, (3, 1, 0xF3))
+
+    def test_returns_none_when_no_exact_byte(self):
+        sig = self._sig([(0, True), (0, True)])
         self.assertIsNone(sigmaker._select_seed_run(sig, self._index({})))
 
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3915,6 +3915,49 @@ class TestIndexSeedEquivalence(CoveredUnitTest):
             )
             self.assertIn(anchor, seeded)
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_wildcard_heavy_one_byte_path_equals_brute_force(self):
+        import random
+        rng = random.Random(2026)
+        data = bytes(rng.randrange(256) for _ in range(8192))
+        mv = memoryview(bytearray(data))
+        idx = sigmaker._ByteIndex.build(mv)
+        buf = MagicMock()
+        buf.data.return_value = mv
+        for anchor in (33, 777, 5000):
+            sig = sigmaker.Signature()
+            # heavy wildcarding so no 2 consecutive exact bytes: every other
+            # byte is a wildcard -> forces the 1-byte seed path.
+            for j in range(7):
+                is_wc = (j % 2 == 1)
+                sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
+            seeded = sigmaker._seed_via_index(sig, idx, buf)
+            expected = self._brute(data, sig)
+            self.assertEqual(sorted(seeded), sorted(expected),
+                             f"anchor {anchor}: 1-byte path != brute force")
+            self.assertIn(anchor, seeded)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_end_of_buffer_pattern_found(self):
+        # Pattern at the very end of the buffer, with its only exact byte as
+        # the last pattern byte -> exercises the n-1 boundary handling.
+        data = bytes(range(256)) * 32  # 8192 bytes, last byte 0xFF
+        mv = memoryview(bytearray(data))
+        idx = sigmaker._ByteIndex.build(mv)
+        buf = MagicMock()
+        buf.data.return_value = mv
+        n = len(data)
+        m = 5
+        anchor = n - m  # pattern occupies the final 5 bytes
+        sig = sigmaker.Signature()
+        for j in range(m):
+            is_wc = (j != m - 1)  # only the last byte exact -> seed at s == m-1
+            sig.append(sigmaker.SignatureByte(data[anchor + j], is_wc))
+        seeded = sigmaker._seed_via_index(sig, idx, buf)
+        expected = self._brute(data, sig)
+        self.assertEqual(sorted(seeded), sorted(expected))
+        self.assertIn(anchor, seeded)
+
 
 class TestBuildByteIndex(CoveredUnitTest):
     """The Cython 2-byte counting-sort index."""


### PR DESCRIPTION
## Background

This continues the function-search performance work (after PR #33 Phase 1 and PR #35 Phase 2). It bundles two phases that build on each other, so they ship as one PR off `main`.

The native profile after Phase 2 showed the cost had moved twice: first to the per-anchor seed scan, then, once that was indexed, to candidate refinement. This PR closes both. I also wrote up the full algorithm and the math behind it in `ALGORITHM.md`.

## Phase 3: Dynamic Seed Selection (1-byte or 2-byte)

The Phase 2 index seeds a search from an exact 2-byte run. But a single rare byte can be more selective than a common 2-byte pair, and a pattern often has several exact runs. Phase 3 picks the run with the smallest index bucket across both widths.

The 1-byte buckets come for free from the existing 2-byte index: all 256 keys with a given high byte occupy a contiguous block of `positions`, so the 1-byte bucket size is `heads[(b+1)<<8] - heads[b<<8]` and its candidate list is a single slice. No second index, no extra memory. One boundary correction handles the final database byte, which is never a 2-byte window start.

Effect on the warden module's largest function: per-anchor seed scans dropped from 206 to 2.

## Phase 4: Cython in-place candidate refinement

With seeding indexed, refinement became the bottleneck: the pure-Python `_refine_offsets` list comprehension was called ~165,000 times for ~14s on that one function. Phase 4 moves the per-byte refine into the Cython extension as `refine_offsets`: a `nogil` two-pointer compaction over a typed `uint32` candidate buffer (`array.array('I')`), in place, with zero per-call allocation. The same buffer is both the Python-visible candidate list and the C-level `uint32*` the kernel compacts, so candidates cross the boundary with no marshalling.

The pure-Python `_refine_offsets` is kept for the create-unique path and as the test oracle; a cross-check property test pins the two implementations together.

## Changes

| Commit | Change |
|--------|--------|
| `9699e74` | Add 1-byte bucket accessors derived from the 2-byte index |
| `1a4c748` | Seed on the most selective 1-byte or 2-byte run; handle n-1 boundary |
| `0222afe` | Extend index-seed equivalence tests: 1-byte path and end-of-buffer |
| `404683e` | Add Cython `refine_offsets`: in-place `nogil` candidate compaction |
| `91857bc` | Route function-sig candidate refine through `array.array` + Cython `refine_offsets` |
| `e036752` | Convert `_ByteIndex` to a frozen slots dataclass |
| `7af2b4e` | Add `ALGORITHM.md`: math, novelty, and Cython mechanics |
| `53bef5b` | Alias the runtime array module as `py_arr_mod` in `simd_scan.pyx` |

## Net behavior

On the warden 16 MB module's largest function (8486 bytes, native idalib):

| Stage | Before | After |
|-------|--------|-------|
| Refinement (`_refine_offsets` to Cython `refine_offsets`) | ~14s, 165k calls | ~0.28s |
| Function total | ~24s | ~15.6s |

Signatures are byte-identical to Phase 3 across all 83 functions of the test binary (full all-functions diff, empty). The remaining cost is now the two seed-scan fallbacks (`find_all_offsets`, ~8.7s for 2 calls) for anchors the index cannot serve; that is the next phase, not this one.

Production defaults are unchanged. The create-unique path and the public API surface are untouched.

## Verification

| Suite | Baseline (`origin/main`) | This branch |
|-------|--------------------------|-------------|
| Host unit | Ran 209, OK | Ran 221, OK |
| Docker `idapro-tests` (9.0) | (integration unchanged) | Ran 239, OK |
| Docker `idapro-tests-9.2` | (integration unchanged) | Ran 239, OK |

The +12 host tests are the new index/seed/refine unit tests; the integration suites are unchanged, so the Docker totals reflect zero integration regressions. The `.so` rebuilds cleanly in both Docker images.

## Test plan

- [ ] Build the extension: `python setup.py build_ext --inplace`
- [ ] Host unit: `python -m unittest tests.unit_test_sigmaker -v` (expect 221 OK)
- [ ] Both Docker images via `docker compose run` (expect 239 OK each)
- [ ] In IDA: "Find shortest unique signature for current function" on a large function returns a correct, unique signature with the wait-box barely appearing

## Notes

`ALGORITHM.md` documents the match-set monotonicity that makes seed-then-refine valid, the counting-sort index, the 1-byte telescoping identity, the in-place refine, what is novel, and why Cython is what makes it practical (including a note on the `cimport array` vs `import array as py_arr_mod` split).

Real-world confirmation from OshidaBCF on #27 after these changes: "it's indeed very very fast, window barely show up for a 26 byte signature."
