### PR TITLE
Extractable engine: generate a GUI-free sigmaker_engine.py for embedders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,11 @@ jobs:
               with:
                   python-version: "3.10"
             - &create-sigmaker-py
-              name: Create sigmaker.py from __init__.py
+              name: Create sigmaker.py and sigmaker_engine.py from __init__.py
               if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
               run: |
                   cp src/sigmaker/__init__.py sigmaker.py
+                  python tools/extract_engine.py sigmaker_engine.py
             - &read-changelog
               name: 📖 Read CHANGELOG section for this version
               id: changelog
@@ -159,6 +160,7 @@ jobs:
               with:
                   files: |
                       sigmaker.py
+                      sigmaker_engine.py
                   tag_name: ${{ steps.version.outputs.tag }} # e.g. v1.3.0
                   name: ${{ steps.version.outputs.tag }}
                   body_path: release_body.md

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An IDA Pro 9.0+ zero-dependency cross-platform signature maker plugin with optio
   - [How it works](#how-it-works)
 - [Using SigMaker as a library](#using-sigmaker-as-a-library)
   - [Stability contract](#stability-contract)
+  - [Embedding the engine](#embedding-the-engine)
   - [Used by](#used-by)
 - [Acknowledgements](#acknowledgements)
 - [Development & Releases](#development--releases)
@@ -217,6 +218,15 @@ If you embed `sigmaker`, you can rely on the following. These are treated as a c
 3. **Stable method signatures.** `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict())`, `XrefFinder.find_xrefs(ea, cfg)`, `XrefFinder.count_code_xrefs_to(ea)`, and `XrefFinder.iter_code_xrefs_to(ea)`.
 4. **Stable format specs.** `f"{sig:ida}"`, `f"{sig:x64dbg}"`, `f"{sig:mask}"`, and `f"{sig:bitmask}"` keep producing their current output exactly.
 5. **Byte-identical defaults.** Production defaults are unchanged across optimizations: a script that does not opt into a new flag gets byte-identical signatures to previous versions.
+
+### Embedding the engine
+
+`sigmaker` is one file by design, but the bottom of it is the IDA plugin shell (config dialogs, action/menu registration, `plugin_t`) which subclasses IDA GUI types and will not import under `idalib`. If you want the engine without the plugin, you have two options:
+
+- **`pip install sigmaker`** for the compiled SIMD speedups, then `import sigmaker` inside IDA or idalib as shown above.
+- **Vendor the generated [`sigmaker_engine.py`](https://github.com/mahmoudimus/ida-sigmaker/releases)** attached to each release. It is the source sliced at the engine/plugin seam: the full engine (everything in `__all__`, including the SIMD path and `display()`), with no Forms, no action/menu registration, and no `plugin_t`, so it imports cleanly headless. Regenerate it yourself any time with `python tools/extract_engine.py`.
+
+The supported surface is the names in `__all__`, and the [stability contract](#stability-contract) applies to all of them. This is the maintained alternative to hand-stripping the GUI, which drifts every release.
 
 ### Used by
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ An IDA Pro 9.0+ zero-dependency cross-platform signature maker plugin with optio
 - [Using SigMaker as a library](#using-sigmaker-as-a-library)
   - [Stability contract](#stability-contract)
   - [Embedding the engine](#embedding-the-engine)
+  - [Profiling (headless)](#profiling-headless)
   - [Used by](#used-by)
 - [Acknowledgements](#acknowledgements)
 - [Development & Releases](#development--releases)
@@ -227,6 +228,23 @@ If you embed `sigmaker`, you can rely on the following. These are treated as a c
 - **Vendor the generated [`sigmaker_engine.py`](https://github.com/mahmoudimus/ida-sigmaker/releases)** attached to each release. It is the source sliced at the engine/plugin seam: the full engine (everything in `__all__`, including the SIMD path and `display()`), with no Forms, no action/menu registration, and no `plugin_t`, so it imports cleanly headless. Regenerate it yourself any time with `python tools/extract_engine.py`.
 
 The supported surface is the names in `__all__`, and the [stability contract](#stability-contract) applies to all of them. This is the maintained alternative to hand-stripping the GUI, which drifts every release.
+
+### Profiling (headless)
+
+The plugin exposes **Start Profiling** / **Stop Profiling** in the right-click `SigMaker` submenu, but the same `cProfile` helpers work headlessly (idalib, batch jobs, CI). They only touch `cProfile` and `idaapi`, no GUI, and they live in the engine, so they are available from `sigmaker_engine.py` too:
+
+```python
+import idapro, idaapi
+idapro.open_database("target.i64", True)
+idaapi.auto_wait()
+import sigmaker
+
+sigmaker.start_profiling()
+# ... run make_signature / XrefFinder / a search ...
+sigmaker.stop_profiling()          # writes {IDAUSR}/sigmaker_profile.prof + .txt
+```
+
+`stop_profiling(output_path=None, top_n=30, sort_by="cumulative")` returns the `.prof` path (and writes a `.txt` top-N summary beside it), or `None` if no session was active. `sigmaker._PROFILER.active` reports whether a session is currently running. Calling `start_profiling()` again without stopping discards the previous session.
 
 ### Used by
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -32,6 +32,40 @@ PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__
 PLUGIN_AUTHOR: str = __author__
 
+# Public engine surface. These names are the supported library API (the same set
+# the downstream-consumer contract pins) and are exactly what ships in the
+# generated, GUI-free sigmaker_engine.py. The IDA plugin shell below the seam is
+# intentionally excluded.
+__all__ = [
+    "Signature",
+    "SignatureByte",
+    "SignatureType",
+    "Match",
+    "SigMakerConfig",
+    "GenerationPolicy",
+    "GenerationStatus",
+    "WildcardPolicy",
+    "OperandProcessor",
+    "InstructionProcessor",
+    "SignatureMaker",
+    "GeneratedSignature",
+    "XrefGeneratedSignature",
+    "XrefFinder",
+    "SignatureParser",
+    "SignatureSearcher",
+    "SearchResults",
+    "SigText",
+    "SignatureFormatter",
+    "IdaFormatter",
+    "X64DbgFormatter",
+    "MaskedBytesFormatter",
+    "ByteArrayBitmaskFormatter",
+    "ProgressReporter",
+    "Unexpected",
+    "UserCanceledError",
+    "SIMD_SPEEDUP_AVAILABLE",
+]
+
 
 WILDCARD_POLICY_CTX: contextvars.ContextVar["WildcardPolicy"] = contextvars.ContextVar(
     "wildcard_policy"
@@ -2978,6 +3012,15 @@ class Clipboard:
         return self.set_text(text)
 
 
+# ============================================================================
+# ENGINE / PLUGIN SEAM
+# Everything ABOVE this line is the self-contained signature engine and is what
+# gets extracted into sigmaker_engine.py (see tools/extract_engine.py). Everything
+# BELOW is the IDA plugin shell: config dialogs, action/menu registration, and the
+# plugin_t entry point, all of which subclass idaapi GUI types.
+# INVARIANT: nothing above this line may reference a symbol defined below it.
+# The seam is enforced by tests/test_engine_extraction.py.
+# ============================================================================
 class ConfigureOperandWildcardBitmaskForm(idaapi.Form):
     """Interactive form to configure wildcardable operands using checkboxes."""
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4256,6 +4256,90 @@ class TestFunctionNameInDisplay(unittest.TestCase):
         self.assertNotIn("(", combined)  # no name parenthetical
 
 
+class TestEngineExtraction(CoveredUnitTest):
+    """Guards the engine/plugin seam and the generated sigmaker_engine.py."""
+
+    SRC = TEST_DIR.parent / "src" / "sigmaker" / "__init__.py"
+    TOOL = TEST_DIR.parent / "tools" / "extract_engine.py"
+    SEAM = "ENGINE / PLUGIN SEAM"
+
+    def _load_extractor(self):
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("extract_engine_tool", self.TOOL)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_seam_marker_present_once(self):
+        text = self.SRC.read_text(encoding="utf-8")
+        self.assertEqual(text.count(self.SEAM), 1, "seam marker must appear exactly once")
+
+    def test_no_above_references_below(self):
+        import ast
+
+        text = self.SRC.read_text(encoding="utf-8")
+        seam_line = next(
+            i for i, ln in enumerate(text.splitlines(), start=1) if self.SEAM in ln
+        )
+        tree = ast.parse(text)
+        below = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.lineno > seam_line
+        }
+        self.assertTrue(below, "expected plugin-shell symbols defined below the seam")
+        offenders = [
+            (node.id, node.lineno)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Name)
+            and isinstance(node.ctx, ast.Load)
+            and node.id in below
+            and node.lineno < seam_line
+        ]
+        self.assertEqual(
+            offenders, [], f"engine references plugin-shell symbols: {offenders}"
+        )
+
+    def test_engine_extracts_imports_and_smokes(self):
+        import importlib.util
+
+        extractor = self._load_extractor()
+        with tempfile.TemporaryDirectory() as d:
+            out = pathlib.Path(d) / "sigmaker_engine.py"
+            extractor.extract_engine(out_path=out)
+            spec = importlib.util.spec_from_file_location(
+                "sigmaker_engine_under_test", out
+            )
+            mod = importlib.util.module_from_spec(spec)
+            with patch.dict(
+                "sys.modules",
+                {
+                    "idaapi": MagicMock(),
+                    "idc": MagicMock(),
+                    # Register before exec so dataclass type-resolution (which looks
+                    # the module up in sys.modules under PEP 563 annotations) works.
+                    "sigmaker_engine_under_test": mod,
+                },
+            ):
+                spec.loader.exec_module(mod)
+                for name in ("SigMakerConfig", "SignatureParser", "SignatureMaker"):
+                    self.assertTrue(hasattr(mod, name), f"engine missing {name}")
+                self.assertTrue(hasattr(mod, "SIMD_SPEEDUP_AVAILABLE"))
+                for name in (
+                    "SigMakerPlugin",
+                    "ConfigureOptionsForm",
+                    "SignatureMakerForm",
+                    "ConfigureOperandWildcardBitmaskForm",
+                ):
+                    self.assertFalse(hasattr(mod, name), f"engine leaked shell {name}")
+                self.assertEqual(
+                    mod.SignatureParser.parse("E8 ? ? ? ? 45 33 F6"),
+                    "E8 ? ? ? ? 45 33 F6",
+                )
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)

--- a/tools/extract_engine.py
+++ b/tools/extract_engine.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate the GUI-free signature engine from the single-file plugin source.
+
+The plugin lives in one file (``src/sigmaker/__init__.py``) by design. Everything
+above the ``ENGINE / PLUGIN SEAM`` marker is the self-contained signature engine;
+everything below is the IDA plugin shell (config Forms, action/menu registration,
+``plugin_t``) that subclasses idaapi GUI types and cannot import under idalib.
+
+This tool slices the source at the seam and writes ``sigmaker_engine.py``, a
+drop-in engine that embedders can vendor instead of hand-stripping the GUI (which
+drifts on every release). It is pure stdlib so it can run anywhere.
+
+Usage:
+    python tools/extract_engine.py [OUT_PATH]    # default: ./sigmaker_engine.py
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# The unique sentinel inside the seam comment block (see src/sigmaker/__init__.py).
+SEAM_SENTINEL = "ENGINE / PLUGIN SEAM"
+
+_GENERATED_HEADER = (
+    "# GENERATED from src/sigmaker/__init__.py (engine slice at the ENGINE / PLUGIN\n"
+    "# SEAM). Do not edit by hand: regenerate with tools/extract_engine.py. This is\n"
+    "# the GUI-free signature engine (no config Forms, no action/menu registration,\n"
+    "# no plugin_t), so it imports under idalib without IDA's GUI base classes.\n"
+    "\n"
+)
+
+
+def _default_source() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parent.parent / "src" / "sigmaker" / "__init__.py"
+
+
+def extract_engine(
+    src_path: "pathlib.Path | str | None" = None,
+    out_path: "pathlib.Path | str | None" = None,
+) -> str:
+    """Return the engine slice of ``src_path``; write it to ``out_path`` if given.
+
+    Raises ValueError if the seam marker is missing or appears more than once.
+    """
+    src = pathlib.Path(src_path) if src_path is not None else _default_source()
+    lines = src.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    seam_idxs = [i for i, ln in enumerate(lines) if SEAM_SENTINEL in ln]
+    if len(seam_idxs) == 0:
+        raise ValueError(f"seam marker {SEAM_SENTINEL!r} not found in {src}")
+    if len(seam_idxs) > 1:
+        raise ValueError(
+            f"seam marker {SEAM_SENTINEL!r} appears {len(seam_idxs)} times in {src}; "
+            "it must be unique"
+        )
+
+    # Walk back over the contiguous comment block that contains the sentinel so the
+    # marker itself is excluded from the engine.
+    block_start = seam_idxs[0]
+    while block_start > 0 and lines[block_start - 1].lstrip().startswith("#"):
+        block_start -= 1
+
+    engine = _GENERATED_HEADER + "".join(lines[:block_start]).rstrip("\n") + "\n"
+
+    if out_path is not None:
+        pathlib.Path(out_path).write_text(engine, encoding="utf-8")
+    return engine
+
+
+def main(argv: "list[str]") -> int:
+    out = argv[1] if len(argv) > 1 else "sigmaker_engine.py"
+    text = extract_engine(out_path=out)
+    print(f"wrote {out} ({text.count(chr(10))} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Background

Embedders vendor the signature engine without the IDA plugin. mrexodia/ida-pro-mcp (and HACK-THE-WORLD/IDAPluginList, which mirrors it) currently hand-strip a GUI-free copy of `sigmaker.py`, which goes stale every time the engine changes. This makes that a maintained, one-command operation instead.

## What blocks a clean strip today

The bottom of `__init__.py` is the plugin shell: three `idaapi.Form` config dialogs, `_ActionHandler`, `_PopupHook`, and `SigMakerPlugin(idaapi.plugin_t)`. Those base classes are resolved at import and are absent/unavailable under `idalib`, so importing the full file headless fails. Everything above is the engine and only depends on idaapi wait-box calls and lazy-imported Qt (both headless-safe).

## Changes

| Commit | What |
|--------|------|
| `b01ce59` | `ENGINE / PLUGIN SEAM` marker before the first Form, plus `__all__` declaring the public engine surface |
| `0a08787` | `tools/extract_engine.py` (stdlib) slices the source at the seam into `sigmaker_engine.py`; `TestEngineExtraction` enforces the seam |
| `a43a699` | `release.yml` generates and uploads `sigmaker_engine.py` alongside `sigmaker.py` |
| `78b84ae` | README "Embedding the engine" section + TOC |

The seam is enforced by CI: the marker is unique, no engine symbol references the plugin shell (AST check), and the extracted engine imports under mocked `idaapi` with the shell classes absent and a parse round-trip working.

## Net behavior

The plugin (`sigmaker.py`) is unchanged except a seam comment and `__all__`, so plugin behavior is byte-identical. The new `sigmaker_engine.py` is generated, never hand-edited, and is the GUI-free engine: the full `__all__` surface including the SIMD path and `display()`, no Forms, no action/menu registration, no `plugin_t`.

I deliberately did **not** do a dependency-injection refactor of the progress/clipboard seam (a "pure logic core"). Those pieces are already headless-safe, and the refactor would risk the byte-identical plugin path for no embedder-visible gain. Noted as possible future work.

## Verification

| Suite | Result |
|-------|--------|
| Host unit | Ran 237, OK (+3 `TestEngineExtraction`) |
| Docker `idapro-tests` (9.0) | Ran 255, OK |
| Docker `idapro-tests-9.2` | Ran 255, OK |

## Test plan

- [ ] `python tools/extract_engine.py /tmp/sigmaker_engine.py`, then import it under idalib/mocked idaapi and confirm `SigMakerConfig`/`SignatureMaker`/`SIMD_SPEEDUP_AVAILABLE` exist and `SigMakerPlugin` does not
- [ ] `python -m unittest tests.unit_test_sigmaker.TestEngineExtraction -v`
- [ ] Both Docker images (255 OK each)

## Notes

The seam invariant (nothing above references below) is documented in-code at the marker and in CLAUDE.local.md, and is guarded by the test, so it cannot silently re-couple.
