### PR TITLE
feat: scope "Search for a signature" to the containing segment (#64)

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -2543,19 +2543,33 @@ class SignatureSearcher:
     def from_signature(cls, input_signature: str) -> "SignatureSearcher":
         return cls(input_signature=input_signature)
 
-    def search(self) -> SearchResults:
+    def search(self, scope_ea: typing.Optional[int] = None) -> SearchResults:
+        """Parse the signature and scan for matches.
+
+        When ``scope_ea`` is given, the scan is limited to the segment
+        containing it (issue #64: search a segment-scoped signature within the
+        same segment). Falls back to the whole database when ``scope_ea`` is in
+        no segment, so a scoped request never silently returns nothing.
+        """
         sig_str = SignatureParser.parse(self.input_signature)
         if not sig_str:
             idaapi.msg("Unrecognized signature type\n")
             return SearchResults([], "")
 
+        scope = None
+        if scope_ea is not None:
+            seg = idaapi.getseg(scope_ea)
+            if seg is not None:
+                scope = (int(seg.start_ea), int(seg.end_ea))
+
+        where = "the current segment" if scope else "the whole database"
         # Wrap the search in a ProgressDialog to allow cancellation
         with ProgressDialog(
             "Search for a signature\n\n"
-            "Scanning the whole database for your pattern.\n\n"
+            f"Scanning {where} for your pattern.\n\n"
             "Press Cancel to stop"
         ):
-            matches = self.find_all(sig_str)
+            matches = self.find_all(sig_str, scope=scope)
 
         return SearchResults(matches, sig_str)
 
@@ -2659,17 +2673,29 @@ class SignatureSearcher:
         ida_signature: str,
         buf: typing.Optional["InMemoryBuffer"] = None,
         skip_more_than_one: bool = False,
+        scope: typing.Optional[tuple[int, int]] = None,
     ) -> list[Match]:
         # Use SIMD if available
         if SIMD_SPEEDUP_AVAILABLE:
+            if buf is None and scope is not None:
+                # Scope the SIMD scan to one segment by loading only its bytes;
+                # offset_mapper resolves the match offsets back to real
+                # addresses (issue #64 search-scope, on top of #68).
+                with ProgressDialog("Please stand by, copying the segment..."):
+                    buf = InMemoryBuffer.load(
+                        mode=InMemoryBuffer.LoadMode.SEGMENTS, scope_ea=scope[0]
+                    )
             return SignatureSearcher._find_all_simd(
                 ida_signature, skip_more_than_one=skip_more_than_one, buf=buf
             )
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
         out: list[Match] = []
-        ea = idaapi.inf_get_min_ea()
-        max_ea = idaapi.inf_get_max_ea()
+        if scope is not None:
+            ea, max_ea = scope
+        else:
+            ea = idaapi.inf_get_min_ea()
+            max_ea = idaapi.inf_get_max_ea()
         _bin_search = getattr(idaapi, "bin_search", None) or getattr(
             idaapi, "bin_search3"
         )
@@ -3283,7 +3309,7 @@ Quick Options:
 <#Wildcard the whole instruction when the operand (usually a register) is encoded into the operator#Wildcard optimized / combined instructions:{cWildcardOptimized}>
 <#Opt-in -- show periodic 'Continue?' prompts while generating. Default is a wait-box with a Cancel button.#Enable continue prompt (opt-in):{cEnablePrompt}>
 <#Opt-in -- when you cancel a unique-signature search, output the partial signature (with match count) instead of nothing. Default off. (Issue #22)#Output partial signature on cancel (opt-in):{cOutputPartialOnCancel}>
-<#Opt-in -- scope uniqueness to the segment containing the anchor instead of the whole database, so functions duplicated across segments (e.g. a boot section and a main section) can be signed. Scope your search to the same segment. (Issue #64)#Limit uniqueness to the containing segment (opt-in):{cScopeToSegment}>{cGroupOptions}>
+<#Opt-in -- scope to the segment containing the anchor instead of the whole database, so functions duplicated across segments (e.g. a boot section and a main section) can be signed. Creation checks uniqueness within that segment; Search is scoped to the segment under your cursor. (Issue #64)#Limit uniqueness and search to the containing segment (opt-in):{cScopeToSegment}>{cGroupOptions}>
 
 <Operand types...:{bOperandTypes}><Other options...:{bOtherOptions}>
 """
@@ -3547,8 +3573,15 @@ class SigMakerPlugin(idaapi.plugin_t):
                     "", idaapi.HIST_SRCH, "Enter a signature"
                 )
                 if input_signature:
+                    # Reuse the "containing segment" opt-in to scope the search
+                    # to the segment under the cursor (issue #64).
+                    scope_ea = (
+                        idaapi.get_screen_ea()
+                        if config.scope_to_segment
+                        else None
+                    )
                     searcher = SignatureSearcher.from_signature(input_signature)
-                    results = searcher.search()
+                    results = searcher.search(scope_ea=scope_ea)
                     results.display()
                 else:
                     idaapi.msg("No signature entered!\n")

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4620,6 +4620,92 @@ class TestSegmentScope(unittest.TestCase):
         self.assertFalse(cfg.scope_to_segment)
 
 
+class TestSearchScope(unittest.TestCase):
+    """Issue #64 follow-up: 'Search for a signature' honors the containing-
+    segment scope, so a segment-scoped signature can be searched within just
+    that segment instead of the whole database."""
+
+    def setUp(self):
+        self._saved_simd = sigmaker.SIMD_SPEEDUP_AVAILABLE
+        self._saved_canceled = sigmaker.idaapi_user_canceled
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+
+    def tearDown(self):
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = self._saved_simd
+        sigmaker.idaapi_user_canceled = self._saved_canceled
+
+    def test_find_all_scope_bounds_binsearch_to_segment(self):
+        # non-SIMD path: bin_search runs over [scope_start, scope_end), not the
+        # whole [min_ea, max_ea).
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = False
+        sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
+        sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
+        sigmaker.idaapi.inf_get_max_ea = MagicMock(return_value=0xFFFFFF)
+        sigmaker.idaapi.compiled_binpat_vec_t = MagicMock
+        sigmaker.idaapi.parse_binpat_str = MagicMock()
+        sigmaker.idaapi.BIN_SEARCH_NOCASE = 0
+        sigmaker.idaapi.BIN_SEARCH_FORWARD = 0
+        bs = MagicMock(
+            side_effect=[(0x2100, None), (sigmaker.idaapi.BADADDR, None)]
+        )
+        sigmaker.idaapi.bin_search = bs
+        results = sigmaker.SignatureSearcher.find_all(
+            "48 8B C4", scope=(0x2000, 0x2200)
+        )
+        self.assertEqual([int(m) for m in results], [0x2100])
+        first_call = bs.call_args_list[0]
+        self.assertEqual(first_call.args[0], 0x2000)  # starts at scope start
+        self.assertEqual(first_call.args[1], 0x2200)  # bounded by scope end
+
+    def test_find_all_scope_loads_single_segment_for_simd(self):
+        # SIMD path: a scoped search with no buffer loads only that segment and
+        # threads it into the scan.
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = True
+        with patch.object(sigmaker, "ProgressDialog", MagicMock()), \
+                patch.object(sigmaker.InMemoryBuffer, "load") as load, \
+                patch.object(
+                    sigmaker.SignatureSearcher, "_find_all_simd", return_value=[]
+                ) as simd:
+            sigmaker.SignatureSearcher.find_all("48 8B C4", scope=(0x2000, 0x2200))
+        load.assert_called_once()
+        self.assertEqual(load.call_args.kwargs.get("scope_ea"), 0x2000)
+        self.assertIs(simd.call_args.kwargs.get("buf"), load.return_value)
+
+    def test_search_resolves_scope_ea_to_its_segment(self):
+        seg = MagicMock(start_ea=0x3000, end_ea=0x3400)
+        sigmaker.idaapi.getseg = MagicMock(return_value=seg)
+        with patch.object(sigmaker, "ProgressDialog", MagicMock()), \
+                patch.object(sigmaker, "SignatureParser") as sp, \
+                patch.object(
+                    sigmaker.SignatureSearcher, "find_all", return_value=[]
+                ) as fa:
+            sp.parse.return_value = "48 8B C4"
+            sigmaker.SignatureSearcher.from_signature("x").search(scope_ea=0x3200)
+        sigmaker.idaapi.getseg.assert_called_once_with(0x3200)
+        self.assertEqual(fa.call_args.kwargs.get("scope"), (0x3000, 0x3400))
+
+    def test_search_without_scope_ea_scans_whole_db(self):
+        with patch.object(sigmaker, "ProgressDialog", MagicMock()), \
+                patch.object(sigmaker, "SignatureParser") as sp, \
+                patch.object(
+                    sigmaker.SignatureSearcher, "find_all", return_value=[]
+                ) as fa:
+            sp.parse.return_value = "48 8B C4"
+            sigmaker.SignatureSearcher.from_signature("x").search()
+        self.assertIsNone(fa.call_args.kwargs.get("scope"))
+
+    def test_search_scope_ea_without_segment_falls_back_to_whole_db(self):
+        sigmaker.idaapi.getseg = MagicMock(return_value=None)
+        with patch.object(sigmaker, "ProgressDialog", MagicMock()), \
+                patch.object(sigmaker, "SignatureParser") as sp, \
+                patch.object(
+                    sigmaker.SignatureSearcher, "find_all", return_value=[]
+                ) as fa:
+            sp.parse.return_value = "48 8B C4"
+            sigmaker.SignatureSearcher.from_signature("x").search(scope_ea=0x9999)
+        self.assertIsNone(fa.call_args.kwargs.get("scope"))
+
+
 if __name__ == "__main__":
     # Run the tests (coverage is handled by the base class)
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Background

Follow-up to #64. RibShark noted that the `scope_to_segment` opt-in shipped in #67 scopes signature **creation** to the anchor's segment, but "Search for a signature" still scans the whole database. So a signature made unique within one segment still returns matches from every segment (his firmware duplicates a boot section and a main section). The checkbox tooltip already told users to "scope your search to the same segment"; this wires that up so the plugin does it for them.

## Change

- `SignatureSearcher.search(scope_ea=)` resolves the segment containing `scope_ea` and limits the scan to `[start_ea, end_ea)`. If the address is in no segment it falls back to the whole database, so a scoped request never silently returns nothing.
- `SignatureSearcher.find_all(scope=)` bounds both search paths:
  - SIMD: loads only that one segment (`InMemoryBuffer.load(scope_ea=)`), and `offset_mapper` maps match offsets back to their real addresses (on top of #68).
  - non-SIMD: bounds `bin_search` to `[start, end)` instead of `[min_ea, max_ea)`.
- The SEARCH action passes `get_screen_ea()` as the scope when the existing "containing segment" checkbox is ticked. No new option: the one checkbox now scopes both creation and search, and its label reflects that.

## Design decisions

- Reused the existing `scope_to_segment` checkbox rather than adding a search-only toggle. The scope is the segment under the cursor at search time, which matches how the creation scope uses the anchor's segment.
- Default is unchanged: with the box unticked, search scans the whole database exactly as before.

## Verification

- Host unit suite: 254 -> 259 OK. New `TestSearchScope`: non-SIMD `bin_search` is bounded to the scope; the SIMD path loads only the scoped segment and threads it into the scan; `search(scope_ea=)` resolves the segment; no `scope_ea` scans the whole database; a `scope_ea` in no segment falls back to the whole database.
- CI Docker matrix on the PR.

## Notes

- Builds on #68 (search address mapping): a single scoped segment is non-contiguous with the image base, so the correct-address mapping from #68 is what makes a scoped search report real addresses.
- `RangeSignatureGenerator` and the xref search are unaffected.
