### PR TITLE
Keep ida-plugin.json version in sync (manifest bump + hook + CI guard) and add hcli docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Keep ida-plugin.json's version in sync with sigmaker.__version__ on every
+# commit. Enable once per clone with:
+#
+#     git config core.hooksPath .githooks
+#
+# The sync script is pure-stdlib Python. If it changes the manifest, the change
+# is staged into this commit so the two versions never drift apart.
+set -e
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "pre-commit: python3 not found, skipping ida-plugin.json version sync" >&2
+    exit 0
+fi
+
+python3 tools/sync_plugin_version.py
+
+if ! git diff --quiet -- ida-plugin.json; then
+    git add ida-plugin.json
+    echo "pre-commit: synced ida-plugin.json version and staged it"
+fi

--- a/README.md
+++ b/README.md
@@ -271,6 +271,14 @@ Thank you to [@A200K](https://github.com/A200K)'s [IDA-Pro-SigMaker](https://git
 4. Test thoroughly
 5. Submit a pull request
 
+The version lives in one place, `__version__` in `src/sigmaker/__init__.py`. To keep `ida-plugin.json` in step with it automatically, enable the repo's git hook once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The pre-commit hook (`.githooks/pre-commit`) runs `tools/sync_plugin_version.py`, which copies `__version__` into `ida-plugin.json` and stages it, so the manifest the IDA Plugin Repository reads can never drift behind a version bump. CI runs the same check (`TestPluginManifestVersion`) as a backstop for commits that skip the hook.
+
 ## Contact
 
 ping me on x [@mahmoudimus](https://x.com/mahmoudimus) or you may contact me from any one of the addresses on [mahmoudimus.com](https://mahmoudimus.com).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Background reading on mahmoudimus.com:
 - [Installation](#installation)
   - [Quick Install](#quick-install)
   - [From Releases](#from-releases)
+  - [Install with hcli](#install-with-hcli)
   - [Need to find your plugin directory?](#need-to-find-your-plugin-directory)
   - [Where and what is my default user directory?](#where-and-what-is-my-default-user-directory)
 - [SIMD Speedups](#simd-speedups)
@@ -54,6 +55,24 @@ sigmaker's main value proposition is its cross-platform (Windows, macOS, Linux) 
 - Restart IDA Pro
 
 That's it!
+
+### Install with hcli
+
+[`hcli`](https://hcli.docs.hex-rays.com/) is Hex-Rays' command-line tool, and it can install sigmaker from the IDA Plugin Repository. Install `hcli` once:
+
+```bash
+curl -LsSf https://hcli.docs.hex-rays.com/install | sh        # macOS/Linux
+iwr -useb https://hcli.docs.hex-rays.com/install.ps1 | iex    # Windows (PowerShell)
+```
+
+Then authenticate (see the [hcli docs](https://hcli.docs.hex-rays.com/)) and install the plugin:
+
+```bash
+hcli plugin search sigmaker
+hcli plugin install SigMaker
+```
+
+`hcli` downloads the plugin and places it in `$IDAUSR/plugins` (`~/.idapro/plugins` on macOS/Linux), where IDA loads it on the next launch. Requires IDA 9.0+. For `SIMD` speedups, also run `pip install sigmaker` as above.
 
 ### Need to find your plugin directory?
 

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.7.3"
+        "version": "1.9.1"
     }
 }

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -9,6 +9,7 @@ import array
 import dataclasses
 import gc
 import itertools
+import json
 import logging
 import pathlib
 import platform
@@ -4254,6 +4255,19 @@ class TestFunctionNameInDisplay(unittest.TestCase):
         combined = "".join(self.msgs)
         self.assertIn(str(sigmaker.Match(0x140001234)), combined)
         self.assertNotIn("(", combined)  # no name parenthetical
+
+
+class TestPluginManifestVersion(unittest.TestCase):
+    """Guard against ida-plugin.json drifting from the package version."""
+
+    def test_manifest_version_matches_package(self):
+        manifest = json.loads((TEST_DIR.parent / "ida-plugin.json").read_text())
+        self.assertEqual(
+            manifest["plugin"]["version"],
+            sigmaker.__version__,
+            "ida-plugin.json version is out of sync with sigmaker.__version__; "
+            "bump ida-plugin.json whenever you bump the package version.",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/sync_plugin_version.py
+++ b/tools/sync_plugin_version.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Keep ``ida-plugin.json``'s version in sync with ``sigmaker.__version__``.
+
+The single source of truth for the version is ``__version__`` in
+``src/sigmaker/__init__.py`` (``pyproject.toml`` already derives the package
+version from it). The IDA Plugin Repository and ``hcli`` read the version out
+of ``ida-plugin.json``, so the two must agree. This script copies the package
+version into the manifest.
+
+It reads ``__version__`` by parsing the source with ``ast`` rather than
+importing the module, because importing ``sigmaker`` pulls in ``idaapi``,
+which only exists inside IDA. The manifest is rewritten with a targeted
+substitution so the rest of its formatting is left untouched.
+
+Usage:
+    python tools/sync_plugin_version.py            # write the manifest in place
+    python tools/sync_plugin_version.py --check     # exit 1 if out of sync, no write
+
+The pre-commit hook in ``.githooks/`` runs the writing form; the unit test
+``TestPluginManifestVersion`` and CI act as the backstop.
+"""
+import argparse
+import ast
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INIT = ROOT / "src" / "sigmaker" / "__init__.py"
+MANIFEST = ROOT / "ida-plugin.json"
+
+
+def package_version() -> str:
+    """Return ``__version__`` from the package source without importing it."""
+    tree = ast.parse(INIT.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise SystemExit(f"could not find __version__ in {INIT}")
+
+
+def manifest_version(text: str) -> str:
+    return json.loads(text)["plugin"]["version"]
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the manifest matches the package version; do not write",
+    )
+    args = parser.parse_args(argv)
+
+    version = package_version()
+    text = MANIFEST.read_text(encoding="utf-8")
+    current = manifest_version(text)
+
+    if current == version:
+        return 0
+
+    if args.check:
+        print(
+            f"ida-plugin.json version {current!r} != sigmaker.__version__ "
+            f"{version!r}; run: python tools/sync_plugin_version.py",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Replace only the version string, so the manifest's formatting is preserved.
+    new_text, n = re.subn(
+        r'("version"\s*:\s*")[^"]*(")', r"\g<1>" + version + r"\g<2>", text, count=1
+    )
+    if n != 1:
+        raise SystemExit("could not locate the version field in ida-plugin.json")
+    MANIFEST.write_text(new_text, encoding="utf-8")
+    print(f"synced ida-plugin.json version {current} -> {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Started from the manifest being stale; turned into making it impossible to drift.

## The drift
`ida-plugin.json` was pinned at `1.7.3` while `sigmaker.__version__` (and the latest tag, v1.9.1) had moved on. The IDA Plugin Repository and `hcli` read that manifest, so it was misreporting the plugin. Bumped to `1.9.1`.

## Keeping it in sync (three layers)
- `tools/sync_plugin_version.py`: stdlib script that reads `__version__` from the package source (via `ast`, no import, so it works outside IDA) and copies it into `ida-plugin.json` with a targeted edit that preserves formatting. `--check` mode verifies without writing.
- `.githooks/pre-commit`: versioned hook that runs the script and stages the manifest on every commit. Enable per clone with `git config core.hooksPath .githooks` (documented in Contributing).
- `TestPluginManifestVersion`: CI unit test asserting the manifest equals `__version__`, as a backstop for commits that skip the hook.

Single source of truth stays `__version__` in `src/sigmaker/__init__.py`.

## hcli install path
Added an "Install with hcli" section to the README: install hcli, `hcli plugin search sigmaker`, `hcli plugin install SigMaker`, into `$IDAUSR/plugins`, with the note that SIMD speedups still come from `pip install sigmaker`.

Files: `ida-plugin.json`, `tools/sync_plugin_version.py`, `.githooks/pre-commit`, `tests/unit_test_sigmaker.py`, `README.md`.