### PR TITLE
fix: correct search-match addresses across non-contiguous segments (#68)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -461,6 +461,13 @@ class InMemoryBuffer:
     _buffer: bytearray = dataclasses.field(
         default_factory=bytearray, init=False, repr=False
     )
+    # (buffer_offset, seg_start_ea, size) per loaded segment, in buffer order.
+    # Segments are concatenated tightly, so a buffer offset does not equal an
+    # address once segments are non-contiguous (e.g. an extra binary loaded at a
+    # distant address). This maps a match offset back to its real address (#68).
+    _segments: list = dataclasses.field(
+        default_factory=list, init=False, repr=False
+    )
 
     @property
     def file_size(self) -> int:
@@ -471,15 +478,43 @@ class InMemoryBuffer:
         return idaapi.get_imagebase()
 
     def _load_segments(self):
-        """Load all IDA segments into a single contiguous bytearray buffer."""
+        """Load all IDA segments into a single contiguous bytearray buffer,
+        recording each segment's buffer offset so a match offset can be mapped
+        back to its real address (segments need not be contiguous, #68)."""
         buf = self._buffer
         seg = idaapi.get_first_seg()
         while seg:
             size = seg.end_ea - seg.start_ea
             data = idaapi.get_bytes(seg.start_ea, size)
             if data:
+                self._segments.append((len(buf), int(seg.start_ea), len(data)))
                 buf.extend(data)
             seg = idaapi.get_next_seg(seg.start_ea)
+
+    def offset_mapper(self) -> typing.Callable[[int], int]:
+        """Return a callable that maps ASCENDING buffer offsets to real IDA
+        addresses. Segments are concatenated tightly even when their addresses
+        are not contiguous, so ``imagebase + offset`` is wrong past the first
+        non-contiguous segment (#68). The callable walks the segment map with a
+        forward cursor, so mapping a run of ascending match offsets costs
+        amortized O(1) each (vs a per-match binary search). Falls back to
+        ``imagebase + offset`` when there is no segment map (FILE mode).
+        """
+        segs = self._segments
+        if not segs:
+            imagebase = self.imagebase
+            return lambda offset: imagebase + offset
+        state = [0]
+
+        def _map(offset: int) -> int:
+            i = state[0]
+            while i + 1 < len(segs) and segs[i + 1][0] <= offset:
+                i += 1
+            state[0] = i
+            buf_off, seg_ea, _size = segs[i]
+            return seg_ea + (offset - buf_off)
+
+        return _map
 
     def _load_input_file(self):
         """Load the original input file into a buffer."""
@@ -2517,6 +2552,10 @@ class SignatureSearcher:
 
         n = len(data_mv)
         off = 0
+        # Matches arrive in ascending offset order, so map each offset to its
+        # real address with a forward cursor (amortized O(1) per match); see
+        # InMemoryBuffer.offset_mapper.
+        to_addr = buf.offset_mapper()
         # Poll cancellation every _CANCEL_POLL_STRIDE matches (see
         # find_all_offsets) so per-match user_cancelled() overhead does not
         # dominate a scan over a short, common pattern.
@@ -2532,8 +2571,7 @@ class SignatureSearcher:
             idx = _simd_scan_bytes(data_mv[off:], sig)
             if idx < 0:
                 break
-            ea = base + off + idx
-            results.append(Match(ea))
+            results.append(Match(to_addr(off + idx)))
             if skip_more_than_one and len(results) > 1:
                 break
             off += idx + 1

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4496,6 +4496,69 @@ class TestArmReferenceAwareWildcard(unittest.TestCase):
         self.assertEqual((off, length), (0, 1))
 
 
+class TestSearchAddressMapping(unittest.TestCase):
+    """Issue #68: a SIMD-search match maps back to its real IDA address even
+    when segments are non-contiguous (e.g. an extra binary loaded at a distant
+    address). Previously the address was inf_get_min_ea() + buffer_offset, which
+    is wrong past the first non-contiguous segment."""
+
+    _KEYS = (
+        "get_first_seg", "get_next_seg", "get_bytes", "get_input_file_path",
+        "get_imagebase", "inf_get_min_ea",
+    )
+
+    def setUp(self):
+        self._saved = {k: getattr(sigmaker.idaapi, k, None) for k in self._KEYS}
+        sigmaker.idaapi.get_input_file_path = MagicMock(return_value="/x")
+        sigmaker.idaapi.get_imagebase = MagicMock(return_value=0x1000)
+        sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(sigmaker.idaapi, k, v)
+
+    def _two_segment_buffer(self):
+        # seg1 @ 0x1000 (4 bytes) then seg2 @ 0x1F78000 (4 bytes): the second is
+        # far from the first, exactly the "extra binary loaded at 0x1F78000" case.
+        s1 = MagicMock(start_ea=0x1000, end_ea=0x1004)
+        s2 = MagicMock(start_ea=0x1F78000, end_ea=0x1F78004)
+        sigmaker.idaapi.get_first_seg = MagicMock(return_value=s1)
+        sigmaker.idaapi.get_next_seg = MagicMock(
+            side_effect=lambda ea: s2 if ea == 0x1000 else None
+        )
+
+        def gb(ea, size):
+            return {0x1000: b"\xAA\xBB\xCC\xDD", 0x1F78000: b"\xF1\xB5\x04\x00"}.get(
+                ea, b""
+            )
+
+        sigmaker.idaapi.get_bytes = MagicMock(side_effect=gb)
+        return sigmaker.InMemoryBuffer.load(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS
+        )
+
+    def test_offset_mapper_across_noncontiguous_segments(self):
+        buf = self._two_segment_buffer()
+        m = buf.offset_mapper()
+        # buffer: AA BB CC DD | F1 B5 04 00  (offsets 0-3 seg1, 4-7 seg2). The
+        # mapper walks a forward cursor, so it expects ascending offsets (as
+        # match positions are).
+        self.assertEqual(m(0), 0x1000)
+        self.assertEqual(m(3), 0x1003)
+        self.assertEqual(m(4), 0x1F78000)  # not 0x1004
+        self.assertEqual(m(6), 0x1F78002)
+
+    def test_offset_mapper_fallback_without_map(self):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        self.assertEqual(buf.offset_mapper()(0x40), 0x1000 + 0x40)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_reports_real_address_in_second_segment(self):
+        buf = self._two_segment_buffer()
+        matches = sigmaker.SignatureSearcher._find_all_simd("F1 B5 04 00", buf=buf)
+        self.assertEqual([int(m.address) for m in matches], [0x1F78000])
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Background

Closes #68. RibShark loads an additional binary (a decompressed chunk) at `0x1F78000`. Searching for a signature in that chunk returns a wrong address (`0x570000`); making signatures is fine. Confirmed pre-existing (independent of #64/#67).

## Root cause

The SIMD search path `_find_all_simd` computed a match address as `inf_get_min_ea() + buffer_offset`. `InMemoryBuffer._load_segments` concatenates all segments **tightly**, so a buffer offset only equals an address while segments are contiguous from the min EA. The extra chunk at `0x1F78000` sits far above the main image, so `base + offset` lands at `0x570000`.

- SIMD-only: the non-SIMD `find_all` uses `idaapi.bin_search` (real addresses), and generation uses the anchor address (not the buffer), so both were already correct. That matches 'making signatures works fine'.

## Fix

Record a `(buffer_offset, seg_start_ea, size)` map while concatenating segments, and translate each match offset through `InMemoryBuffer.offset_to_addr` (`seg_start_ea + (offset - buffer_offset)`, binary-searched) instead of `base + offset`. Falls back to `imagebase + offset` when there is no map (FILE mode).

## Verification

- Host unit suite 247 -> 250 OK. New `TestSearchAddressMapping`, including a SIMD test that searches RibShark's exact bytes (`F1 B5 04 00`) in a segment at `0x1F78000` and asserts the match reports `0x1F78000`.
- CI Docker matrix on the PR.