### PR TITLE
chore: release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.11.0] - 2026-07-05
+
+### Added
+
+- **Opt-in "Limit uniqueness and search to the containing segment".** A new checkbox scopes both signature creation and the "Search for a signature" action to a single segment (the segment containing the anchor for creation, the segment under the cursor for search) instead of the whole database. This lets you sign functions that are duplicated across segments, for example a boot section and a main section, where no whole-database-unique signature exists, and then search for that signature within the same segment. Off by default, so existing behavior is unchanged. ([#64](https://github.com/mahmoudimus/ida-sigmaker/issues/64), [#67](https://github.com/mahmoudimus/ida-sigmaker/pull/67), [#70](https://github.com/mahmoudimus/ida-sigmaker/pull/70))
+
+### Fixed
+
+- **Signature search reports the correct address across non-contiguous segments.** The SIMD search mapped a match's buffer offset to `min_ea + offset`, which is wrong once segments are not contiguous: an extra binary loaded at a distant address such as `0x1F78000` was reported around `0x570000`. Matches now map back to their real address through a recorded segment map. Making signatures was never affected (it uses the function address, not the scan buffer). ([#68](https://github.com/mahmoudimus/ida-sigmaker/issues/68), [#69](https://github.com/mahmoudimus/ida-sigmaker/pull/69))
+
+[1.11.0]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.10.0...v1.11.0
+
 ## [1.10.0] - 2026-07-03
 
 ### Fixed

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.10.0"
+        "version": "1.11.0"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -26,7 +26,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
## Release v1.11.0

Bundles the recently merged work:

- **#64 containing-segment scope** (creation via #67, search via #70): an opt-in checkbox scopes signature uniqueness and the "Search for a signature" action to a single segment, so functions duplicated across segments (for example a boot section and a main section) can be signed and searched. Off by default.
- **#68 search-address fix** (#69): signature search now reports the correct address across non-contiguous segments (a match in a chunk loaded at a distant address was reported near `0x570000`).

## Changes

- `__version__` and `ida-plugin.json` bumped to 1.11.0.
- CHANGELOG entry for 1.11.0 (Added: segment scope; Fixed: search address).

## After merge

Tagging `v1.11.0` triggers `release.yml`, which builds the single-file `sigmaker.py` and the speedups wheel.
