### PR TITLE
feat: reference-aware ARM operand wildcarding via the operand dialog

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -964,7 +964,21 @@ class WildcardPolicy:
 
     @classmethod
     def for_arm(cls) -> "WildcardPolicy":
-        return cls(frozenset(cls.BaseKind) | frozenset(cls.ARMKind))
+        # Default to address-bearing operands only: direct memory references,
+        # displacements, immediates, and near/far branch targets. is_off refines
+        # the ambiguous imm/displ operands to actual addresses at match time
+        # (see OperandProcessor._get_operand_offset_arm), so bare constants and
+        # stack slots are not wildcarded. Register lists, coprocessor registers,
+        # ARM conditions, arbitrary text, and plain registers are stable across
+        # builds and are left out of the default; users who need register-
+        # tolerant matching enable them in the operand-wildcard dialog.
+        return cls(frozenset({
+            cls.BaseKind.MEM,
+            cls.BaseKind.DISPL,
+            cls.BaseKind.IMM,
+            cls.BaseKind.NEAR,
+            cls.BaseKind.FAR,
+        }))
 
     @classmethod
     def for_mips(cls) -> "WildcardPolicy":
@@ -1269,20 +1283,48 @@ class OperandProcessor:
     def _get_operand_offset_arm(
         self, ins: idaapi.insn_t, off: typing.List[int], length: typing.List[int]
     ) -> bool:
+        # Which operands to wildcard is driven by the user's operand-wildcard
+        # policy (the "Configure operand wildcarding" dialog); the default is
+        # address-bearing types only (see WildcardPolicy.for_arm). On top of the
+        # policy we apply an is_off refinement for the two ambiguous types:
+        # o_imm and o_displ carry both build-varying addresses (ADRP #x@PAGE,
+        # LDR #x@PAGEOFF) and stable constants (#0x40) / stack slots ([SP,#var]).
+        # We wildcard only the ones IDA resolved to an address (is_off), so
+        # selecting "Immediate"/"Displacement" never masks a stable constant.
+        #
+        # Byte range: little-endian ARM/Thumb keeps the opcode+condition in the
+        # high byte and the immediate/offset in the low bytes, so wildcarding the
+        # low ins.size-1 bytes usually suffices (Thumb-1 = 2 bytes -> length 1;
+        # ARM/Thumb-2 = 4 -> 3; 8 -> 7). But some offsets reach into the high
+        # byte: branch targets (Thumb-2 BL/BLX and long B span all bytes) and
+        # AArch64 ADRP (immlo sits in the high byte). For those we must wildcard
+        # the whole instruction, or the offset bits left in the high byte make
+        # the signature miss other builds (issue #61 follow-up).
         policy = WildcardPolicy.current()
+        flags = idaapi.get_flags(ins.ea)
         for op in ins:
-            if op.type in policy.allowed_types:
+            if op.type == idaapi.o_void:
+                continue
+            if op.type not in policy.allowed_types:
+                continue
+            if op.type in (idaapi.o_imm, idaapi.o_displ) and not idaapi.is_off(
+                flags, op.n
+            ):
+                continue
+            # o_imm reaching here is is_off (an address immediate, e.g. ADRP);
+            # together with branch targets its offset can span the high byte.
+            spans_high_byte = op.type in (
+                idaapi.o_near,
+                idaapi.o_far,
+                idaapi.o_imm,
+            )
+            if spans_high_byte:
+                off[0] = 0
+                length[0] = ins.size
+            else:
                 off[0] = op.offb
-                # Wildcard the low ins.size-1 bytes, which hold the immediate /
-                # offset fields on little-endian ARM/Thumb, keeping the high
-                # opcode+condition byte. Thumb-1 is 2 bytes (length 1); ARM and
-                # Thumb-2 are 4 (length 3); 8 covers double-width encodings.
-                # op.offb is 0 for these bit-field operands, which is why the
-                # 4- and 8-byte paths already work. Previously ins.size == 2
-                # fell through to 0, so no Thumb operand was ever wildcarded
-                # (issue #61).
                 length[0] = ins.size - 1 if ins.size in (2, 4, 8) else 0
-                return True
+            return True
         return False
 
     def get_operand(
@@ -1292,9 +1334,9 @@ class OperandProcessor:
         length: typing.List[int],
         wildcard_optimized: bool,
     ) -> bool:
-        policy = WildcardPolicy.current()
         if self._is_arm:
             return self._get_operand_offset_arm(ins, off, length)
+        policy = WildcardPolicy.current()
         for op in ins:
             if op.type == idaapi.o_void:
                 continue

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4359,87 +4359,141 @@ class TestPluginManifestVersion(unittest.TestCase):
         )
 
 
-class TestArmThumbOperandWildcard(unittest.TestCase):
-    """Issue #61: operands of 2-byte Thumb instructions must be wildcarded.
-
-    _get_operand_offset_arm only mapped ins.size 4->3 and 8->7, so every 16-bit
-    Thumb-1 instruction got length 0 and was emitted unwildcarded.
+class TestArmReferenceAwareWildcard(unittest.TestCase):
+    """ARM/Thumb wildcarding respects the operand-wildcard policy, refines the
+    ambiguous imm/displ types to real addresses via is_off, and wildcards the
+    whole instruction where the offset reaches the high byte (branch targets,
+    ADRP). Register-bearing operands stay exact unless the user selects them.
     """
 
-    _OP_TYPE = 991  # stand-in for an allowed ARM operand type (e.g. o_mem)
-
     class _Op:
-        def __init__(self, type_, offb):
+        def __init__(self, type_, offb, n):
             self.type = type_
             self.offb = offb
+            self.n = n
 
     class _Ins:
-        def __init__(self, size, ops):
+        def __init__(self, size, ops, ea=0x1000):
             self.size = size
             self._ops = ops
+            self.ea = ea
 
         def __iter__(self):
             return iter(self._ops)
 
-    def _arm_processor(self):
+    def setUp(self):
+        ia = sigmaker.idaapi
+        self._saved = {
+            k: getattr(ia, k, None) for k in ("get_flags", "is_off", "get_bytes")
+        }
+        ia.get_flags = MagicMock(return_value=0)
+        self._offset_ops = set()  # operand indices IDA marks as offsets
+        ia.is_off = lambda flags, n: n in self._offset_ops
+        # Default test policy: addresses only, matching WildcardPolicy.for_arm.
+        self._addr_types = {ia.o_mem, ia.o_displ, ia.o_imm, ia.o_near, ia.o_far}
+        self._tok = sigmaker.WildcardPolicy.set_current(
+            sigmaker.WildcardPolicy(frozenset(self._addr_types))
+        )
+
+    def tearDown(self):
+        sigmaker.WildcardPolicy.reset_current(self._tok)
+        for k, v in self._saved.items():
+            setattr(sigmaker.idaapi, k, v)
+
+    def _proc(self):
         proc = sigmaker.OperandProcessor()
         proc._is_arm = True  # bypass idaapi.ph_get_id() under the mock
         return proc
 
-    def _with_policy(self):
-        policy = sigmaker.WildcardPolicy(frozenset({self._OP_TYPE}))
-        return sigmaker.WildcardPolicy.set_current(policy)
+    def _run(self, size, ops):
+        off, length = [0], [0]
+        found = self._proc().get_operand(self._Ins(size, ops), off, length, True)
+        return found, off[0], length[0]
 
-    def test_thumb_2byte_operand_wildcards_low_byte(self):
-        proc = self._arm_processor()
-        tok = self._with_policy()
-        try:
-            off, length = [0], [0]
-            ins = self._Ins(2, [self._Op(self._OP_TYPE, 0)])
-            found = proc.get_operand(ins, off, length, wildcard_optimized=True)
-            self.assertTrue(found)
-            self.assertEqual((off[0], length[0]), (0, 1))
-        finally:
-            sigmaker.WildcardPolicy.reset_current(tok)
+    def test_address_immediate_adrp_wildcards_whole_instruction(self):
+        ia = sigmaker.idaapi
+        self._offset_ops = {1}  # ADRP: op1 is the address immediate (is_off)
+        found, off, length = self._run(
+            4, [self._Op(ia.o_reg, 0, 0), self._Op(ia.o_imm, 0, 1)]
+        )
+        self.assertTrue(found)
+        self.assertEqual((off, length), (0, 4))  # immlo reaches the high byte
 
-    def test_4byte_arm_operand_length_unchanged(self):
-        proc = self._arm_processor()
-        tok = self._with_policy()
-        try:
-            off, length = [0], [0]
-            ins = self._Ins(4, [self._Op(self._OP_TYPE, 0)])
-            proc.get_operand(ins, off, length, wildcard_optimized=True)
-            self.assertEqual((off[0], length[0]), (0, 3))
-        finally:
-            sigmaker.WildcardPolicy.reset_current(tok)
+    def test_address_displacement_pageoff_keeps_high_byte(self):
+        ia = sigmaker.idaapi
+        self._offset_ops = {1}  # LDR [X8,#sym@PAGEOFF]: offset in the low bytes
+        found, off, length = self._run(
+            4, [self._Op(ia.o_reg, 0, 0), self._Op(ia.o_displ, 0, 1)]
+        )
+        self.assertTrue(found)
+        self.assertEqual((off, length), (0, 3))
+
+    def test_branch_target_wildcards_whole_instruction(self):
+        # RibShark #61 follow-up: Thumb-2 BL/BLX and long B put offset bits in
+        # the high byte, so the whole instruction must be masked.
+        ia = sigmaker.idaapi
+        self._offset_ops = set()  # near targets carry a code xref, not is_off
+        found, off, length = self._run(4, [self._Op(ia.o_near, 0, 0)])
+        self.assertTrue(found)
+        self.assertEqual((off, length), (0, 4))
+
+    def test_o_mem_literal_keeps_opcode_byte(self):
+        # Thumb "LDR Rt, off_X" (o_mem): imm8 is the low byte, opcode the high.
+        ia = sigmaker.idaapi
+        self._offset_ops = set()
+        found, off, length = self._run(2, [self._Op(ia.o_mem, 0, 0)])
+        self.assertTrue(found)
+        self.assertEqual((off, length), (0, 1))
 
     def test_thumb_ldr_literal_produces_wildcarded_signature(self):
-        # RibShark #61: LDR R5, off (bytes 1B 4D) must become "?? 4D".
-        proc = self._arm_processor()
+        # #61 stays fixed and specific: 1B 4D -> ?? 4D.
+        ia = sigmaker.idaapi
+        self._offset_ops = set()
         instr = b"\x1B\x4D"
         ea = 0x1000
-        orig_get_bytes = sigmaker.idaapi.get_bytes
-        sigmaker.idaapi.get_bytes = (
-            lambda addr, count: instr[addr - ea: addr - ea + count]
+        ia.get_bytes = lambda a, c: instr[a - ea: a - ea + c]
+        sig = sigmaker.Signature()
+        ins = self._Ins(2, [self._Op(ia.o_mem, 0, 0)], ea=ea)
+        sigmaker.InstructionProcessor(self._proc()).append_instruction_to_sig(
+            sig, ea, ins, wildcard_operands=True, wildcard_optimized=True
         )
-        tok = self._with_policy()
-        try:
-            iproc = sigmaker.InstructionProcessor(proc)
-            sig = sigmaker.Signature()
-            ins = self._Ins(2, [self._Op(self._OP_TYPE, 0)])
-            iproc.append_instruction_to_sig(
-                sig, ea, ins, wildcard_operands=True, wildcard_optimized=True
-            )
-            self.assertEqual(
-                list(sig),
-                [
-                    sigmaker.SignatureByte(0x1B, True),
-                    sigmaker.SignatureByte(0x4D, False),
-                ],
-            )
-        finally:
-            sigmaker.WildcardPolicy.reset_current(tok)
-            sigmaker.idaapi.get_bytes = orig_get_bytes
+        self.assertEqual(
+            list(sig),
+            [
+                sigmaker.SignatureByte(0x1B, True),
+                sigmaker.SignatureByte(0x4D, False),
+            ],
+        )
+
+    def test_bare_immediate_not_wildcarded(self):
+        # o_imm without is_off is a stable constant (#0x40) -> stays exact.
+        ia = sigmaker.idaapi
+        self._offset_ops = set()
+        found, _, _ = self._run(4, [self._Op(ia.o_imm, 0, 0)])
+        self.assertFalse(found)
+
+    def test_stack_displacement_not_wildcarded(self):
+        # o_displ without is_off is a stack slot ([SP,#var]) -> stays exact.
+        ia = sigmaker.idaapi
+        self._offset_ops = set()
+        found, _, _ = self._run(4, [self._Op(ia.o_displ, 0, 0)])
+        self.assertFalse(found)
+
+    def test_register_list_exact_by_default(self):
+        # Not in the addresses-only default policy -> PUSH {R4-R6,LR} stays 70 B5.
+        reglist = sigmaker.WildcardPolicy.ARMKind.REGLIST
+        found, _, _ = self._run(2, [self._Op(reglist, 0, 0)])
+        self.assertFalse(found)
+
+    def test_register_list_wildcarded_when_selected(self):
+        # User enables "Register list" in the operand dialog (broad mode).
+        reglist = sigmaker.WildcardPolicy.ARMKind.REGLIST
+        with sigmaker.WildcardPolicy.use(
+            sigmaker.WildcardPolicy(frozenset(self._addr_types | {reglist}))
+        ):
+            found, off, length = self._run(2, [self._Op(reglist, 0, 0)])
+        self.assertTrue(found)
+        self.assertEqual((off, length), (0, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background

Follow-up to #62, incorporating RibShark's testing feedback on #61.

The first cut of this PR *replaced* the operand-type policy with an `is_off` check. That was wrong in two ways: it ignored the user's "Configure operand wildcarding" dialog, and it had a byte-precision bug (branch offsets that reach the high byte were left partly exact). This revision fixes both.

## What changed

1. **Respect the operand-wildcard dialog on ARM.** `_get_operand_offset_arm` goes back through `WildcardPolicy.current()` (the dialog's selection). `for_arm()` now defaults to address-bearing types only (Memory, Displacement, Immediate, Near, Far), so out of the box it is precise. "Register list" / "General Register" / etc. are one checkbox away for register-tolerant matching, so there is **no new option** (this is RibShark's aggressive-vs-precise toggle, via the dialog that already exists).

2. **`is_off` refinement for the ambiguous types.** On ARM, addresses live in `o_imm` (`ADRP #x@PAGE`) and `o_displ` (`LDR #x@PAGEOFF`), but so do stable constants (`#0x40`) and stack slots (`[SP,#var]`). When Immediate/Displacement is selected, only the ones IDA resolved to an address (`is_off`) are wildcarded, so constants and stack slots stay exact.

3. **Byte-range fix (RibShark's `BL` bug).** A Thumb-2 `BL`/`BLX` (and long `B`, and AArch64 `ADRP`) put offset bits in the high byte, so the old "keep the high opcode byte" heuristic left them exact and the signature missed other builds (`FF` vs `F8`). Those now wildcard the whole instruction; other address operands keep the high opcode byte (so #61's Thumb literal stays the specific `?? 4D`).

## Verification

- Host unit suite: 247 OK. 9 ARM cases: address immediate -> whole instruction; displacement -> low bytes; branch -> whole; `o_mem` literal -> `?? 4D`; bare immediate / stack slot -> exact; reg-list exact by default / wildcarded when selected.
- Real AArch64 database: `ADRP`/`ADRL`/`ADR` and `BL`/`B`/`CBZ`/`TBZ` wildcard the whole instruction; `LDR@PAGEOFF` masks the low bytes; `SUB`/`STP [SP,#var]`/`MOV #imm` stay exact; 29% wildcard rate.
- CI Docker matrix on the PR.

## Notes

- Stacked on #62; the first commit is #62's Thumb length fix.
- "Broad vs precise" is the existing operand-wildcard dialog, default precise. No new config surface.
