### PR TITLE
chore: release 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.10.0] - 2026-07-03
+
+### Fixed
+
+- **ARM Thumb operands are now wildcarded.** Operand wildcarding sized the mask only for 4- and 8-byte instructions, so every 16-bit Thumb-1 instruction got a wildcard length of 0 and was left fully literal (a PC-relative literal load like `LDR R5, off_X` kept its build-varying offset byte). 2-byte Thumb now wildcards the offset while keeping the opcode byte. ([#61](https://github.com/mahmoudimus/ida-sigmaker/issues/61), [#62](https://github.com/mahmoudimus/ida-sigmaker/pull/62))
+- **ARM/Thumb branch and `ADRP` offsets that reach the high byte are fully masked.** Thumb-2 `BL`/`BLX`, long `B`, and AArch64 `ADRP` place offset bits in the high opcode byte; masking only the low bytes left those bits literal, so a signature could miss other builds (the reporter saw an offset nibble change from `FF` to `F8`). These instructions now wildcard the whole instruction. ([#61](https://github.com/mahmoudimus/ida-sigmaker/issues/61), [#65](https://github.com/mahmoudimus/ida-sigmaker/pull/65))
+
+### Changed
+
+- **ARM operand wildcarding is address-aware and driven by the operand dialog.** The default now wildcards only address-bearing operands (memory references, displacements, immediates, and branch targets), refined by IDA's offset flag so real addresses (`ADRP #x@PAGE`, `LDR #x@PAGEOFF`) are masked while bare constants (`#0x40`) and stack slots (`[SP,#var]`) stay exact. For targets where registers move between builds, enable "General Register" and/or "Register list" in the "Configure operand wildcarding" dialog. ([#65](https://github.com/mahmoudimus/ida-sigmaker/pull/65))
+
+[1.10.0]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.9.2...v1.10.0
+
 ## [1.9.2] - 2026-06-19
 
 ### Fixed

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.9.2"
+        "version": "1.10.0"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -26,7 +26,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.9.2"
+__version__ = "1.10.0"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
Release 1.10.0: version bump + CHANGELOG for the ARM/Thumb operand wildcarding work shipped since v1.9.2.

- #62: 2-byte Thumb operands are now wildcarded (#61).
- #65: reference-aware ARM wildcarding (respects the operand dialog, addresses-only default refined by is_off) and the branch/ADRP high-byte offset fix.

Tagging `v1.10.0` after merge triggers the release workflow (single-file `sigmaker.py` + wheel + GitHub release).