### PR TITLE
deploy: fix retired macos-13 runner, pin ubuntu-24.04, add linux-arm wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,14 @@ jobs:
             matrix:
                 include:
                     - os: linux-intel
-                      runs-on: ubuntu-latest
+                      runs-on: ubuntu-24.04
+                    - os: linux-arm
+                      runs-on: ubuntu-24.04-arm
                     - os: windows-intel
                       runs-on: windows-latest
                     - os: macos-intel
-                      # macos-13 was the last x86_64 runner
-                      runs-on: macos-13
+                      # macos-15-intel is the current x86_64 runner (macos-13 retired Dec 2025)
+                      runs-on: macos-15-intel
                     - os: macos-arm
                       # macos-14+ (including latest) are ARM64 runners
                       runs-on: macos-latest


### PR DESCRIPTION
## Background

PyPI has been frozen at **1.6.0**: every release since (1.7.0 through 1.8.0) built most wheels but never uploaded. Root cause: `deploy.yml`'s `build_wheels` matrix included `macos-13`, which GitHub [retired in December 2025](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). The `macos-intel` job queues forever, and `upload_to_pypi` has `needs: [build_wheels, build_sdist]`, so the PyPI publish never runs.

## Changes

- `macos-intel`: `macos-13` to **`macos-15-intel`** (the current and last x86_64 macOS image, supported until Aug 2027).
- `linux-intel`: `ubuntu-latest` pinned to **`ubuntu-24.04`** for determinism.
- New **`linux-arm`** leg on **`ubuntu-24.04-arm`** for native aarch64 Linux wheels (no QEMU).

Matrix is now: linux-intel, linux-arm, windows-intel, macos-intel, macos-arm, plus the sdist.

## Net effect

Unblocks the PyPI upload and adds aarch64 Linux coverage. After merge, re-running the Release workflow for `v1.8.0` fires `workflow_run` to deploy, which builds all five wheels + sdist on live runners and publishes 1.8.0 (`skip-existing: true` is set).
