### PR TITLE
Display containing function name in signature output (v1.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.1] - 2026-05-30
+
+### Added
+
+- **Signature output now labels addresses with the containing function name.** `GeneratedSignature.display`, `XrefGeneratedSignature.display`, and the function-signature action append ` (funcname)` to printed addresses when the address lies in a named function, falling back to the bare address otherwise. The address is always kept, so distinct anchors in the same function stay distinguishable. ([#47](https://github.com/mahmoudimus/ida-sigmaker/pull/47))
+
+[1.9.1]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.9.0...v1.9.1
+
 ## [1.9.0] - 2026-05-30
 
 ### Changed

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1034,6 +1034,21 @@ class WildcardPolicy:
         return cls._Use(policy, cls)
 
 
+def _func_name_suffix(ea: int) -> str:
+    """Return ' (funcname)' when ``ea`` lies inside a named function, else ''.
+
+    Labels addresses in human-facing output with the containing function name
+    when one is available, falling back to the bare address. The isinstance
+    guard keeps the suffix empty when idaapi.get_func_name returns a non-string
+    (e.g. under a mocked idaapi in tests) or nothing.
+    """
+    with contextlib.suppress(BaseException):
+        name = idaapi.get_func_name(ea)
+        if isinstance(name, str) and name:
+            return f" ({name})"
+    return ""
+
+
 @dataclasses.dataclass(slots=True, frozen=True)
 class GeneratedSignature:
     """Result container for signature generation operations."""
@@ -1063,16 +1078,21 @@ class GeneratedSignature:
                 if self.match_count is not None
                 else "match count unavailable"
             )
-            prefix = (
-                f"Partial signature (NOT unique, {count_str}) for {self.address}"
-                if self.address is not None
-                else f"Partial signature (NOT unique, {count_str})"
-            )
+            if self.address is not None:
+                prefix = (
+                    f"Partial signature (NOT unique, {count_str}) for "
+                    f"{self.address}{_func_name_suffix(int(self.address))}"
+                )
+            else:
+                prefix = f"Partial signature (NOT unique, {count_str})"
             idaapi.msg(f"{prefix}: {fmted}\n")
             return
 
         if self.address is not None:
-            idaapi.msg(f"Signature for {self.address}: {fmted}\n")
+            idaapi.msg(
+                f"Signature for {self.address}"
+                f"{_func_name_suffix(int(self.address))}: {fmted}\n"
+            )
         else:
             idaapi.msg(f"Signature: {fmted}\n")
 
@@ -1112,7 +1132,10 @@ class XrefGeneratedSignature:
             address = generated_signature.address
             signature = generated_signature.signature
             fmted = format(signature, t)
-            idaapi.msg(f"XREF Signature #{i} @ {address}: {fmted}\n")
+            idaapi.msg(
+                f"XREF Signature #{i} @ {address}"
+                f"{_func_name_suffix(int(address))}: {fmted}\n"
+            )
             if i == 0:
                 Clipboard.set_text(fmted)
 
@@ -3385,7 +3408,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             offset = int(result.address) - int(pfn.start_ea)
             idaapi.msg(
                 f"Function signature (offset +{hex(offset)} into function "
-                f"{hex(pfn.start_ea)}):\n"
+                f"{hex(pfn.start_ea)}{_func_name_suffix(int(pfn.start_ea))}):\n"
             )
             result.display(config)
             return

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -26,7 +26,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4181,6 +4181,72 @@ class TestSeedDeferredWhenAllWildcard(unittest.TestCase):
         self.assertEqual([sig[i].value for i in range(5, 8)], [0x8B, 0x45, 0x08])
 
 
+class TestFunctionNameInDisplay(unittest.TestCase):
+    """Address output is labeled with the containing function name when one is
+    available, falling back to the bare EA otherwise."""
+
+    def setUp(self):
+        self._orig_msg = sigmaker.idaapi.msg
+        self._orig_get_name = sigmaker.idaapi.get_func_name
+        self.msgs: list[str] = []
+        sigmaker.idaapi.msg = lambda s: self.msgs.append(s)
+
+    def tearDown(self):
+        sigmaker.idaapi.msg = self._orig_msg
+        sigmaker.idaapi.get_func_name = self._orig_get_name
+
+    def test_suffix_with_name(self):
+        sigmaker.idaapi.get_func_name = MagicMock(return_value="Java_x_y_calc")
+        self.assertEqual(sigmaker._func_name_suffix(0x1000), " (Java_x_y_calc)")
+
+    def test_suffix_without_name(self):
+        sigmaker.idaapi.get_func_name = MagicMock(return_value="")
+        self.assertEqual(sigmaker._func_name_suffix(0x1000), "")
+
+    def test_suffix_handles_none_and_nonstring(self):
+        sigmaker.idaapi.get_func_name = MagicMock(return_value=None)
+        self.assertEqual(sigmaker._func_name_suffix(0x1000), "")
+        sigmaker.idaapi.get_func_name = MagicMock(return_value=MagicMock())
+        self.assertEqual(sigmaker._func_name_suffix(0x1000), "")
+
+    def test_suffix_suppresses_exceptions(self):
+        sigmaker.idaapi.get_func_name = MagicMock(side_effect=RuntimeError("boom"))
+        self.assertEqual(sigmaker._func_name_suffix(0x1000), "")
+
+    def test_unique_display_includes_name_and_address(self):
+        sigmaker.idaapi.get_func_name = MagicMock(return_value="myfunc")
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA, wildcard_operands=False,
+            continue_outside_of_function=False, wildcard_optimized=False,
+        )
+        sig = sigmaker.Signature()
+        for i in range(4):
+            sig.append(sigmaker.SignatureByte(0xE8 + i, False))
+        result = sigmaker.GeneratedSignature(sig, sigmaker.Match(0x140001234))
+        with patch.object(sigmaker.Clipboard, "set_text", return_value=True):
+            result.display(cfg)
+        combined = "".join(self.msgs)
+        self.assertIn("Signature for", combined)
+        self.assertIn("(myfunc)", combined)
+        self.assertIn(str(sigmaker.Match(0x140001234)), combined)  # EA still present
+
+    def test_unique_display_falls_back_to_ea_when_unnamed(self):
+        sigmaker.idaapi.get_func_name = MagicMock(return_value="")
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA, wildcard_operands=False,
+            continue_outside_of_function=False, wildcard_optimized=False,
+        )
+        sig = sigmaker.Signature()
+        for i in range(4):
+            sig.append(sigmaker.SignatureByte(0xE8 + i, False))
+        result = sigmaker.GeneratedSignature(sig, sigmaker.Match(0x140001234))
+        with patch.object(sigmaker.Clipboard, "set_text", return_value=True):
+            result.display(cfg)
+        combined = "".join(self.msgs)
+        self.assertIn(str(sigmaker.Match(0x140001234)), combined)
+        self.assertNotIn("(", combined)  # no name parenthetical
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
Labels signature output with the containing function name.

## Change

`GeneratedSignature.display`, `XrefGeneratedSignature.display`, and the function-signature action now append ` (funcname)` to printed addresses when the address lies in a named function, falling back to the bare address otherwise. The address is always kept, so distinct anchors in the same function stay distinguishable. A new `_func_name_suffix(ea)` helper guards on `isinstance(name, str)` and suppresses exceptions, so a mocked or empty `idaapi.get_func_name` yields no suffix.

This only changes human-facing `display()` console text; the format-specs (`f"{sig:ida}"` etc.), `Match.__str__`, and the config/method surface are untouched, so the downstream contract holds.

## Verification

- Host unit: Ran 234, OK (+6 tests in `TestFunctionNameInDisplay`: name present/absent, None/non-string, exception suppression, display with name vs EA fallback)

This PR also cuts **v1.9.1** (version bump + CHANGELOG).