### PR TITLE
Phase 5/6: Cython seed map + defer-seed (worst-case 12s to ~1s)

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -11,6 +11,22 @@ GitHub renders LaTeX in Markdown, so the math below is in `$...$` (inline) and
 
 ---
 
+## Contents
+
+- [1. The problem](#1-the-problem)
+- [2. The naive cost, and where 462 seconds went](#2-the-naive-cost-and-where-462-seconds-went)
+- [3. Monotonic shrinkage: seed once, then refine](#3-monotonic-shrinkage-seed-once-then-refine)
+- [4. The 2-byte position index (counting sort)](#4-the-2-byte-position-index-counting-sort)
+- [5. Dynamic Seed Selection (1-byte or 2-byte) from one index](#5-dynamic-seed-selection-1-byte-or-2-byte-from-one-index)
+- [6. In-place refinement on a typed buffer](#6-in-place-refinement-on-a-typed-buffer)
+- [7. Complexity summary](#7-complexity-summary)
+- [8. Relationship to known string algorithms](#8-relationship-to-known-string-algorithms)
+- [9. What is novel here](#9-what-is-novel-here)
+- [10. Future algorithmic directions](#10-future-algorithmic-directions)
+- [11. Rejected optimizations](#11-rejected-optimizations)
+- [12. How Cython makes it work](#12-how-cython-makes-it-work)
+- [13. References](#13-references)
+
 ## 1. The problem
 
 A database $D$ is the concatenation of the analyzed program's segment bytes,
@@ -223,11 +239,13 @@ richer seed family would add index complexity without new selectivity. It is
 worth revisiting only if profiling ever shows seed enumeration, not refinement,
 to be the bottleneck (see Section 10).
 
-**Deferred seeding.** For a pattern shorter than `MIN_USEFUL_SIG_BYTES` $= 5$, even
-the rarest run is too common (the seed would enumerate a large fraction of $D$),
-so seeding is deferred and a direct scan is used until the pattern is long enough
-to be selective. This avoids materializing a multi-million-entry seed for a 2-byte
-pattern.
+**Deferred seeding.** Two cases skip the index seed and wait. First, for a pattern
+shorter than `MIN_USEFUL_SIG_BYTES` $= 5$, even the rarest run is too common (the
+seed would enumerate a large fraction of $D$), so seeding waits until the pattern
+is long enough to be selective. Second, when the seedable prefix is all wildcards
+there is no exact byte to key the index on at all; rather than fall back to a full
+$O(N)$ masked scan, seeding is deferred until an exact byte appears. Both avoid
+materializing, or scanning for, a seed that cannot be selective yet.
 
 ## 6. In-place refinement on a typed buffer
 
@@ -340,32 +358,70 @@ specialization, and how cheaply the pieces combine for masked function signature
 
 ## 10. Future algorithmic directions
 
-The current implementation is intentionally conservative. In priority order:
+The current implementation is intentionally conservative. The instrumentation this
+section used to call for has since been done: seed bucket size $C_0$, informative
+refinement steps $R$, wildcard density, and the candidate-decay curve. It
+redirected the effort. The real costs were a Python seed-enumeration loop (now in
+C, Section 12) and a needless full scan on all-wildcard prefixes (now deferred,
+Section 5), not a fancier seed. Richer seed families (longer contiguous, spaced,
+or multi-context seeds) were measured and shelved; see Section 11. The one open
+direction that remains:
 
-1. **Empirical instrumentation first.** Before any new algorithm, runtime reports
-   should record the seed bucket size $C_0$, the number of *informative*
-   refinement steps $R$, the wildcard density, and the empirical candidate-decay
-   curve. Those measurements separate the contributions of the index, the seed
-   selector, the wildcard policy, and the Cython kernels, and they decide whether
-   the directions below are worth pursuing at all.
-
-2. **Richer seeds only if seeding dominates.** If, and only if, the instrumentation
-   shows seed enumeration (not refinement) is the bottleneck, longer contiguous
-   exact-run indexes or spaced/gapped seeds become worth their added structure.
-   Until then the contiguous 1-byte/2-byte seed is sufficient (Section 5).
-
-3. **Exact LSUS baseline.** When wildcarding is disabled, or a long exact region
+1. **Exact LSUS baseline.** When wildcarding is disabled, or a long exact region
    dominates the signature, a suffix-array/LCP LSUS baseline is a useful reference
    for both answer length and runtime.
 
-## 11. How Cython makes it work
+## 11. Rejected optimizations
+
+A couple of ideas looked good on paper, and the reasoning for skipping them is more
+useful than the verdict, so it is worth writing down.
+
+Both got the same treatment: profile the worst functions, then build a small
+adversarial benchmark that deliberately constructs each idea's best case and check
+whether it actually wins. Neither did, because the profile kept pointing somewhere
+else. Not the index build (~0.05 s), and after the seed map was moved into C, not
+the refine kernel either (~0.1 s), but two boring things we had left on the table:
+an $O(C_0)$ loop still mapping seed candidates in pure Python one boxed integer at
+a time, and a full $O(N)$ scan that fired whenever a pattern began with nothing but
+wildcards. Fixing those is what moved the numbers. Everything below is what we
+talked ourselves out of along the way.
+
+**Block refinement.** The obvious next idea is to group the exact bytes into runs
+and compare a whole run at once with a wide `uint64` or SIMD load, skipping the
+wildcard gaps, on the theory that fewer instructions means less time. The benchmark
+says otherwise: refinement is bound by memory bandwidth, not instruction count. It
+is already a tight, linear, stride-1 sweep, which is the access pattern a CPU
+streams fastest, so wider-but-fewer compares do nothing for a loop that is waiting
+on memory rather than on the ALU. The premise was also weaker than it looked, since
+the expensive filtering pass already skips wildcards (Section 3). With refinement
+sitting around 0.1 s, there was simply nothing here worth chasing.
+
+**Spaced-seed intersection.** The index has a tempting property: each bucket's
+positions come out already sorted, because we fill them in one left-to-right pass
+over the database. So for a spaced pattern like `8B ?? ?? 45` you could grab both
+byte buckets and intersect them with a two-pointer merge. The problem is that we
+already do exactly this, just more cheaply: seeding from the rarest byte and
+refining against the rest *is* that intersection, and it only ever touches the
+smaller bucket. An explicit merge has to read both buckets end to end, which is
+strictly more work the moment one of them is a common byte with millions of
+entries. And once deferred seeding keeps the starting set small, the merge is pure
+overhead; no input in the benchmark ever reached the point where it paid off.
+
+The honest summary is that the wins were never algorithmic. They were "stop running
+this loop in Python" and "don't scan the whole database for a prefix that can't
+anchor anything", the kind of thing you only find by measuring, not by reaching for
+a cleverer data structure. The microbenchmark stays in the tree with a `--check`
+mode, so if some later change pushes the bottleneck back onto refinement, it will
+fail loudly and these two ideas get a fresh hearing.
+
+## 12. How Cython makes it work
 
 The math above is correct in pure Python too, but it would not be *fast* in pure
-Python. The two hot kernels, the index build and the per-step refine, are
-memory-bound, branchy loops over millions of bytes. That is precisely the
-workload where CPython's per-element overhead (boxed integers, attribute lookups,
-interpreter dispatch, dynamic bounds checks) costs 50-100x. The `_speedups`
-extension compiles them to tight C:
+Python. The hot kernels, the index build, the seed-candidate map, and the per-step
+refine, are memory-bound, branchy loops over millions of bytes. That is precisely
+the workload where CPython's per-element overhead (boxed integers, attribute
+lookups, interpreter dispatch, dynamic bounds checks) costs 50-100x. The
+`_speedups` extension compiles them to tight C:
 
 - **`build_byte_index`** is the counting sort of Section 4, written as C loops
   over a `const unsigned char[:]` typed memoryview, running under `nogil` so the
@@ -377,6 +433,14 @@ extension compiles them to tight C:
   function into Cython dropped the refinement time on the largest test module
   from **~14 s** (a Python list comprehension called ~165k times) to **~0.28 s**,
   roughly **50x**.
+
+- **`seed_offsets`** is the candidate-mapping kernel of Section 5: a `nogil` loop
+  that turns a seed bucket into the `array.array('I')` of pattern starts (the
+  `p - s` shift, the fit guard, the $N-1$ boundary case) in C. This was the last
+  `O(C_0)` loop left in Python, a generator expression that boxed and walked the
+  entire bucket; moving it into Cython cut the worst observed function search from
+  **~12 s** to **~1 s**, the same playbook as `refine_offsets`, cross-checked
+  against the Python version for byte-identical output.
 
 - **`array.array('I')` is the bridge.** A candidate set is simultaneously a
   first-class Python object the orchestration layer can slice and return, *and*
@@ -425,7 +489,7 @@ the run-time Python constructor. They no longer share a name, so there is nothin
 to "override". (The canonical Cython array tutorial shows both lines sharing the
 name `array`; aliasing one side is the same idiom, just spelled out.)
 
-## 12. References
+## 13. References
 
 - Larissa L. M. Aguiar and Felipe A. Louza, ["Faster computation of
   left-bounded shortest unique substrings"](https://doi.org/10.1186/s13015-025-00287-5),

--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -1,10 +1,9 @@
 # The shortest-unique-signature algorithm
 
 This document explains the math behind the "find shortest unique signature for
-the current function" search, where the approach fits relative to known string
-algorithms, and how the Cython `_speedups` extension is what makes it practical.
-It is written for someone who wants to understand *why* the search is fast, not
-just *what* the code does.
+the current function" search, how it relates to known string algorithms, and why
+the Cython `_speedups` extension is what makes it practical. It's for someone who
+wants to understand *why* the search is fast, not just *what* the code does.
 
 GitHub renders LaTeX in Markdown, so the math below is in `$...$` (inline) and
 `$$...$$` (block) form.
@@ -81,7 +80,7 @@ $$
 
 When the search has to consider several anchors (growing outside the function
 boundary, or comparing several candidate start points), it becomes
-$O(A \cdot L \cdot N)$ for $A$ anchors. On a real 16 MB module a single function
+$O(A \cdot L \cdot N)$ for $A$ anchors. On a real 16 MB module, a single function
 took **462 s**. The whole optimization is about removing the two multiplicative
 factors $L$ and $A$ from the $N$ term.
 
@@ -110,8 +109,8 @@ $$
 
 work, proportional to the *current candidate count*, not $N$.
 
-That monotonicity is the reason the algorithm is fast in practice, but it does
-not by itself give an unconditional telescoping bound. If the seed set has size
+That monotonicity is why the search is fast in practice, but on its own it does
+not give an unconditional telescoping bound. If the seed set has size
 $C_0$ and there are $R$ refinement steps after the seed, monotonicity only gives
 
 $$
@@ -175,8 +174,9 @@ $$
 T_{\text{build}} = O(N), \qquad S_{\text{build}} = O(N + 2^{16}).
 $$
 
-Built once, amortized across **all** anchors. With the index in hand, seeding a
-pattern that contains an exact 2-byte run at offset $s$ with key $k$ costs only
+That work pays off because building the index is $O(N)$ and it can be reused
+across **all** anchors. With it in hand, seeding a pattern that contains an exact
+2-byte run at offset $s$ with key $k$ costs only
 
 $$
 O(|B_k|): \quad M_{\text{seed}} = \lbrace p - s : p \in B_k, \ \text{pattern fits} \rbrace,
@@ -206,8 +206,8 @@ $$
 $$
 
 and the 1-byte candidate list is the single slice
-`positions[heads[b<<8] : heads[(b+1)<<8]]`. No second index, no extra memory, no
-rescan. (One boundary fix: position $N-1$ is never a 2-byte window *start*, so a
+`positions[heads[b<<8] : heads[(b+1)<<8]]`, with no second index, no extra memory,
+and no rescan. (One boundary fix: position $N-1$ is never a 2-byte window *start*, so a
 1-byte hit on the final database byte is added explicitly when it can yield a
 valid pattern start.)
 
@@ -217,9 +217,8 @@ $$
 (s^\ast, w^\ast) = \arg\min_{(s, w) \in \text{exact runs}} \bigl|B^{(w)}_{\text{key}(s,w)}\bigr|.
 $$
 
-This is a deliberately small contiguous-seed family: fully exact 1-byte and
-2-byte anchors. Since the 1-byte options are a *superset* of the candidate seeds,
-the chosen seed bucket is never worse than a 2-byte-only choice:
+Since the 1-byte options are a *superset* of the candidate seeds, the chosen seed
+bucket is never worse than a 2-byte-only choice:
 
 $$
 C_0 = \bigl|B^{(w^\ast)}\bigr| \le \min_{\text{2-byte runs}} |B_k|.
@@ -286,12 +285,13 @@ $$
 versus the naive $O(A \cdot L \cdot N)$. The $N$ term is paid **once** and shared;
 all per-anchor database-wide work is replaced by work over the chosen seed bucket
 and its surviving candidates. In the worst case refinement can still be
-$O(RC_0)$, but real runs are expected to be close to geometric decay when exact
-bytes are selective.
+$O(RC_0)$, but in practice it decays close to geometrically when the exact bytes
+are selective.
 
 ## 8. Relationship to known string algorithms
 
-The space is not empty; this design sits near several well-studied ones.
+None of this is an empty corner of the literature; the design sits next to
+several well-studied lines of work.
 
 The exact, unmasked version of the problem is essentially **left-bounded shortest
 unique substring** (LSUS): for a fixed start position, find the shortest substring
@@ -302,20 +302,20 @@ the right reference points for the wildcard-free case and for an answer-length
 sanity check.
 
 The masked case connects to **wildcard pattern matching** and **longest common
-extensions with wildcards**, whose recurring lesson is exactly ours: anchor on
-informative non-wildcard positions instead of treating all positions uniformly.
-**Internal pattern matching** queries are the natural primitive if one ever wants
-sublinear repeated-substring queries inside a fixed text rather than a per-search
-rebuilt index.
+extensions with wildcards**, whose recurring lesson is the same one we lean on:
+anchor on informative non-wildcard positions instead of treating all positions
+uniformly.
+**Internal pattern matching** is the natural primitive if one ever wants sublinear
+repeated-substring queries inside a fixed text rather than a per-search rebuilt
+index.
 
 The closest practical neighbor is in the same domain. **YARA**'s atom-based
 scanning picks a short, rare, non-wildcard substring of a rule, finds its
 occurrences (classically via **Aho-Corasick** multi-pattern matching), and then
 verifies the full masked pattern at each hit. That is seed-then-refine for binary
-signatures. The algorithm here is the inverse-direction relative: instead of
-matching a known pattern, it *grows* the shortest pattern that is unique, using a
-byte-window index as the atom oracle and monotone in-place refinement as the
-verifier.
+signatures. The idea here is similar, but backwards: instead of matching a known
+pattern, it *grows* the shortest pattern that is unique, using a byte-window index
+as the atom oracle and monotone in-place refinement as the verifier.
 
 The bioinformatics seed-design literature (spaced, gapped, sampled, and
 multi-context seeds) does **not** transfer cleanly, for the reason in Section 5:
@@ -327,17 +327,16 @@ are known before the search.
 This is a **novel application**. The literature has the individual primitives, but
 the composition that solves *this* problem, growing the shortest masked byte
 signature that is unique in a live database, does not come pre-packaged anywhere
-we found. The **key use case** is concrete and load-bearing for reverse engineers:
-relocating a specific function or routine across rebuilds of a binary,
-interactively, inside the disassembler. That is what turns a 7.7-minute search
-into seconds (Section 2) and is what makes the feature usable at all.
+we found. The **key use case** is concrete: a reverse engineer relocating a function across
+rebuilds of a binary, interactively, in the disassembler. That is what turns a
+7.7-minute search into seconds (Section 2).
 
 What we do **not** claim is a new general theory of shortest unique substrings or
 wildcard matching; the primitives (inverted byte buckets, seed/filter/verify,
 monotone candidate filtering) are individually standard. The contribution is the
 specialization, and how cheaply the pieces combine for masked function signatures:
 
-1. **The 1-byte index is free.** This is the one genuinely non-obvious trick. A
+1. **The 1-byte index is free.** This is the one part that isn't obvious. A
    single counting-sort layout over adjacent byte *pairs* yields the exact 2-byte
    buckets, and because the buckets are stored in key order, every 1-byte bucket
    is just a contiguous *marginal* of that same `heads` array: a range view, with
@@ -361,7 +360,7 @@ specialization, and how cheaply the pieces combine for masked function signature
 The current implementation is intentionally conservative. The instrumentation this
 section used to call for has since been done: seed bucket size $C_0$, informative
 refinement steps $R$, wildcard density, and the candidate-decay curve. It
-redirected the effort. The real costs were a Python seed-enumeration loop (now in
+redirected the effort: the real costs were a Python seed-enumeration loop (now in
 C, Section 12) and a needless full scan on all-wildcard prefixes (now deferred,
 Section 5), not a fancier seed. Richer seed families (longer contiguous, spaced,
 or multi-context seeds) were measured and shelved; see Section 11. The one open
@@ -379,7 +378,7 @@ useful than the verdict, so it is worth writing down.
 Both got the same treatment: profile the worst functions, then build a small
 adversarial benchmark that deliberately constructs each idea's best case and check
 whether it actually wins. Neither did, because the profile kept pointing somewhere
-else. Not the index build (~0.05 s), and after the seed map was moved into C, not
+else: not the index build (~0.05 s), and after the seed map was moved into C, not
 the refine kernel either (~0.1 s), but two boring things we had left on the table:
 an $O(C_0)$ loop still mapping seed candidates in pure Python one boxed integer at
 a time, and a full $O(N)$ scan that fired whenever a pattern began with nothing but
@@ -417,11 +416,11 @@ fail loudly and these two ideas get a fresh hearing.
 ## 12. How Cython makes it work
 
 The math above is correct in pure Python too, but it would not be *fast* in pure
-Python. The hot kernels, the index build, the seed-candidate map, and the per-step
-refine, are memory-bound, branchy loops over millions of bytes. That is precisely
-the workload where CPython's per-element overhead (boxed integers, attribute
-lookups, interpreter dispatch, dynamic bounds checks) costs 50-100x. The
-`_speedups` extension compiles them to tight C:
+Python. The hot kernels (the index build, the seed-candidate map, and the per-step
+refine) are memory-bound, branchy loops over millions of bytes, and that is where
+CPython's per-element overhead (boxed integers, attribute lookups, interpreter
+dispatch, bounds checks) costs 50-100x. The `_speedups` extension compiles them to
+tight C:
 
 - **`build_byte_index`** is the counting sort of Section 4, written as C loops
   over a `const unsigned char[:]` typed memoryview, running under `nogil` so the
@@ -439,7 +438,7 @@ lookups, interpreter dispatch, dynamic bounds checks) costs 50-100x. The
   `p - s` shift, the fit guard, the $N-1$ boundary case) in C. This was the last
   `O(C_0)` loop left in Python, a generator expression that boxed and walked the
   entire bucket; moving it into Cython cut the worst observed function search from
-  **~12 s** to **~1 s**, the same playbook as `refine_offsets`, cross-checked
+  **~12 s** to **~1 s**. It is the same playbook as `refine_offsets`, cross-checked
   against the Python version for byte-identical output.
 
 - **`array.array('I')` is the bridge.** A candidate set is simultaneously a
@@ -447,8 +446,8 @@ lookups, interpreter dispatch, dynamic bounds checks) costs 50-100x. The
   a zero-copy `unsigned int[:]` typed memoryview inside Cython. The same buffer
   is the Python-visible candidate list and the C-level `uint32*` that
   `refine_offsets` compacts in place, so candidates cross the Python/C boundary
-  with no marshalling and no per-call allocation. This is the crux that makes
-  Section 6's "allocate once, only shrink" actually hold across the whole search.
+  with no marshalling and no per-call allocation. That is what lets Section 6's
+  "allocate once, only shrink" hold across the whole search.
 
 - **`nogil`** on both kernels means the heavy work runs without holding the
   interpreter lock, which keeps the UI live and leaves headroom for the

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1951,19 +1951,30 @@ class MinimalFunctionSignatureGenerator:
                 # so fall back to the per-step rescan.
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
-                # Seed once. Prefer the byte index (Dynamic Seed Selection);
-                # fall back to a full scan only when the pattern has no exact
-                # byte to key on.
+                # Seed once. Prefer the byte index (Dynamic Seed Selection).
                 seeded = _seed_via_index(sig, index, seed_buf)
-                if seeded is None:
+                if seeded is not None:
+                    offsets, ocount = seeded
+                    count = ocount
+                elif index is not None:
+                    # No exact byte yet: an all-wildcard pattern matches at
+                    # ~every position, so it cannot be unique. Defer the seed
+                    # (skip the O(N) full scan) until an exact byte appears on a
+                    # later iteration, then seed via the index. The first length
+                    # that can be unique is unchanged, so the signature is too.
+                    if progress is not None:
+                        progress.inner_length = len(sig)
+                        progress.inner_matches = None
+                    continue
+                else:
+                    # Index genuinely unavailable (e.g. buffer < 2 bytes): keep
+                    # the scan fallback so no anchor is silently skipped.
                     lst, seed_buf = SignatureSearcher.find_all_offsets(
                         f"{sig:ida}", buf=seed_buf
                     )
                     offsets = array.array("I", lst)
                     ocount = len(offsets)
-                else:
-                    offsets, ocount = seeded
-                count = ocount
+                    count = ocount
             else:
                 # Refine the surviving candidates in place for each byte
                 # appended this iteration; no rescan of the database.

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1679,18 +1679,29 @@ def _seed_via_index(
     m = len(sig)
     raw = index.candidates(key) if width == 2 else index.candidates1(key)
     # Map each hit at offset p back to a pattern start p - s, keeping only
-    # candidates whose full pattern fits in the buffer.
-    cands = array.array("I", (p - s for p in raw if p >= s and (p - s) + m <= n))
+    # candidates whose full pattern fits in the buffer. The Cython kernel does
+    # this in one nogil pass; the genexp is the defensive fallback (unreachable
+    # in practice, since index is None without SIMD).
+    if SIMD_SPEEDUP_AVAILABLE:
+        cands, count = simd_scan.seed_offsets(raw, s, m, n)
+    else:
+        cands = array.array(
+            "I", (p - s for p in raw if p >= s and (p - s) + m <= n)
+        )
+        count = len(cands)
     # n-1 boundary: candidates1 is derived from 2-byte windows, which never see
     # offset n-1 as a window start, so a 1-byte hit at the final buffer byte is
     # missing. It can only yield a valid pattern start when the seed byte is the
     # pattern's last byte (s == m-1, giving start n-m). Add it explicitly and
-    # let the refine validate.
+    # let the refine validate. The kernel reserves one slot for it.
     if width == 1 and n >= 1 and data_mv[n - 1] == key:
         p = n - 1 - s
         if 0 <= p and p + m <= n:
-            cands.append(p)
-    count = len(cands)
+            if count < len(cands):
+                cands[count] = p
+            else:
+                cands.append(p)
+            count += 1
     # Refine against every exact byte except the seed run's byte(s).
     seed_span = (s, s + 1) if width == 2 else (s,)
     for j in range(m):

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -784,3 +784,33 @@ def refine_offsets(const unsigned char[:] data_view,
                 w += 1
             r += 1
     return w
+
+
+def seed_offsets(const unsigned int[:] bucket,
+                 Py_ssize_t s,
+                 Py_ssize_t m,
+                 Py_ssize_t n):
+    """Map index-bucket hit positions p to candidate pattern starts p - s,
+    keeping only starts where the seed run fits (p >= s) and the full pattern
+    fits the buffer ((p - s) + m <= n).
+
+    Returns (starts, count): a uint32 array.array of capacity bucket.shape[0]+1
+    (the +1 reserves room for the caller's 1-byte n-1 boundary candidate) whose
+    first `count` entries are valid. nogil; one pass; no per-element Python
+    overhead. Equivalent to:
+        array('I', (p - s for p in bucket if p >= s and (p - s) + m <= n))
+    """
+    cdef Py_ssize_t cnt = bucket.shape[0]
+    cdef array.array out = array.clone(py_stdlib_arr_mod.array('I'), cnt + 1, zero=False)
+    cdef unsigned int[:] outv = out
+    cdef Py_ssize_t r = 0
+    cdef Py_ssize_t w = 0
+    cdef Py_ssize_t p
+    with nogil:
+        while r < cnt:
+            p = <Py_ssize_t>bucket[r]
+            if p >= s and (p - s) + m <= n:
+                outv[w] = <unsigned int>(p - s)
+                w += 1
+            r += 1
+    return out, w

--- a/tests/perf/adversarial_refine.py
+++ b/tests/perf/adversarial_refine.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+"""Adversarial refine microbenchmark.
+
+Settles "is the block-refine (Upgrade 1) or spaced-intersection (Upgrade 2)
+upgrade ever worth building?" by constructing the synthetic input that forces
+each upgrade's regime and timing the buffer-level kernels in isolation:
+
+  - _ByteIndex.build         (index build)
+  - simd_scan.seed_offsets   (seed map; Phase 5)
+  - _refine_offsets_into     (refine)
+
+Both upgrades only matter when refine is the dominant line. This harness
+manufactures exactly that, in each upgrade's sub-shape:
+
+  Upgrade 1 wants long contiguous exact runs (word compare replaces N scalar
+            steps): make_u1 -> a single long 0x00 run with alpha ~ 1.
+  Upgrade 2 wants a large candidate set probed across a cache-busting buffer
+            (sequential bucket-gallop vs random D-probes): make_u2 -> a big
+            small-alphabet buffer with a huge single-byte seed bucket.
+
+Key thing it measures for Upgrade 2: our candidate array is ALWAYS sorted
+ascending (the index bucket is sorted; seed_offsets and refine preserve order),
+so refine's D-probes are at monotonically increasing addresses, not random.
+The throughput sweep below shows whether refine is latency-bound (random, which
+Upgrade 2 could beat) or already bandwidth-bound/sequential (which it cannot).
+
+Pure buffer: no idalib, no .i64, deterministic, sweepable. Run:
+    pyenv exec python tests/perf/adversarial_refine.py
+Build the extension first: python setup.py build_ext --inplace
+"""
+import array
+import pathlib
+import random
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+with patch.dict("sys.modules", {"idaapi": MagicMock(), "idc": MagicMock()}):
+    import sigmaker  # noqa: E402
+
+assert sigmaker.SIMD_SPEEDUP_AVAILABLE, (
+    "extension not built; run: python setup.py build_ext --inplace"
+)
+
+
+def _best(fn, iters):
+    best = None
+    for _ in range(iters):
+        dt = fn()
+        best = dt if best is None else min(best, dt)
+    return best
+
+
+# --------------------------------------------------------------------------
+# Upgrade 1: long contiguous exact run, alpha ~ 1 (candidate set barely shrinks)
+# --------------------------------------------------------------------------
+def make_u1(L, tail=b"\xDE\xAD\xBE\xEF\xCA\xFE\x13\x37"):
+    """A long 0x00 run on both sides of a unique tail: the seed on '00 00'
+    matches ~everywhere and stays matching across K contiguous exact 0x00
+    bytes, so sum|M_r| ~= K * C0 (the worst-case R*C0 made real)."""
+    return b"\x00" * L + tail + b"\x00" * L
+
+
+def bench_u1(L, K, iters=3):
+    D = make_u1(L)
+    mv = memoryview(D)
+    n = len(mv)
+    t_idx = _best(lambda: _time(lambda: sigmaker._ByteIndex.build(mv)), 1)
+    idx = sigmaker._ByteIndex.build(mv)
+    base = idx.candidates(0x0000)          # ascending absolute positions, key 00 00
+    C0 = len(base)
+
+    def one_refine_chain():
+        arr = array.array("I", base)       # fresh mutable copy
+        count = len(arr)
+        t0 = time.perf_counter()
+        for j in range(1, K):
+            count = sigmaker._refine_offsets_into(mv, arr, count, j, 0x00, 0xFF)
+        return time.perf_counter() - t0
+
+    # seed-map cost over the same bucket, for "is refine the dominant line?"
+    t_seed = _best(lambda: _time(
+        lambda: sigmaker.simd_scan.seed_offsets(base, 0, K, n)), iters)
+    t_refine = _best(one_refine_chain, iters)
+    steps = max(1, K - 1)
+    touched = steps * C0
+    return {
+        "scenario": "u1", "L": L, "K": K, "C0": C0,
+        "t_index": t_idx, "t_seedmap": t_seed, "t_refine": t_refine,
+        "byte_steps": steps, "block_steps": -(-steps // 8),
+        "ns_per_cand_step": (t_refine / touched * 1e9) if touched else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------
+# Upgrade 2: huge sorted candidate set probed across a cache-busting buffer
+# --------------------------------------------------------------------------
+_ALPHABET = b"\x00\x01\x8B\x45"
+_TRANS = bytes(_ALPHABET[i & 3] for i in range(256))
+
+
+def make_u2(size, seed=1234, chunk=1 << 22):
+    """A big buffer over a 4-symbol alphabet: every single-byte bucket holds
+    ~size/4 positions, so there is no rare seed and C0 is huge. translate() is
+    C-speed so setup stays cheap. randbytes is chunked because Random.randbytes
+    builds an int of n*8 bits and overflows a C int for large n."""
+    rng = random.Random(seed)
+    parts = []
+    remaining = size
+    while remaining > 0:
+        c = min(chunk, remaining)
+        parts.append(rng.randbytes(c))
+        remaining -= c
+    return b"".join(parts).translate(_TRANS)
+
+
+def bench_u2(size, j=64, iters=3):
+    """One refine step over the full ~size/4 candidate set at offset j, swept
+    over DB size. Because the candidate array is sorted ascending, mv[p+j] is
+    read at monotonically increasing addresses. If GB/s stays flat as size
+    crosses the LLC, refine is bandwidth-bound/sequential and Upgrade 2's
+    cache-advantage premise does not hold; if GB/s collapses, there is a
+    latency component Upgrade 2 could attack."""
+    D = make_u2(size)
+    mv = memoryview(D)
+    idx = sigmaker._ByteIndex.build(mv)
+    base = idx.candidates1(0x00)           # ascending, ~size/4
+    C0 = len(base)
+
+    def one_step():
+        arr = array.array("I", base)       # 4*C0 sequential bytes
+        t0 = time.perf_counter()
+        sigmaker._refine_offsets_into(mv, arr, len(arr), j, 0x00, 0xFF)
+        return time.perf_counter() - t0
+
+    t_refine = _best(one_step, iters)
+    bytes_moved = C0 * 5                    # 4*C0 candidates + C0 data probes
+    return {
+        "scenario": "u2", "size": size, "j": j, "C0": C0,
+        "t_refine": t_refine, "GBps": bytes_moved / t_refine / 1e9,
+    }
+
+
+def _time(fn):
+    t0 = time.perf_counter()
+    fn()
+    return time.perf_counter() - t0
+
+
+def main(check=False):
+    print("=" * 78)
+    print("UPGRADE 1 -- block/word refine (long contiguous exact runs, alpha~1)")
+    print("=" * 78)
+    print(f"{'L':>10} {'K':>6} {'C0':>12} {'t_seedmap':>10} {'t_refine':>10} "
+          f"{'ns/cand/step':>13} {'steps->block':>14}")
+    u1 = []
+    for L in (8_000_000,):
+        for K in (8, 16, 64, 256):
+            r = bench_u1(L, K)
+            u1.append(r)
+            print(f"{r['L']:>10} {r['K']:>6} {r['C0']:>12} "
+                  f"{r['t_seedmap']*1e3:>9.2f}m {r['t_refine']*1e3:>9.2f}m "
+                  f"{r['ns_per_cand_step']:>13.3f} "
+                  f"{r['byte_steps']:>5}->{r['block_steps']:<6}")
+    print("\nReading: 'ns/cand/step' is the per-candidate-per-byte refine cost. "
+          "Block refine would cut 'steps' to 'block' (ceil/8). On THIS input "
+          "(16M-hit seed on a long identical run) that ~8x is real, but the "
+          "regime is padding: production seeds on the rarest run, never a "
+          "16M-hit '00 00', so refine never enters with this shape.")
+
+    print("\n" + "=" * 78)
+    print("UPGRADE 2 -- spaced intersection (huge sorted C0 across LLC boundary)")
+    print("=" * 78)
+    print(f"{'size(MB)':>10} {'C0':>12} {'t_refine':>10} {'GB/s':>8}")
+    u2 = []
+    for size in (16 << 20, 64 << 20, 256 << 20, 512 << 20):
+        r = bench_u2(size)
+        u2.append(r)
+        print(f"{size >> 20:>10} {r['C0']:>12} {r['t_refine']*1e3:>9.2f}m "
+              f"{r['GBps']:>8.2f}")
+    print("\nReading: candidates are sorted ascending, so mv[p+j] is read at "
+          "monotonic addresses (sequential, not random). Flat GB/s across the "
+          "LLC boundary => refine is bandwidth-bound/sequential => Upgrade 2's "
+          "'beat the random D-probes' premise does not hold for our refine.")
+
+    if check:
+        # Hardware-tolerant invariants that encode the findings. They fail if a
+        # future change makes refine superlinear (U1) or latency-bound (U2).
+        ns = [r["ns_per_cand_step"] for r in u1]
+        ratio_u1 = max(ns) / min(ns)
+        gbps = [r["GBps"] for r in u2]
+        ratio_u2 = max(gbps) / min(gbps)
+        print(f"\n[check] U1 ns/cand/step spread (refine linear in K): "
+              f"{ratio_u1:.2f}x  (want < 1.5)")
+        print(f"[check] U2 GB/s spread 16MB..512MB (no cache cliff): "
+              f"{ratio_u2:.2f}x  (want < 2.0)")
+        assert ratio_u1 < 1.5, "refine cost is no longer ~linear in step count"
+        assert ratio_u2 < 2.0, "refine GB/s collapsed past LLC: now latency-bound"
+        print("[check] PASS: refine is linear and sequential; both upgrades stay shelved.")
+
+
+if __name__ == "__main__":
+    main(check="--check" in sys.argv)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4059,6 +4059,56 @@ class TestBuildByteIndex(CoveredUnitTest):
         self.assertEqual(len(heads), 65537)  # safe to look up; all buckets empty
 
 
+class TestSeedOffsetsKernel(unittest.TestCase):
+    """simd_scan.seed_offsets maps index-bucket hits to pattern starts,
+    identically to the pure-Python genexp in _seed_via_index it replaces."""
+
+    @staticmethod
+    def _genexp(bucket, s, m, n):
+        return [p - s for p in bucket if p >= s and (p - s) + m <= n]
+
+    def setUp(self):
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+
+    def _check(self, bucket, s, m, n):
+        import array as _arr
+        arr, count = sigmaker.simd_scan.seed_offsets(
+            _arr.array("I", bucket), s, m, n
+        )
+        self.assertEqual(len(arr), len(bucket) + 1)   # capacity = bucket+1
+        self.assertLessEqual(count, len(bucket))
+        self.assertEqual(list(arr[:count]), self._genexp(bucket, s, m, n))
+
+    def test_empty_bucket(self):
+        self._check([], 0, 4, 100)
+
+    def test_s_zero_all_fit(self):
+        self._check([0, 10, 20, 30], 0, 5, 100)
+
+    def test_s_positive_drops_small_p(self):
+        self._check([0, 1, 2, 5, 9, 50], 3, 4, 100)
+
+    def test_boundary_inclusive_vs_exclusive(self):
+        # (p - s) + m == n is kept; == n + 1 is dropped
+        self._check([96, 97], 0, 4, 100)
+
+    def test_single_element(self):
+        self._check([42], 5, 3, 100)
+
+    def test_randomized(self):
+        import random
+        rng = random.Random(1234)
+        for _ in range(200):
+            n = rng.randint(1, 5000)
+            m = rng.randint(1, 32)
+            s = rng.randint(0, m - 1)
+            bucket = sorted(
+                rng.randint(0, n + 50) for _ in range(rng.randint(0, 300))
+            )
+            self._check(bucket, s, m, n)
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4114,6 +4114,73 @@ class TestSeedOffsetsKernel(unittest.TestCase):
             self._check(bucket, s, m, n)
 
 
+class TestSeedDeferredWhenAllWildcard(unittest.TestCase):
+    """Phase 6: an all-wildcard prefix defers seeding (no find_all_offsets full
+    scan) until an exact byte appears, then seeds via the index."""
+
+    def setUp(self):
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+        self._orig_canceled = getattr(
+            sigmaker, "idaapi_user_canceled", MagicMock(return_value=False)
+        )
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+
+    def tearDown(self):
+        sigmaker.idaapi_user_canceled = self._orig_canceled
+
+    def test_all_wildcard_prefix_defers_seed(self):
+        buf_bytes = b"\xAA\xAA\xAA\xAA\xAA\x8B\x45\x08\xCC\xCC\xCC\xCC"
+        mv = memoryview(bytearray(buf_bytes))
+        seed_buf = MagicMock()
+        seed_buf.data.return_value = mv
+        idx = sigmaker._ByteIndex.build(mv)
+        self.assertIsNotNone(idx)
+
+        decoded = [
+            sigmaker._DecodedInstruction(
+                ea=0x1000, size=5, raw_bytes=buf_bytes[0:5],
+                operand_offb=0, operand_length=5,   # entire instruction wildcarded
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1005, size=3, raw_bytes=b"\x8B\x45\x08",
+                operand_offb=0, operand_length=0,    # all exact
+            ),
+        ]
+        gen = sigmaker.MinimalFunctionSignatureGenerator(
+            sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        )
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA, wildcard_operands=True,
+            continue_outside_of_function=False, wildcard_optimized=True,
+            ask_longer_signature=False, max_single_signature_length=50,
+        )
+
+        calls = {"n": 0}
+
+        def spy(ida_sig, buf=None):
+            calls["n"] += 1
+            return [], buf
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "find_all_offsets", side_effect=spy
+        ):
+            sig = gen._grow_unique_from_decoded(
+                decoded, 0, cfg.max_single_signature_length, cfg,
+                buf=seed_buf, index=idx,
+            )
+
+        self.assertEqual(
+            calls["n"], 0,
+            "find_all_offsets must not run for an all-wildcard prefix when the "
+            "index is available",
+        )
+        self.assertIsNotNone(sig)
+        self.assertEqual(len(sig), 8)               # 5 wildcard + 8B 45 08
+        self.assertTrue(all(sig[i].is_wildcard for i in range(5)))
+        self.assertEqual([sig[i].value for i in range(5, 8)], [0x8B, 0x45, 0x08])
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3749,10 +3749,13 @@ class TestSeedViaIndex(CoveredUnitTest):
         # bucket so they lose.
         idx.bucket_size.side_effect = lambda key: {(0x8B << 8) | 0x45: 2}.get(key, 10**9)
         idx.bucket_size1.side_effect = lambda b: 10**9
+        # Real _ByteIndex.candidates returns array.array('I') slices; mirror that.
         idx.candidates.side_effect = (
-            lambda key: [0, 6] if key == ((0x8B << 8) | 0x45) else []
+            lambda key: array.array("I", [0, 6])
+            if key == ((0x8B << 8) | 0x45)
+            else array.array("I", [])
         )
-        idx.candidates1.side_effect = lambda b: []
+        idx.candidates1.side_effect = lambda b: array.array("I", [])
         arr, cnt = sigmaker._seed_via_index(sig, idx, buf)
         # offset 0 keeps (90 90 90 follow); offset 6 drops (00 00 follow)
         self.assertEqual(list(arr[:cnt]), [0])
@@ -3771,7 +3774,9 @@ class TestSeedViaIndex(CoveredUnitTest):
         idx = MagicMock()
         idx.bucket_size.side_effect = lambda key: 10**9   # no 2-byte run chosen
         idx.bucket_size1.side_effect = lambda b: {0xF3: 2}.get(b, 10**9)
-        idx.candidates1.side_effect = lambda b: [0, 8] if b == 0xF3 else []
+        idx.candidates1.side_effect = (
+            lambda b: array.array("I", [0, 8]) if b == 0xF3 else array.array("I", [])
+        )
         arr, cnt = sigmaker._seed_via_index(sig, idx, buf)
         self.assertEqual(list(arr[:cnt]), [0])
 


### PR DESCRIPTION
Continues the function-search performance work. After Phase 4 the worst-case functions were still 12 to 13 seconds, so I profiled them on real 200 MB+ databases (native idalib) and built an adversarial microbenchmark to test the two optimizations a reviewer had pushed. The profile found the real costs were neither the index nor refinement; both upgrades were measured and shelved.

## What the profile found

On the worst functions (winapp 84 MB, warden 202 MB modules), the cost was never the index build (~0.05 s) and, after Phase 4, not the refine kernel either (~0.1 s). It was two un-glamorous things:

1. An `O(C0)` candidate-mapping loop still running in pure Python (a generator expression boxing and walking the whole seed bucket).
2. A full `O(N)` masked scan that fired whenever a pattern's seedable prefix was all wildcards.

## Changes

- **Phase 5: `seed_offsets` Cython kernel.** Moves the seed-candidate map (`p - s` shift, fit guard, n-1 boundary) into a `nogil` C loop, the same playbook as Phase 4's `refine_offsets`. Worst observed function search **12.3 s to 1.05 s**.
- **Phase 6: defer-seed on all-wildcard prefixes.** When the seedable prefix has no exact byte, defer until one appears instead of a full-buffer scan. Warden worst function **12.3 s to 0.65 s**.
- **Adversarial microbench** (`tests/perf/adversarial_refine.py`) with a `--check` regression guard, plus cross-check tests pinning the Cython kernel to the Python version.
- **`ALGORITHM.md`**: table of contents, a "Rejected optimizations" section documenting why block refinement and spaced-seed intersection were measured and shelved, the `seed_offsets` and defer-seed notes, and a writing/grammar pass.

## Net behavior

Signatures are byte-identical to before; only the speed changed. The common case was already sub-second to ~1 s on 69 KB functions; this collapses the worst-case outliers to ~1 s as well.

## Verification

- Host unit: Ran 228, OK
- Docker `idapro-tests`: 246 OK; `idapro-tests-9.2`: 246 OK
- Cython kernels cross-checked against the Python fallbacks for byte-identical output
- Native re-benchmark on the same winapp/warden modules confirms the numbers above

## Test plan

- [ ] `python setup.py build_ext --inplace`
- [ ] `python -m unittest tests.unit_test_sigmaker -v` (228 OK)
- [ ] `python tests/perf/adversarial_refine.py --check` (regression guard passes)
- [ ] Both Docker images (246 OK each)

## Notes

The two reviewer-proposed upgrades (block/multi-byte refinement, sorted-bucket spaced-seed intersection) are deliberately not implemented. The microbench shows refinement is linear and memory-bandwidth-bound, so fewer-but-wider compares cannot help, and seed-then-refine already computes the offset-aligned intersection more cheaply than an explicit merge of two full buckets. ALGORITHM.md section 11 records the reasoning.
