### PR TITLE
feat: opt-in per-segment signature scope (#64)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -516,6 +516,22 @@ class InMemoryBuffer:
 
         return _map
 
+    def _load_single_segment(self, ea: int):
+        """Load only the segment containing ``ea`` (issue #64), recording it in
+        the segment map so offset_mapper resolves match addresses correctly.
+
+        Falls back to loading all segments when ``ea`` is not inside any
+        segment, so callers never end up with an empty corpus by accident.
+        """
+        seg = idaapi.getseg(ea)
+        if seg is None:
+            self._load_segments()
+            return
+        data = idaapi.get_bytes(seg.start_ea, seg.end_ea - seg.start_ea)
+        if data:
+            self._segments.append((len(self._buffer), int(seg.start_ea), len(data)))
+            self._buffer.extend(data)
+
     def _load_input_file(self):
         """Load the original input file into a buffer."""
         if not self.file_path.exists():
@@ -528,10 +544,13 @@ class InMemoryBuffer:
         cls,
         file_path: str | pathlib.Path | None = None,
         mode: "InMemoryBuffer.LoadMode" = LoadMode.SEGMENTS,
+        scope_ea: typing.Optional[int] = None,
     ) -> "InMemoryBuffer":
         """
         Load the buffer using the specified mode.
         mode: _LoadMode.SEGMENTS (default) or _LoadMode.FILE
+        scope_ea: in SEGMENTS mode, load only the segment containing this
+            address instead of all segments (issue #64). Ignored in FILE mode.
         """
         if file_path is None:
             file_path = idaapi.get_input_file_path()
@@ -540,6 +559,8 @@ class InMemoryBuffer:
         instance = cls(file_path=file_path, mode=mode)
         if mode == cls.LoadMode.FILE:
             instance._load_input_file()
+        elif scope_ea is not None:
+            instance._load_single_segment(scope_ea)
         else:
             instance._load_segments()
         return instance
@@ -621,6 +642,11 @@ class SigMakerConfig:
     # Issue #22: when True, cancelling a unique-signature search emits the
     # partial signature with its match count instead of nothing. Default off.
     output_partial_on_cancel: bool = False
+    # Issue #64: when True, scope uniqueness to the segment containing the
+    # anchor instead of the whole database. Lets you sign functions that are
+    # duplicated across segments (e.g. a boot section and a main section) as
+    # long as the eventual search is scoped to the same segment. Default off.
+    scope_to_segment: bool = False
 
 
 @dataclasses.dataclass(slots=True, frozen=True, repr=False)
@@ -1553,6 +1579,12 @@ class UniqueSignatureGenerator:
         # first scan; buf holds the segment buffer the offsets index into.
         offsets: typing.Optional[list[int]] = None
         buf: typing.Optional["InMemoryBuffer"] = None
+        if cfg.scope_to_segment:
+            # Issue #64: scope uniqueness to the anchor's segment. Pre-load it so
+            # the seed scan and every refinement stay within the segment.
+            buf = InMemoryBuffer.load(
+                mode=InMemoryBuffer.LoadMode.SEGMENTS, scope_ea=ea
+            )
 
         def build_partial() -> GeneratedSignature:
             # Trim trailing wildcards, mirror the success path.
@@ -1616,11 +1648,13 @@ class UniqueSignatureGenerator:
                 if not SIMD_SPEEDUP_AVAILABLE:
                     # Non-SIMD builds have no in-memory buffer to refine
                     # against, so fall back to the per-step rescan.
-                    count = SignatureSearcher.count_matches(f"{sig:ida}")
+                    count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
                 elif offsets is None:
                     # Seed once: scan the whole database, keep every match
                     # offset. The candidate count is the exact match count.
-                    offsets, buf = SignatureSearcher.find_all_offsets(f"{sig:ida}")
+                    offsets, buf = SignatureSearcher.find_all_offsets(
+                        f"{sig:ida}", buf=buf
+                    )
                     count = len(offsets)
                 else:
                     # Refine the surviving candidates in memory for each byte
@@ -1931,7 +1965,10 @@ class MinimalFunctionSignatureGenerator:
         index: typing.Optional["_ByteIndex"] = None
         if SIMD_SPEEDUP_AVAILABLE:
             with ProgressDialog("Please stand by, copying segments..."):
-                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+                buf = InMemoryBuffer.load(
+                    mode=InMemoryBuffer.LoadMode.SEGMENTS,
+                    scope_ea=int(pfn.start_ea) if cfg.scope_to_segment else None,
+                )
             # Build the 2-byte position index once for the whole search so each
             # anchor seeds with an O(1) lookup instead of a full-buffer scan.
             index = _ByteIndex.build(buf.data())
@@ -3245,7 +3282,8 @@ Quick Options:
 <#Don't stop signature generation when reaching end of function#Continue when leaving function scope:{cContinueOutside}>
 <#Wildcard the whole instruction when the operand (usually a register) is encoded into the operator#Wildcard optimized / combined instructions:{cWildcardOptimized}>
 <#Opt-in -- show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>
-<#Opt-in -- when you cancel a unique-signature search, output the partial signature (with match count) instead of nothing. Default off. (Issue #22)#Output partial signature on cancel (opt-in):{cOutputPartialOnCancel}>{cGroupOptions}>
+<#Opt-in -- when you cancel a unique-signature search, output the partial signature (with match count) instead of nothing. Default off. (Issue #22)#Output partial signature on cancel (opt-in):{cOutputPartialOnCancel}>
+<#Opt-in -- scope uniqueness to the segment containing the anchor instead of the whole database, so functions duplicated across segments (e.g. a boot section and a main section) can be signed. Scope your search to the same segment. (Issue #64)#Limit uniqueness to the containing segment (opt-in):{cScopeToSegment}>{cGroupOptions}>
 
 <Operand types...:{bOperandTypes}><Other options...:{bOtherOptions}>
 """
@@ -3272,6 +3310,7 @@ Quick Options:
                     "cWildcardOptimized",
                     "cEnablePrompt",
                     "cOutputPartialOnCancel",
+                    "cScopeToSegment",
                 ),
                 # Bits: 1 (wildcards) + 4 (wildcard optimized). Bit 8 (enable
                 # prompt) and bit 16 (output partial on cancel) default OFF.
@@ -3457,6 +3496,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             wildcard_optimized = bool(form.cGroupOptions.value & 4)  # type: ignore
             enable_continue_prompt = bool(form.cGroupOptions.value & 8)  # type: ignore
             output_partial_on_cancel = bool(form.cGroupOptions.value & 16)  # type: ignore
+            scope_to_segment = bool(form.cGroupOptions.value & 32)  # type: ignore
 
         # Create SigMakerConfig
         config = SigMakerConfig(
@@ -3466,6 +3506,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             wildcard_optimized=wildcard_optimized,
             enable_continue_prompt=enable_continue_prompt,
             output_partial_on_cancel=output_partial_on_cancel,
+            scope_to_segment=scope_to_segment,
         )
 
         try:

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2269,7 +2269,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         with patch.object(
             sigmaker.SignatureSearcher,
             "count_matches",
-            side_effect=lambda *_: next(counts),
+            side_effect=lambda *_, **__: next(counts),
         ):
             result = gen.generate(
                 0x1000, self._make_cfg(), policy=sigmaker.GenerationPolicy.permissive()
@@ -2306,7 +2306,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         counts = iter([100, 50, 0])
         user_canceled_state = {"value": False}
 
-        def fake_count_matches(_ida_sig):
+        def fake_count_matches(_ida_sig, buf=None):
             v = next(counts)
             if v == 0:
                 # Simulate find_all bailing because the user just clicked Cancel.
@@ -2350,7 +2350,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         gen = self._make_generator(cancel_after_iterations=1)
         user_canceled_state = {"value": False}
 
-        def fake_count_matches(_ida_sig):
+        def fake_count_matches(_ida_sig, buf=None):
             # First (and only) call returns 0 with cancel flag already set.
             user_canceled_state["value"] = True
             return 0
@@ -2390,7 +2390,7 @@ class TestUniqueSignatureGeneratorPartialOnCancel(CoveredUnitTest):
         with patch.object(
             sigmaker.SignatureSearcher,
             "count_matches",
-            side_effect=lambda *_: next(counts),
+            side_effect=lambda *_, **__: next(counts),
         ):
             gen.generate(
                 0x1000,
@@ -4557,6 +4557,67 @@ class TestSearchAddressMapping(unittest.TestCase):
         buf = self._two_segment_buffer()
         matches = sigmaker.SignatureSearcher._find_all_simd("F1 B5 04 00", buf=buf)
         self.assertEqual([int(m.address) for m in matches], [0x1F78000])
+
+
+class TestSegmentScope(unittest.TestCase):
+    """Issue #64: scope_to_segment loads only the anchor's segment as the
+    uniqueness corpus, so functions duplicated across segments can be signed."""
+
+    _SEG_KEYS = (
+        "getseg", "get_bytes", "get_first_seg", "get_next_seg",
+        "get_input_file_path", "get_imagebase",
+    )
+
+    def setUp(self):
+        self._saved = {k: getattr(sigmaker.idaapi, k, None) for k in self._SEG_KEYS}
+        sigmaker.idaapi.get_input_file_path = MagicMock(return_value="/x")
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(sigmaker.idaapi, k, v)
+
+    def _load(self, **kw):
+        return sigmaker.InMemoryBuffer.load(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS, **kw
+        )
+
+    def test_scope_ea_loads_only_containing_segment(self):
+        seg = MagicMock(start_ea=0x2000, end_ea=0x2010)
+        sigmaker.idaapi.getseg = MagicMock(return_value=seg)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\xAA" * 0x10)
+        buf = self._load(scope_ea=0x2008)
+        self.assertEqual(bytes(buf.data()), b"\xAA" * 0x10)
+        sigmaker.idaapi.getseg.assert_called_once_with(0x2008)
+        sigmaker.idaapi.get_bytes.assert_called_once_with(0x2000, 0x10)
+
+    def test_no_scope_loads_all_segments(self):
+        s1 = MagicMock(start_ea=0, end_ea=4)
+        sigmaker.idaapi.get_first_seg = MagicMock(return_value=s1)
+        sigmaker.idaapi.get_next_seg = MagicMock(return_value=None)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x01\x02\x03\x04")
+        sigmaker.idaapi.getseg = MagicMock(
+            side_effect=AssertionError("getseg must not be used without scope_ea")
+        )
+        buf = self._load()
+        self.assertEqual(bytes(buf.data()), b"\x01\x02\x03\x04")
+
+    def test_scope_ea_without_segment_falls_back_to_all(self):
+        sigmaker.idaapi.getseg = MagicMock(return_value=None)
+        s1 = MagicMock(start_ea=0, end_ea=2)
+        sigmaker.idaapi.get_first_seg = MagicMock(return_value=s1)
+        sigmaker.idaapi.get_next_seg = MagicMock(return_value=None)
+        sigmaker.idaapi.get_bytes = MagicMock(return_value=b"\x09\x09")
+        buf = self._load(scope_ea=0x9999)
+        self.assertEqual(bytes(buf.data()), b"\x09\x09")
+
+    def test_config_scope_to_segment_defaults_false(self):
+        cfg = sigmaker.SigMakerConfig(
+            output_format=sigmaker.SignatureType.IDA,
+            wildcard_operands=False,
+            continue_outside_of_function=False,
+            wildcard_optimized=False,
+        )
+        self.assertFalse(cfg.scope_to_segment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Background

Closes #64. RibShark: in firmware, functions are duplicated between a boot section and a main section, so a whole-database-unique signature is impossible (even growing outside the function exceeds the length budget). Requested scoping uniqueness to a single segment, since the eventual search can be scoped to the same segment.

## Change

Opt-in `SigMakerConfig.scope_to_segment` (default `False`, appended so the library contract and current behavior are unchanged). When on, uniqueness is checked against only the segment containing the anchor, instead of the whole database.

- `InMemoryBuffer.load(scope_ea=)` loads only the segment containing the address (`idaapi.getseg` -> `[start_ea, end_ea)`), falling back to all segments if the address is in none.
- `UniqueSignatureGenerator` pre-loads the anchor's segment and threads that buffer through `count_matches` / `find_all_offsets`, so the seed scan and every refinement stay within the segment.
- `MinimalFunctionSignatureGenerator` scopes its buffer and byte index to the function's segment.
- A new **"Limit uniqueness to the containing segment (opt-in)"** checkbox in the options form (`cGroupOptions` bit 32).

The anchor address comes from the function, not the buffer, so only the match *count* needs scoping; loading one segment is enough (and simpler for address mapping than the all-segments buffer).

## Design decisions

- Scope is the function's **own** segment (auto-detected). No segment picker.
- Exposed as one checkbox, off by default. Making it automatic would silently produce signatures that are only segment-unique, which would surprise anyone searching the whole database.

## Verification

- Host unit suite: 250 -> 254 OK (rebased on #68, which merged first). New `TestSegmentScope`: `scope_ea` loads only the containing segment; no `scope_ea` loads all segments (unchanged); a `scope_ea` with no segment falls back to all; `scope_to_segment` defaults `False`.
- CI Docker matrix on the PR (both IDA images green).

## Notes

- Rebased on #68 (search address mapping). `_load_single_segment` now records the scoped segment in the buffer's segment map, so a follow-up scoped *search* resolves match addresses through the same #68 `offset_mapper` path.
- Non-goal: no segment picker; `RangeSignatureGenerator` emits a fixed range and does not search for uniqueness, so it is unaffected.
- When using a segment-scoped signature, scope the *search* to the same segment (as RibShark noted). Wiring the search UI to do that automatically is the tracked follow-up on #64.
- Updated the non-SIMD `PartialOnCancel` test mocks to accept the `buf` keyword that `count_matches` already declared.
