### PR TITLE
fix: wildcard operands on 2-byte Thumb instructions (#61)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1273,7 +1273,15 @@ class OperandProcessor:
         for op in ins:
             if op.type in policy.allowed_types:
                 off[0] = op.offb
-                length[0] = 3 if ins.size == 4 else (7 if ins.size == 8 else 0)
+                # Wildcard the low ins.size-1 bytes, which hold the immediate /
+                # offset fields on little-endian ARM/Thumb, keeping the high
+                # opcode+condition byte. Thumb-1 is 2 bytes (length 1); ARM and
+                # Thumb-2 are 4 (length 3); 8 covers double-width encodings.
+                # op.offb is 0 for these bit-field operands, which is why the
+                # 4- and 8-byte paths already work. Previously ins.size == 2
+                # fell through to 0, so no Thumb operand was ever wildcarded
+                # (issue #61).
+                length[0] = ins.size - 1 if ins.size in (2, 4, 8) else 0
                 return True
         return False
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4359,6 +4359,89 @@ class TestPluginManifestVersion(unittest.TestCase):
         )
 
 
+class TestArmThumbOperandWildcard(unittest.TestCase):
+    """Issue #61: operands of 2-byte Thumb instructions must be wildcarded.
+
+    _get_operand_offset_arm only mapped ins.size 4->3 and 8->7, so every 16-bit
+    Thumb-1 instruction got length 0 and was emitted unwildcarded.
+    """
+
+    _OP_TYPE = 991  # stand-in for an allowed ARM operand type (e.g. o_mem)
+
+    class _Op:
+        def __init__(self, type_, offb):
+            self.type = type_
+            self.offb = offb
+
+    class _Ins:
+        def __init__(self, size, ops):
+            self.size = size
+            self._ops = ops
+
+        def __iter__(self):
+            return iter(self._ops)
+
+    def _arm_processor(self):
+        proc = sigmaker.OperandProcessor()
+        proc._is_arm = True  # bypass idaapi.ph_get_id() under the mock
+        return proc
+
+    def _with_policy(self):
+        policy = sigmaker.WildcardPolicy(frozenset({self._OP_TYPE}))
+        return sigmaker.WildcardPolicy.set_current(policy)
+
+    def test_thumb_2byte_operand_wildcards_low_byte(self):
+        proc = self._arm_processor()
+        tok = self._with_policy()
+        try:
+            off, length = [0], [0]
+            ins = self._Ins(2, [self._Op(self._OP_TYPE, 0)])
+            found = proc.get_operand(ins, off, length, wildcard_optimized=True)
+            self.assertTrue(found)
+            self.assertEqual((off[0], length[0]), (0, 1))
+        finally:
+            sigmaker.WildcardPolicy.reset_current(tok)
+
+    def test_4byte_arm_operand_length_unchanged(self):
+        proc = self._arm_processor()
+        tok = self._with_policy()
+        try:
+            off, length = [0], [0]
+            ins = self._Ins(4, [self._Op(self._OP_TYPE, 0)])
+            proc.get_operand(ins, off, length, wildcard_optimized=True)
+            self.assertEqual((off[0], length[0]), (0, 3))
+        finally:
+            sigmaker.WildcardPolicy.reset_current(tok)
+
+    def test_thumb_ldr_literal_produces_wildcarded_signature(self):
+        # RibShark #61: LDR R5, off (bytes 1B 4D) must become "?? 4D".
+        proc = self._arm_processor()
+        instr = b"\x1B\x4D"
+        ea = 0x1000
+        orig_get_bytes = sigmaker.idaapi.get_bytes
+        sigmaker.idaapi.get_bytes = (
+            lambda addr, count: instr[addr - ea: addr - ea + count]
+        )
+        tok = self._with_policy()
+        try:
+            iproc = sigmaker.InstructionProcessor(proc)
+            sig = sigmaker.Signature()
+            ins = self._Ins(2, [self._Op(self._OP_TYPE, 0)])
+            iproc.append_instruction_to_sig(
+                sig, ea, ins, wildcard_operands=True, wildcard_optimized=True
+            )
+            self.assertEqual(
+                list(sig),
+                [
+                    sigmaker.SignatureByte(0x1B, True),
+                    sigmaker.SignatureByte(0x4D, False),
+                ],
+            )
+        finally:
+            sigmaker.WildcardPolicy.reset_current(tok)
+            sigmaker.idaapi.get_bytes = orig_get_bytes
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Background

Issue #61 (RibShark): generating Thumb signatures with all wildcard options selected produces no wildcards.

> This creates the signature "70 B5 1B 4D 04 00" which has no wildcards, despite me selecting otherwise. This is a problem since other versions of this code alter the offset in the 2nd instruction, for instance.

The second instruction is a PC-relative literal load `LDR R5, off_A3940` (bytes `1B 4D`), whose offset byte `1B` shifts between builds and should be wildcarded.

## Bug fixed

1. `OperandProcessor._get_operand_offset_arm` computed the wildcard byte length only for `ins.size == 4` (length 3) and `ins.size == 8` (length 7). There was no case for `ins.size == 2`, so every 16-bit Thumb-1 instruction fell through to length 0. `append_instruction_to_sig` treats length 0 as "no operand" and emits the whole instruction unwildcarded, so no Thumb operand was ever wildcarded.

## Changes

| Commit | What |
|---|---|
| `fe7bfa3` | Map `ins.size == 2 -> length 1`; add mocked ARM operand tests. |

The length is now `ins.size - 1` for sizes in `{2, 4, 8}`. On little-endian ARM/Thumb the immediate/offset lives in the low bytes and the opcode+condition in the high byte, so wildcarding the low `size-1` bytes and keeping the high opcode byte is correct. `off = op.offb` is unchanged (it is 0 for these bit-field operands, which is why the 4- and 8-byte paths already worked).

## Net behavior

For RibShark's `LDR R5, off_A3940` (`1B 4D`), the offset byte is now wildcarded: `?? 4D`. 4- and 8-byte ARM instructions are byte-identical to before. Only `wildcard_operands=True` on ARM is affected; x86/MIPS/PPC are untouched.

## Verification

| Suite | Before | After |
|---|---|---|
| host unit | 238 OK | 241 OK (+3 ARM tests) |

The Docker integration matrix runs against an x86 target and does not exercise the ARM operand path; CI on this PR covers the full matrix.

## Test plan

- [x] `test_thumb_2byte_operand_wildcards_low_byte`: a size-2 operand yields `(off, length) == (0, 1)`.
- [x] `test_4byte_arm_operand_length_unchanged`: size-4 still yields `(0, 3)`.
- [x] `test_thumb_ldr_literal_produces_wildcarded_signature`: `1B 4D -> ?? 4D` on RibShark's exact bytes.
- [ ] On a real Thumb database, FIND_FUNCTION_SIG with all wildcard options produces `?? B5 ?? 4D 04 00` for the reported sequence (LDR offset wildcarded; see the note below on the PUSH byte).

## Notes

Flagged for a separate decision, out of scope here:

- `for_arm()` allows `REGLIST` and `IMM`, so `PUSH {R4-R6,LR}` also wildcards its low byte now (`?? B5`, the register-list byte). A register list is stable across builds, so this costs uniqueness for no robustness gain. It is pre-existing ARM32 behavior that this change extends to Thumb; the reporter opted into it by selecting all wildcard options. Worth revisiting whether the ARM policy should exclude `REGLIST`/`IMM`.
- The ARM path ignores `wildcard_optimized` (unlike x86), so ARM has no conservative mode.
