### PR TITLE
fix: stop xref generation on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.9.2] - 2026-06-19
+
+### Fixed
+
+- **Canceling XREF signature generation now stops the XREF loop and keeps completed results.** If Cancel fired while one per-xref signature was being generated, `UserCanceledError` was caught as a generic per-candidate failure and the loop moved on to the next xref. XREF generation now stops immediately and prints the complete xref signatures found so far. This does not touch the SIMD speedup paths. ([#55](https://github.com/mahmoudimus/ida-sigmaker/issues/55), [#56](https://github.com/mahmoudimus/ida-sigmaker/pull/56))
+
+[1.9.2]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.9.1...v1.9.2
+
 ## [1.9.1] - 2026-05-30
 
 ### Added

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.9.1"
+        "version": "1.9.2"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2265,6 +2265,8 @@ class XrefFinder:
                 # Public API: returns SignatureResult
                 result = self.signature_maker.make_signature(frm_ea, cfg_no_prompt)
                 sig: typing.Optional[Signature] = result.signature
+            except UserCanceledError:
+                break
             except Exception:
                 sig = None
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -26,7 +26,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.9.1"
+__version__ = "1.9.2"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2571,6 +2571,95 @@ class TestGeneratedSignatureDisplay(CoveredUnitTest):
         fa.assert_not_called()
 
 
+class _FakeXrefProgressDialog:
+    """Minimal progress dialog for XrefFinder unit tests."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def user_canceled(self) -> bool:
+        return False
+
+    def replace_message(self, msg: str) -> None:
+        self.messages.append(msg)
+
+
+class TestXrefFinderCancellation(CoveredUnitTest):
+    """Cancel during one XREF candidate stops and keeps prior results."""
+
+    def _cfg(self) -> sigmaker.SigMakerConfig:
+        return sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+        )
+
+    def _sig(self, value: int) -> sigmaker.Signature:
+        sig = sigmaker.Signature()
+        sig.append(sigmaker.SignatureByte(value, False))
+        sig.append(sigmaker.SignatureByte(value + 1, False))
+        return sig
+
+    def _finder(self) -> sigmaker.XrefFinder:
+        finder = sigmaker.XrefFinder()
+        finder.progress_dialog = _FakeXrefProgressDialog()
+        return finder
+
+    def test_cancel_inside_candidate_generation_returns_prior_xrefs(self):
+        finder = self._finder()
+        first = sigmaker.GeneratedSignature(self._sig(0x40))
+        third = sigmaker.GeneratedSignature(self._sig(0x50))
+
+        with patch.object(sigmaker.XrefFinder, "count_code_xrefs_to", return_value=3), \
+                patch.object(
+                    sigmaker.XrefFinder,
+                    "iter_code_xrefs_to",
+                    return_value=iter([0x1010, 0x1020, 0x1030]),
+                ), patch.object(
+                    sigmaker.SignatureMaker,
+                    "make_signature",
+                    side_effect=[
+                        first,
+                        sigmaker.UserCanceledError("user canceled"),
+                        third,
+                    ],
+                ) as make_signature:
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(make_signature.call_count, 2)
+        self.assertEqual(len(result.signatures), 1)
+        self.assertEqual(result.signatures[0].address, sigmaker.Match(0x1010))
+        self.assertEqual(result.signatures[0].signature, first.signature)
+
+    def test_non_cancel_candidate_error_still_skips_and_continues(self):
+        finder = self._finder()
+        first = sigmaker.GeneratedSignature(self._sig(0x40))
+        third = sigmaker.GeneratedSignature(self._sig(0x50))
+
+        with patch.object(sigmaker.XrefFinder, "count_code_xrefs_to", return_value=3), \
+                patch.object(
+                    sigmaker.XrefFinder,
+                    "iter_code_xrefs_to",
+                    return_value=iter([0x1010, 0x1020, 0x1030]),
+                ), patch.object(
+                    sigmaker.SignatureMaker,
+                    "make_signature",
+                    side_effect=[
+                        first,
+                        RuntimeError("bad xref"),
+                        third,
+                    ],
+                ) as make_signature:
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(make_signature.call_count, 3)
+        self.assertEqual(
+            [generated.address for generated in result.signatures],
+            [sigmaker.Match(0x1010), sigmaker.Match(0x1030)],
+        )
+
+
 class TestGenerationStatusAndPolicy(CoveredUnitTest):
     """GenerationStatus and GenerationPolicy classmethods give callers a clean opt-in switch."""
 


### PR DESCRIPTION
## Background

Issue #55 reports that XREF signature generation can feel endless when a target has many incoming xrefs. The requested behavior is to press Cancel and keep the signatures that were already generated.

## Root cause

I found that `XrefFinder.find_xrefs()` catches `Exception` around each per-xref `make_signature()` call. `UserCanceledError` is an `Exception`, so canceling during one candidate was treated like a bad xref candidate and the loop continued to the next xref.

## Changes

I now catch `UserCanceledError` before the broad per-candidate handler and break the xref loop. That returns the prior generated xref signatures instead of discarding them or continuing through every xref.

I also added focused unit coverage for both paths:

- cancel inside candidate generation stops before the next xref and returns prior results
- ordinary non-cancel candidate errors are still skipped so the rest of the xrefs can continue

## Speedups

No `_speedups`, SIMD scan, byte index, seed selection, or candidate-refinement code changed.

## Verification

- `PYTHONPATH=src pyenv exec python -m unittest tests.unit_test_sigmaker.TestXrefFinderCancellation -v`
- `PYTHONPATH=src pyenv exec python -m unittest tests.unit_test_sigmaker --buffer 2>&1 | grep -E "^Ran |^OK|^FAILED|^ERROR"`
  - `Ran 238 tests in 1.331s`
  - `OK (skipped=3)`
