### PR TITLE
refactor: encapsulate the profiler session in a Profiler object (drop the global)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2594,7 +2594,94 @@ class SignatureSearcher:
         return len(matches) == 1
 
 
-_ACTIVE_PROFILE: typing.Any = None
+class Profiler:
+    """Central holder for the optional cProfile session behind the Start/Stop
+    Profiling actions.
+
+    Encapsulates the single in-flight profile so there is no bare module global:
+    inspect (``active``), flip (``start`` / ``stop``), and ``reset`` all live on
+    one object. The module exposes a singleton ``_PROFILER``; ``start_profiling``
+    and ``stop_profiling`` are thin console-facing wrappers around it.
+    """
+
+    def __init__(self) -> None:
+        self._profile: typing.Any = None
+
+    @property
+    def active(self) -> bool:
+        """True while a profiling session is running."""
+        return self._profile is not None
+
+    def start(self) -> None:
+        """Begin a session, discarding any already-running one."""
+        import cProfile
+
+        if self._profile is not None:
+            self._profile.disable()
+            idaapi.msg("start_profiling: discarding previous active session\n")
+        pr = cProfile.Profile()
+        pr.enable()
+        self._profile = pr
+        idaapi.msg("start_profiling: profiling enabled\n")
+
+    def stop(
+        self,
+        output_path: typing.Optional[str] = None,
+        top_n: int = 30,
+        sort_by: str = "cumulative",
+    ) -> typing.Optional[str]:
+        """Stop the active session, dump the result, and print a summary.
+
+        Returns the .prof path on success, or None if no session was active.
+        """
+        import pstats
+        import io as _io
+
+        if self._profile is None:
+            idaapi.msg(
+                "stop_profiling: no active session; call start_profiling() first\n"
+            )
+            return None
+        pr = self._profile
+        self._profile = None
+        pr.disable()
+
+        if output_path is None:
+            idausr = idaapi.get_user_idadir()
+            output_path = os.path.join(idausr, "sigmaker_profile.prof")
+        text_path = (
+            output_path + ".txt" if not output_path.endswith(".txt") else output_path
+        )
+
+        pr.dump_stats(output_path)
+
+        buf = _io.StringIO()
+        pstats.Stats(pr, stream=buf).sort_stats(sort_by).print_stats(top_n)
+        text = buf.getvalue()
+
+        header = (
+            f"stop_profiling:\n"
+            f"  prof dump:   {output_path}\n"
+            f"  text dump:   {text_path}\n"
+            f"  sort by:     {sort_by}\n"
+            f"  top {top_n}:\n"
+        )
+        with open(text_path, "w") as f:
+            f.write(header)
+            f.write(text)
+
+        idaapi.msg(header)
+        idaapi.msg(text)
+        return output_path
+
+    def reset(self) -> None:
+        """Discard any active session without dumping (safety / tests)."""
+        if self._profile is not None:
+            self._profile.disable()
+        self._profile = None
+
+
+_PROFILER = Profiler()
 
 
 def start_profiling() -> None:
@@ -2610,15 +2697,7 @@ def start_profiling() -> None:
     Calling start_profiling() twice without an intervening stop_profiling()
     discards the previous session and begins a fresh one.
     """
-    import cProfile
-    global _ACTIVE_PROFILE
-    if _ACTIVE_PROFILE is not None:
-        _ACTIVE_PROFILE.disable()
-        idaapi.msg("start_profiling: discarding previous active session\n")
-    pr = cProfile.Profile()
-    pr.enable()
-    _ACTIVE_PROFILE = pr
-    idaapi.msg("start_profiling: profiling enabled\n")
+    _PROFILER.start()
 
 
 def stop_profiling(
@@ -2640,41 +2719,7 @@ def stop_profiling(
         Output is also printed via idaapi.msg so it appears in the IDA
         Output window.
     """
-    import pstats
-    import io as _io
-    global _ACTIVE_PROFILE
-    if _ACTIVE_PROFILE is None:
-        idaapi.msg("stop_profiling: no active session; call start_profiling() first\n")
-        return None
-    pr = _ACTIVE_PROFILE
-    _ACTIVE_PROFILE = None
-    pr.disable()
-
-    if output_path is None:
-        idausr = idaapi.get_user_idadir()
-        output_path = os.path.join(idausr, "sigmaker_profile.prof")
-    text_path = output_path + ".txt" if not output_path.endswith(".txt") else output_path
-
-    pr.dump_stats(output_path)
-
-    buf = _io.StringIO()
-    pstats.Stats(pr, stream=buf).sort_stats(sort_by).print_stats(top_n)
-    text = buf.getvalue()
-
-    header = (
-        f"stop_profiling:\n"
-        f"  prof dump:   {output_path}\n"
-        f"  text dump:   {text_path}\n"
-        f"  sort by:     {sort_by}\n"
-        f"  top {top_n}:\n"
-    )
-    with open(text_path, "w") as f:
-        f.write(header)
-        f.write(text)
-
-    idaapi.msg(header)
-    idaapi.msg(text)
-    return output_path
+    return _PROFILER.stop(output_path=output_path, top_n=top_n, sort_by=sort_by)
 
 
 class ProgressDialog:

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -3316,15 +3316,24 @@ class TestStartStopProfiling(CoveredUnitTest):
             return_value=tempfile.mkdtemp()
         )
         # Ensure no stale session leaks between tests.
-        sigmaker._ACTIVE_PROFILE = None
+        sigmaker._PROFILER.reset()
 
     def tearDown(self):
-        sigmaker._ACTIVE_PROFILE = None
+        sigmaker._PROFILER.reset()
 
     def test_stop_without_start_returns_none(self):
         result = sigmaker.stop_profiling()
         self.assertIsNone(result)
         sigmaker.idaapi.msg.assert_called()
+
+    def test_active_query_reflects_session(self):
+        self.assertFalse(sigmaker._PROFILER.active)
+        sigmaker.start_profiling()
+        self.assertTrue(sigmaker._PROFILER.active)
+        sigmaker.stop_profiling(
+            output_path=tempfile.NamedTemporaryFile(suffix=".prof", delete=False).name
+        )
+        self.assertFalse(sigmaker._PROFILER.active)
 
     def test_start_then_stop_writes_files(self):
         out = tempfile.NamedTemporaryFile(suffix=".prof", delete=False).name
@@ -3339,10 +3348,10 @@ class TestStartStopProfiling(CoveredUnitTest):
 
     def test_start_twice_discards_previous(self):
         sigmaker.start_profiling()
-        first = sigmaker._ACTIVE_PROFILE
+        first = sigmaker._PROFILER._profile
         sigmaker.start_profiling()
-        self.assertIsNotNone(sigmaker._ACTIVE_PROFILE)
-        self.assertIsNot(sigmaker._ACTIVE_PROFILE, first)
+        self.assertTrue(sigmaker._PROFILER.active)
+        self.assertIsNot(sigmaker._PROFILER._profile, first)
         sigmaker.stop_profiling(output_path=tempfile.NamedTemporaryFile(suffix=".prof", delete=False).name)
 
 


### PR DESCRIPTION
Follow-up to a globals audit: `_ACTIVE_PROFILE` was the one genuinely runtime-mutated module global, reassigned through two `global` statements in `start_profiling` / `stop_profiling`.

## Change

Encapsulate the in-flight cProfile session in a `Profiler` class with one central surface:
- `active` (property) to inspect,
- `start()` / `stop(...)` to flip,
- `reset()` to discard without dumping.

A module-level `_PROFILER = Profiler()` singleton backs the existing `start_profiling()` / `stop_profiling()` console functions, which become thin delegates. Their signatures, docstrings, console messages, and file output are unchanged, and the plugin's Start/Stop Profiling menu actions still call them as before. The only remaining `global` in the module is the load-once SIMD capability probe in `_load_speedups_sibling` (import-time detection, not runtime state).

## Verification

- Host unit: Ran 235, OK (+1 `test_active_query_reflects_session`; the existing profiler tests now drive the object via `_PROFILER.reset()` / `.active`).
- No behavior change: profiler output and messages are byte-identical; only the state location moved off a bare global into the object.

## Test plan

- [ ] `python -m unittest tests.unit_test_sigmaker.TestStartStopProfiling -v`
- [ ] In IDA: Start Profiling, run a search, Stop Profiling, confirm the .prof/.txt dump is written as before.