### PR TITLE
docs: link mahmoudimus.com in the background reading line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An IDA Pro 9.0+ zero-dependency cross-platform signature maker plugin with optional SIMD (e.g. AVX2/NEON/SSE2) speedups that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions.
 
-Background reading on mahmoudimus.com:
+Background reading on [mahmoudimus.com](https://mahmoudimus.com):
 
 - [IDA Pro and Cython: super-charging the work-horse of reverse engineering](https://mahmoudimus.com/blog/2025/08/ida-pro-and-cython-super-charging-the-work-horse-of-reverse-engineering/): how the optional SIMD speedups were built.
 - [Growing a unique function signature without rescanning the binary](https://mahmoudimus.com/blog/2026/05/growing-a-unique-function-signature-without-rescanning-the-binary/): the search algorithm, with interactive visualizations.


### PR DESCRIPTION
Small fix: the "Background reading on mahmoudimus.com:" line had the domain as plain text. Link it to https://mahmoudimus.com. Wording otherwise unchanged.