### PR TITLE
fix: reject cross-segment signature matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-visible changes to this plugin are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Signature search and uniqueness checks no longer bridge segment boundaries.** IDA segments are copied into one tightly packed scan buffer for speed, but adjacent buffer bytes may belong to unrelated, non-contiguous segments. Direct searches, seed/refinement generation, and byte-index-backed minimal-function generation now reject candidates whose full pattern crosses a segment boundary while preserving the contiguous-buffer SIMD and index speedups.
+
 ## [1.11.0] - 2026-07-05
 
 ### Added

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -491,6 +491,23 @@ class InMemoryBuffer:
                 buf.extend(data)
             seg = idaapi.get_next_seg(seg.start_ea)
 
+    def _segment_buffer_ends(self) -> "array.array":
+        """Return each loaded segment's exclusive end in buffer coordinates.
+
+        FILE-mode buffers have no segment map, so their entire buffer is one
+        searchable span. Ends are uint64 so direct scanning does not gain the
+        byte index's existing uint32 candidate-offset limit.
+        """
+        if self._segments:
+            return array.array(
+                "Q",
+                (
+                    buffer_offset + size
+                    for buffer_offset, _segment_ea, size in self._segments
+                ),
+            )
+        return array.array("Q", [len(self._buffer)])
+
     def offset_mapper(self) -> typing.Callable[[int], int]:
         """Return a callable that maps ASCENDING buffer offsets to real IDA
         addresses. Segments are concatenated tightly even when their addresses
@@ -617,6 +634,36 @@ class InMemoryBuffer:
                 "ida_addr_to_segment_offset is only valid in 'segments' mode."
             )
         return ida_addr - self.imagebase
+
+
+def _buffer_segment_ends(
+    buf: "InMemoryBuffer", buffer_size: int
+) -> "array.array":
+    """Return searchable span ends for a buffer or buffer-like test double."""
+    if isinstance(buf, InMemoryBuffer):
+        return buf._segment_buffer_ends()
+    return array.array("Q", [buffer_size])
+
+
+def _span_fits_checker(
+    segment_ends: typing.Sequence[int],
+) -> typing.Callable[[int, int], bool]:
+    """Return a validator for ascending candidate starts."""
+    segment_index = 0
+
+    def fits(start: int, size: int) -> bool:
+        nonlocal segment_index
+        while (
+            segment_index < len(segment_ends)
+            and start >= segment_ends[segment_index]
+        ):
+            segment_index += 1
+        return (
+            segment_index < len(segment_ends)
+            and start + size <= segment_ends[segment_index]
+        )
+
+    return fits
 
 
 @dataclasses.dataclass
@@ -1579,6 +1626,7 @@ class UniqueSignatureGenerator:
         # first scan; buf holds the segment buffer the offsets index into.
         offsets: typing.Optional[list[int]] = None
         buf: typing.Optional["InMemoryBuffer"] = None
+        segment_ends: typing.Optional[typing.Sequence[int]] = None
         if cfg.scope_to_segment:
             # Issue #64: scope uniqueness to the anchor's segment. Pre-load it so
             # the seed scan and every refinement stay within the segment.
@@ -1651,11 +1699,23 @@ class UniqueSignatureGenerator:
                     count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
                 elif offsets is None:
                     # Seed once: scan the whole database, keep every match
-                    # offset. The candidate count is the exact match count.
+                    # offset. Seed from the eventual output form so candidates
+                    # that only a trailing wildcard would push across a segment
+                    # boundary remain available when uniqueness is checked
+                    # after trimming.
+                    seed_signature = Signature(sig)
+                    seed_signature.trim_signature()
+                    if not seed_signature:
+                        seed_signature = sig
                     offsets, buf = SignatureSearcher.find_all_offsets(
-                        f"{sig:ida}", buf=buf
+                        f"{seed_signature:ida}", buf=buf
                     )
-                    count = len(offsets)
+                    data_mv = buf.data()
+                    segment_ends = _buffer_segment_ends(buf, len(data_mv))
+                    valid_offsets = _filter_offsets_by_segment_ends(
+                        offsets, len(sig), segment_ends
+                    )
+                    count = len(valid_offsets)
                 else:
                     # Refine the surviving candidates in memory for each byte
                     # appended this iteration; no rescan of the database.
@@ -1664,7 +1724,12 @@ class UniqueSignatureGenerator:
                         sb = sig[j]
                         mask = 0x00 if sb.is_wildcard else 0xFF
                         offsets = _refine_offsets(data_mv, offsets, j, sb.value, mask)
-                    count = len(offsets)
+                    if segment_ends is None:
+                        segment_ends = _buffer_segment_ends(buf, len(data_mv))
+                    valid_offsets = _filter_offsets_by_segment_ends(
+                        offsets, len(sig), segment_ends
+                    )
+                    count = len(valid_offsets)
                 # find_all_offsets polls idaapi_user_canceled inside its scan
                 # loop and bails when set, returning whatever partial offsets
                 # it had so far (often 0). When the call was interrupted, keep
@@ -1675,12 +1740,42 @@ class UniqueSignatureGenerator:
                 if not idaapi_user_canceled():
                     progress.last_match_count = count
                     if count == 1:
+                        trimmed_signature = Signature(sig)
+                        trimmed_signature.trim_signature()
+                        if not trimmed_signature:
+                            continue
+                        if len(trimmed_signature) < len(sig):
+                            if offsets is None or segment_ends is None:
+                                if not SignatureSearcher.is_unique(
+                                    f"{trimmed_signature:ida}", buf=buf
+                                ):
+                                    continue
+                            else:
+                                trimmed_count = len(
+                                    _filter_offsets_by_segment_ends(
+                                        offsets,
+                                        len(trimmed_signature),
+                                        segment_ends,
+                                    )
+                                )
+                                if trimmed_count != 1:
+                                    continue
                         sig.trim_signature()
                         return GeneratedSignature(sig, Match(ea))
 
         if cancel.partial is not None:
             return cancel.partial
         raise Unexpected("Signature not unique (reached end of analysis)")
+
+
+def _filter_offsets_by_segment_ends(
+    offsets: list[int],
+    pattern_size: int,
+    segment_ends: typing.Sequence[int],
+) -> list[int]:
+    """Keep sorted candidate starts whose full pattern fits in one segment."""
+    span_fits = _span_fits_checker(segment_ends)
+    return [start for start in offsets if span_fits(start, pattern_size)]
 
 
 def _refine_offsets(
@@ -1726,6 +1821,35 @@ def _refine_offsets_into(
             cands[w] = cands[r]
             w += 1
     return w
+
+
+def _filter_offsets_into_by_segment_ends(
+    cands: "array.array",
+    count: int,
+    pattern_size: int,
+    segment_ends: typing.Sequence[int],
+) -> int:
+    """Compact segment-valid sorted candidates in place."""
+    if SIMD_SPEEDUP_AVAILABLE:
+        return simd_scan.filter_offsets_by_segment_ends(
+            cands, count, pattern_size, segment_ends
+        )
+
+    segment_index = 0
+    write_index = 0
+    for read_index in range(count):
+        start = cands[read_index]
+        while (
+            segment_index < len(segment_ends)
+            and start >= segment_ends[segment_index]
+        ):
+            segment_index += 1
+        if segment_index == len(segment_ends):
+            break
+        if start + pattern_size <= segment_ends[segment_index]:
+            cands[write_index] = start
+            write_index += 1
+    return write_index
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1801,6 +1925,7 @@ def _seed_via_index(
     sig: "Signature",
     index: typing.Optional["_ByteIndex"],
     buf: "InMemoryBuffer",
+    segment_ends: typing.Optional[typing.Sequence[int]] = None,
 ) -> typing.Optional[tuple["array.array", int]]:
     """Seed the candidate set from the byte index instead of scanning.
 
@@ -1819,6 +1944,8 @@ def _seed_via_index(
     data_mv = buf.data()
     n = len(data_mv)
     m = len(sig)
+    if segment_ends is None:
+        segment_ends = _buffer_segment_ends(buf, n)
     raw = index.candidates(key) if width == 2 else index.candidates1(key)
     # Map each hit at offset p back to a pattern start p - s, keeping only
     # candidates whose full pattern fits in the buffer. The Cython kernel does
@@ -1853,6 +1980,12 @@ def _seed_via_index(
         if sb.is_wildcard:
             continue
         count = _refine_offsets_into(data_mv, cands, count, j, sb.value, 0xFF)
+    count = _filter_offsets_into_by_segment_ends(
+        cands,
+        count,
+        m,
+        segment_ends,
+    )
     return cands, count
 
 
@@ -1963,6 +2096,7 @@ class MinimalFunctionSignatureGenerator:
         # 84% of generate() wall time when called per-is_unique.
         buf: typing.Optional["InMemoryBuffer"] = None
         index: typing.Optional["_ByteIndex"] = None
+        segment_ends: typing.Optional[typing.Sequence[int]] = None
         if SIMD_SPEEDUP_AVAILABLE:
             with ProgressDialog("Please stand by, copying segments..."):
                 buf = InMemoryBuffer.load(
@@ -1971,7 +2105,9 @@ class MinimalFunctionSignatureGenerator:
                 )
             # Build the 2-byte position index once for the whole search so each
             # anchor seeds with an O(1) lookup instead of a full-buffer scan.
-            index = _ByteIndex.build(buf.data())
+            data_mv = buf.data()
+            index = _ByteIndex.build(data_mv)
+            segment_ends = _buffer_segment_ends(buf, len(data_mv))
 
         # Iterate the pre-decoded anchors inside a ProgressBox so the wait
         # box shows live progress (issue #27). enumerate() keeps the index
@@ -2006,6 +2142,7 @@ class MinimalFunctionSignatureGenerator:
             sig = self._grow_unique_from_decoded(
                 decoded, anchor_idx, progress.best_size, cfg,
                 buf=buf, progress=progress, index=index,
+                segment_ends=segment_ends,
             )
             if sig is None:
                 continue
@@ -2035,6 +2172,7 @@ class MinimalFunctionSignatureGenerator:
         buf: typing.Optional["InMemoryBuffer"] = None,
         progress: typing.Optional["_FunctionSigProgress"] = None,
         index: typing.Optional["_ByteIndex"] = None,
+        segment_ends: typing.Optional[typing.Sequence[int]] = None,
     ) -> typing.Optional[Signature]:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
@@ -2056,6 +2194,9 @@ class MinimalFunctionSignatureGenerator:
         offsets: typing.Optional["array.array"] = None
         ocount = 0
         seed_buf = buf
+        if segment_ends is None and seed_buf is not None:
+            seed_data = seed_buf.data()
+            segment_ends = _buffer_segment_ends(seed_buf, len(seed_data))
         min_useful = self.MIN_USEFUL_SIG_BYTES
         for i in range(anchor_idx, len(decoded)):
             if (
@@ -2097,7 +2238,9 @@ class MinimalFunctionSignatureGenerator:
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
                 # Seed once. Prefer the byte index (Dynamic Seed Selection).
-                seeded = _seed_via_index(sig, index, seed_buf)
+                seeded = _seed_via_index(
+                    sig, index, seed_buf, segment_ends=segment_ends
+                )
                 if seeded is not None:
                     offsets, ocount = seeded
                     count = ocount
@@ -2130,12 +2273,39 @@ class MinimalFunctionSignatureGenerator:
                     ocount = _refine_offsets_into(
                         data_mv, offsets, ocount, j, sb.value, mask
                     )
+                if segment_ends is None:
+                    segment_ends = _buffer_segment_ends(seed_buf, len(data_mv))
+                ocount = _filter_offsets_into_by_segment_ends(
+                    offsets,
+                    ocount,
+                    len(sig),
+                    segment_ends,
+                )
                 count = ocount
 
             if progress is not None:
                 progress.inner_length = len(sig)
                 progress.inner_matches = count
             if count == 1:
+                trimmed_signature = Signature(sig)
+                trimmed_signature.trim_signature()
+                if not trimmed_signature:
+                    continue
+                if len(trimmed_signature) < len(sig):
+                    trimmed_seed = _seed_via_index(
+                        trimmed_signature,
+                        index,
+                        seed_buf,
+                        segment_ends=segment_ends,
+                    )
+                    if trimmed_seed is not None:
+                        _trimmed_offsets, trimmed_count = trimmed_seed
+                        if trimmed_count != 1:
+                            continue
+                    elif not SignatureSearcher.is_unique(
+                        f"{trimmed_signature:ida}", buf=seed_buf
+                    ):
+                        continue
                 sig.trim_signature()
                 return sig
 
@@ -2602,7 +2772,6 @@ class SignatureSearcher:
             return [Match(base)]
 
         n = len(data_mv)
-        off = 0
         # Matches arrive in ascending offset order, so map each offset to its
         # real address with a forward cursor (amortized O(1) per match); see
         # InMemoryBuffer.offset_mapper.
@@ -2611,21 +2780,26 @@ class SignatureSearcher:
         # find_all_offsets) so per-match user_cancelled() overhead does not
         # dominate a scan over a short, common pattern.
         since_poll = 0
-        while off <= n - k:
-            since_poll += 1
-            if since_poll >= _CANCEL_POLL_STRIDE:
-                since_poll = 0
-                if idaapi_user_canceled():
-                    LOGGER.info("Search canceled by user")
-                    break
+        segment_start = 0
+        for segment_end in _buffer_segment_ends(buf, n):
+            off = segment_start
+            while off <= segment_end - k:
+                since_poll += 1
+                if since_poll >= _CANCEL_POLL_STRIDE:
+                    since_poll = 0
+                    if idaapi_user_canceled():
+                        LOGGER.info("Search canceled by user")
+                        return results
 
-            idx = _simd_scan_bytes(data_mv[off:], sig)
-            if idx < 0:
-                break
-            results.append(Match(to_addr(off + idx)))
-            if skip_more_than_one and len(results) > 1:
-                break
-            off += idx + 1
+                idx = _simd_scan_bytes(data_mv[off:segment_end], sig)
+                if idx < 0:
+                    break
+                start = off + idx
+                results.append(Match(to_addr(start)))
+                if skip_more_than_one and len(results) > 1:
+                    return results
+                off = start + 1
+            segment_start = segment_end
         return results
 
     @staticmethod
@@ -2649,23 +2823,27 @@ class SignatureSearcher:
         if k == 0:
             return [0], buf
         n = len(data_mv)
-        off = 0
         # Poll cancellation every _CANCEL_POLL_STRIDE matches rather than on
         # every match: idaapi.user_cancelled() costs ~0.5us per call and a
         # short, common seed can produce millions of matches, so per-match
         # polling alone can dominate the scan (observed: 44s of a 76s seed).
         since_poll = 0
-        while off <= n - k:
-            since_poll += 1
-            if since_poll >= _CANCEL_POLL_STRIDE:
-                since_poll = 0
-                if idaapi_user_canceled():
+        segment_start = 0
+        for segment_end in _buffer_segment_ends(buf, n):
+            off = segment_start
+            while off <= segment_end - k:
+                since_poll += 1
+                if since_poll >= _CANCEL_POLL_STRIDE:
+                    since_poll = 0
+                    if idaapi_user_canceled():
+                        return offsets, buf
+                idx = _simd_scan_bytes(data_mv[off:segment_end], sig)
+                if idx < 0:
                     break
-            idx = _simd_scan_bytes(data_mv[off:], sig)
-            if idx < 0:
-                break
-            offsets.append(off + idx)
-            off += idx + 1
+                start = off + idx
+                offsets.append(start)
+                off = start + 1
+            segment_start = segment_end
         return offsets, buf
 
     @staticmethod

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -786,6 +786,46 @@ def refine_offsets(const unsigned char[:] data_view,
     return w
 
 
+def filter_offsets_by_segment_ends(unsigned int[:] cands,
+                                   Py_ssize_t count,
+                                   Py_ssize_t pattern_size,
+                                   const unsigned long long[:] segment_ends):
+    """Keep sorted candidate starts whose pattern fits in one segment.
+
+    Compacts cands[0:count] in place and returns the new count. Segment ends
+    are exclusive buffer offsets in ascending order. The scan is allocation
+    free and runs under nogil after validating its direct-call contract.
+    """
+    cdef Py_ssize_t seg_count = segment_ends.shape[0]
+    cdef Py_ssize_t i
+    if count < 0 or count > cands.shape[0]:
+        raise ValueError("count must be within the candidate array")
+    if pattern_size <= 0:
+        raise ValueError("pattern_size must be positive")
+    if seg_count == 0:
+        raise ValueError("segment_ends must not be empty")
+    for i in range(1, seg_count):
+        if segment_ends[i] <= segment_ends[i - 1]:
+            raise ValueError("segment_ends must be strictly increasing")
+
+    cdef Py_ssize_t r = 0
+    cdef Py_ssize_t w = 0
+    cdef Py_ssize_t seg = 0
+    cdef Py_ssize_t start
+    with nogil:
+        while r < count:
+            start = <Py_ssize_t>cands[r]
+            while seg < seg_count and start >= segment_ends[seg]:
+                seg += 1
+            if seg == seg_count:
+                break
+            if start + pattern_size <= segment_ends[seg]:
+                cands[w] = cands[r]
+                w += 1
+            r += 1
+    return w
+
+
 def seed_offsets(const unsigned int[:] bucket,
                  Py_ssize_t s,
                  Py_ssize_t m,

--- a/tests/perf/segment_span_filter.py
+++ b/tests/perf/segment_span_filter.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""Compare Python and Cython segment-span candidate filtering.
+
+This is a reporting benchmark, not a wall-clock CI assertion. It fails only
+when the implementations disagree. Build the extension before running:
+
+    pyenv exec pip install -e .
+    PYTHONPATH=src pyenv exec python tests/perf/segment_span_filter.py
+"""
+
+import array
+import pathlib
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+with patch.dict("sys.modules", {"idaapi": MagicMock(), "idc": MagicMock()}):
+    import sigmaker
+
+
+SEGMENT_SIZE = 4096
+SEGMENT_COUNT = 1024
+PATTERN_SIZE = 16
+
+
+def _best(function, iterations=5):
+    best_elapsed = None
+    result = None
+    for _ in range(iterations):
+        start = time.perf_counter()
+        result = function()
+        elapsed = time.perf_counter() - start
+        best_elapsed = elapsed if best_elapsed is None else min(best_elapsed, elapsed)
+    return best_elapsed, result
+
+
+def _benchmark_direct_single_span() -> None:
+    data = memoryview((b"\x90" + b"\x00" * 15) * (1 << 18))
+    signature = sigmaker._SimdSignature("90")
+    size = len(data)
+
+    def original_loop():
+        count = 0
+        offset = 0
+        while offset < size:
+            index = sigmaker._simd_scan_bytes(data[offset:], signature)
+            if index < 0:
+                break
+            count += 1
+            offset += index + 1
+        return count
+
+    def segmented_loop():
+        count = 0
+        segment_start = 0
+        for segment_end in (size,):
+            offset = segment_start
+            while offset < segment_end:
+                index = sigmaker._simd_scan_bytes(
+                    data[offset:segment_end], signature
+                )
+                if index < 0:
+                    break
+                count += 1
+                offset += index + 1
+            segment_start = segment_end
+        return count
+
+    original_elapsed, original_count = _best(original_loop)
+    segmented_elapsed, segmented_count = _best(segmented_loop)
+    if segmented_count != original_count:
+        raise AssertionError("Segmented direct scan changed the match count")
+
+    delta = segmented_elapsed / original_elapsed - 1
+    print("\ndirect single-span scan:")
+    print(f"hits:        {original_count:,}")
+    print(f"original:    {original_elapsed * 1000:.3f} ms")
+    print(f"segmented:   {segmented_elapsed * 1000:.3f} ms")
+    print(f"delta:       {delta:+.1%}")
+
+
+def main() -> None:
+    if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+        raise RuntimeError("SIMD extension is not built; run: pip install -e .")
+
+    total_size = SEGMENT_SIZE * SEGMENT_COUNT
+    candidate_list = list(range(0, total_size, 4))
+    segment_ends = array.array(
+        "Q", range(SEGMENT_SIZE, total_size + 1, SEGMENT_SIZE)
+    )
+
+    start = time.perf_counter()
+    python_candidates = sigmaker._filter_offsets_by_segment_ends(
+        candidate_list,
+        PATTERN_SIZE,
+        segment_ends,
+    )
+    python_elapsed = time.perf_counter() - start
+
+    cython_candidates = array.array("I", candidate_list)
+    start = time.perf_counter()
+    cython_count = sigmaker.simd_scan.filter_offsets_by_segment_ends(
+        cython_candidates,
+        len(cython_candidates),
+        PATTERN_SIZE,
+        segment_ends,
+    )
+    cython_elapsed = time.perf_counter() - start
+
+    actual = list(cython_candidates[:cython_count])
+    if actual != python_candidates:
+        raise AssertionError("Python and Cython segment-span filters disagree")
+
+    ratio = python_elapsed / cython_elapsed if cython_elapsed else float("inf")
+    print(f"candidates: {len(candidate_list):,}")
+    print(f"survivors:  {cython_count:,}")
+    print(f"python:     {python_elapsed * 1000:.3f} ms")
+    print(f"cython:     {cython_elapsed * 1000:.3f} ms")
+    print(f"ratio:      {ratio:.2f}x")
+    _benchmark_direct_single_span()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -2498,6 +2498,89 @@ class TestUniqueSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         # Two 0x90 bytes survive to uniqueness (offset 0: 0x90 0x90).
         self.assertEqual(len(result.signature), 2)
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_wildcard_growth_drops_cross_segment_candidate(self):
+        append_count = 0
+        processor = MagicMock()
+
+        def append_byte(sig, *_args):
+            nonlocal append_count
+            sig.append(
+                sigmaker.SignatureByte(0x90, is_wildcard=append_count == 1)
+            )
+            append_count += 1
+
+        processor.append_instruction_to_sig.side_effect = append_byte
+        gen = sigmaker.UniqueSignatureGenerator(processor)
+
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(b"\x90\x00\x90\x00\x90\x00")
+        seed_buf._segments.extend(
+            [
+                (0, 0x1000, 3),
+                (3, 0x2000, 3),
+            ]
+        )
+
+        with patch.object(
+            sigmaker,
+            "InstructionWalker",
+            return_value=[
+                (0x1000, MagicMock(), 1),
+                (0x1001, MagicMock(), 1),
+                (0x1002, MagicMock(), 1),
+            ],
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            return_value=([0, 2], seed_buf),
+        ):
+            result = gen.generate(
+                0x1000,
+                self._make_cfg(),
+                policy=sigmaker.GenerationPolicy.strict(),
+            )
+
+        self.assertEqual(result.status, sigmaker.GenerationStatus.UNIQUE)
+        self.assertEqual(append_count, 3)
+        self.assertEqual(len(result.signature), 3)
+
+
+class TestSegmentSpanCandidateFilter(CoveredUnitTest):
+    def test_filters_sorted_candidates_without_reordering(self):
+        self.assertEqual(
+            sigmaker._filter_offsets_by_segment_ends(
+                [0, 3, 4, 6], pattern_size=2, segment_ends=[4, 8]
+            ),
+            [0, 4, 6],
+        )
+
+    def test_keeps_candidate_ending_exactly_at_segment_end(self):
+        self.assertEqual(
+            sigmaker._filter_offsets_by_segment_ends(
+                [2], pattern_size=2, segment_ends=[4]
+            ),
+            [2],
+        )
+
+    def test_in_place_python_fallback_matches_list_filter(self):
+        candidates = array.array("I", [0, 2, 3, 4, 6, 7, 99])
+        segment_ends = array.array("Q", [4, 8])
+        expected = sigmaker._filter_offsets_by_segment_ends(
+            list(candidates),
+            pattern_size=2,
+            segment_ends=segment_ends,
+        )
+        with patch.object(sigmaker, "SIMD_SPEEDUP_AVAILABLE", False):
+            count = sigmaker._filter_offsets_into_by_segment_ends(
+                candidates,
+                len(candidates),
+                2,
+                segment_ends,
+            )
+
+        self.assertEqual(list(candidates[:count]), expected)
+
 
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
     """display() branches on status and respects the no-clipboard rule for partials."""
@@ -3233,6 +3316,65 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         )
         self.assertEqual(len(result.signature), 5)
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_wildcard_boundary_uniqueness_survives_trimming(self):
+        pattern = b"\x10\x20\x30\x40\x50"
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(
+            pattern + b"\x00\x60" + pattern + b"\x00\x60"
+        )
+        seed_buf._segments.extend(
+            [
+                (0, 0x1000, 7),
+                (7, 0x2000, 5),
+                (12, 0x3000, 2),
+            ]
+        )
+        index = sigmaker._ByteIndex.build(seed_buf.data())
+        decoded = [
+            sigmaker._DecodedInstruction(
+                ea=0x1000,
+                size=5,
+                raw_bytes=pattern,
+                operand_offb=0,
+                operand_length=0,
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1005,
+                size=1,
+                raw_bytes=b"\x00",
+                operand_offb=0,
+                operand_length=1,
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1006,
+                size=1,
+                raw_bytes=b"\x60",
+                operand_offb=0,
+                operand_length=0,
+            ),
+        ]
+        generator = sigmaker.MinimalFunctionSignatureGenerator(
+            sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        )
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            signature = generator._grow_unique_from_decoded(
+                decoded,
+                0,
+                50,
+                self._make_cfg(),
+                buf=seed_buf,
+                index=index,
+            )
+
+        self.assertIsNotNone(signature)
+        self.assertEqual(len(signature), 7)
+        self.assertTrue(signature[5].is_wildcard)
+        self.assertFalse(signature[6].is_wildcard)
+
 
 class TestSignatureSearcherBufferCache(CoveredUnitTest):
     """The SignatureSearcher scan API accepts an optional cached buffer."""
@@ -3833,6 +3975,17 @@ class TestSeedViaIndex(CoveredUnitTest):
             sig.append(sigmaker.SignatureByte(v, w))
         return sig
 
+    def _segmented_buffer(self, *payloads):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        offset = 0
+        for segment_index, payload in enumerate(payloads):
+            buf._segments.append(
+                (offset, 0x1000 + segment_index * 0x1000, len(payload))
+            )
+            buf._buffer.extend(payload)
+            offset += len(payload)
+        return buf
+
     def test_index_seed_matches_buffer(self):
         buf = MagicMock()
         buf.data.return_value = memoryview(
@@ -3893,6 +4046,22 @@ class TestSeedViaIndex(CoveredUnitTest):
         buf.data.return_value = memoryview(bytearray(b"\x90" * 10))
         sig = self._sig([(0x90, False), (0x91, False)])
         self.assertIsNone(sigmaker._seed_via_index(sig, None, buf))
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_rejects_seed_that_exists_only_across_segment_boundary(self):
+        buf = self._segmented_buffer(b"\x00\xAA", b"\xBB\x00")
+        index = sigmaker._ByteIndex.build(buf.data())
+        sig = self._sig([(0xAA, False), (0xBB, False)])
+        candidates, count = sigmaker._seed_via_index(sig, index, buf)
+        self.assertEqual(list(candidates[:count]), [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_keeps_valid_seeds_around_boundary_candidate(self):
+        buf = self._segmented_buffer(b"\xAA\xBB\xAA", b"\xBB\xAA\xBB")
+        index = sigmaker._ByteIndex.build(buf.data())
+        sig = self._sig([(0xAA, False), (0xBB, False)])
+        candidates, count = sigmaker._seed_via_index(sig, index, buf)
+        self.assertEqual(list(candidates[:count]), [0, 4])
 
 
 class TestSelectSeedRun(CoveredUnitTest):
@@ -4126,6 +4295,95 @@ class TestRefineOffsetsCython(CoveredUnitTest):
             arr = array.array("I", cand_list)
             n = sigmaker.simd_scan.refine_offsets(mv, arr, len(cand_list), j, value, mask)
             self.assertEqual(sorted(arr[:n]), sorted(py))
+
+
+class TestFilterOffsetsBySegmentEndsCython(CoveredUnitTest):
+    """The in-place Cython segment-span candidate compactor."""
+
+    def setUp(self):
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+
+    def _filter(self, candidates, count, pattern_size, segment_ends):
+        cands = array.array("I", candidates)
+        ends = array.array("Q", segment_ends)
+        new_count = sigmaker.simd_scan.filter_offsets_by_segment_ends(
+            cands, count, pattern_size, ends
+        )
+        return cands, new_count
+
+    def test_compacts_multiple_segments_in_place(self):
+        cands, count = self._filter([0, 2, 3, 4, 6, 7], 6, 2, [4, 8])
+        self.assertEqual(count, 4)
+        self.assertEqual(list(cands[:count]), [0, 2, 4, 6])
+
+    def test_empty_candidates(self):
+        cands, count = self._filter([], 0, 2, [4])
+        self.assertEqual(count, 0)
+        self.assertEqual(list(cands[:count]), [])
+
+    def test_ignores_capacity_beyond_count(self):
+        cands, count = self._filter([0, 3, 4, 99], 3, 2, [4, 8])
+        self.assertEqual(count, 2)
+        self.assertEqual(list(cands[:count]), [0, 4])
+
+    def test_rejects_invalid_arguments(self):
+        cands = array.array("I", [0])
+        ends = array.array("Q", [4])
+        with self.assertRaises(ValueError):
+            sigmaker.simd_scan.filter_offsets_by_segment_ends(cands, 2, 1, ends)
+        with self.assertRaises(ValueError):
+            sigmaker.simd_scan.filter_offsets_by_segment_ends(cands, 1, 0, ends)
+        with self.assertRaises(ValueError):
+            sigmaker.simd_scan.filter_offsets_by_segment_ends(
+                cands, 1, 1, array.array("Q")
+            )
+        with self.assertRaises(ValueError):
+            sigmaker.simd_scan.filter_offsets_by_segment_ends(
+                cands, 1, 1, array.array("Q", [4, 3])
+            )
+
+    def test_matches_python_reference_randomized(self):
+        rng = random.Random(8675309)
+        for _ in range(200):
+            segment_lengths = [rng.randint(1, 128) for _ in range(rng.randint(1, 12))]
+            segment_ends = list(itertools.accumulate(segment_lengths))
+            total = segment_ends[-1]
+            candidates = sorted(
+                rng.sample(range(total), rng.randint(0, min(total, 200)))
+            )
+            pattern_size = rng.randint(1, 24)
+            expected = sigmaker._filter_offsets_by_segment_ends(
+                candidates, pattern_size, segment_ends
+            )
+            cands, count = self._filter(
+                candidates, len(candidates), pattern_size, segment_ends
+            )
+            self.assertEqual(list(cands[:count]), expected)
+
+    def test_dispatcher_calls_cython_kernel_once(self):
+        candidates = array.array("I", range(0, 4096, 4))
+        segment_ends = array.array("Q", [1024, 2048, 3072, 4096])
+        kernel = sigmaker.simd_scan.filter_offsets_by_segment_ends
+        with patch.object(
+            sigmaker.simd_scan,
+            "filter_offsets_by_segment_ends",
+            wraps=kernel,
+        ) as wrapped:
+            count = sigmaker._filter_offsets_into_by_segment_ends(
+                candidates,
+                len(candidates),
+                16,
+                segment_ends,
+            )
+
+        wrapped.assert_called_once_with(
+            candidates,
+            len(candidates),
+            16,
+            segment_ends,
+        )
+        self.assertGreater(count, 0)
 
 
 class TestBuildByteIndex(CoveredUnitTest):
@@ -4537,6 +4795,28 @@ class TestSearchAddressMapping(unittest.TestCase):
             mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS
         )
 
+    def _three_segment_buffer(self):
+        s1 = MagicMock(start_ea=0x1000, end_ea=0x1004)
+        s2 = MagicMock(start_ea=0x2000, end_ea=0x2004)
+        s3 = MagicMock(start_ea=0x3000, end_ea=0x3003)
+        sigmaker.idaapi.get_first_seg = MagicMock(return_value=s1)
+        sigmaker.idaapi.get_next_seg = MagicMock(
+            side_effect=lambda ea: {
+                0x1000: s2,
+                0x2000: s3,
+            }.get(ea)
+        )
+        sigmaker.idaapi.get_bytes = MagicMock(
+            side_effect=lambda ea, size: {
+                0x1000: b"\xAA\xAA\xAA\xDD",
+                0x2000: b"\xF1\xDD\xF1\x00",
+                0x3000: b"\xDD\xF1\x00",
+            }.get(ea, b"")
+        )
+        return sigmaker.InMemoryBuffer.load(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS
+        )
+
     def test_offset_mapper_across_noncontiguous_segments(self):
         buf = self._two_segment_buffer()
         m = buf.offset_mapper()
@@ -4548,6 +4828,20 @@ class TestSearchAddressMapping(unittest.TestCase):
         self.assertEqual(m(4), 0x1F78000)  # not 0x1004
         self.assertEqual(m(6), 0x1F78002)
 
+    def test_segment_buffer_ends(self):
+        buf = self._two_segment_buffer()
+        self.assertEqual(list(buf._segment_buffer_ends()), [4, 8])
+
+    def test_whole_buffer_is_one_span_without_segment_map(self):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        buf._buffer.extend(b"\xAA\xBB\xCC")
+        self.assertEqual(list(buf._segment_buffer_ends()), [3])
+
+    def test_segment_buffer_ends_support_offsets_past_four_gibibytes(self):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        buf._segments.append((0, 0x1000, 0x1_0000_0001))
+        self.assertEqual(list(buf._segment_buffer_ends()), [0x1_0000_0001])
+
     def test_offset_mapper_fallback_without_map(self):
         buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
         self.assertEqual(buf.offset_mapper()(0x40), 0x1000 + 0x40)
@@ -4557,6 +4851,57 @@ class TestSearchAddressMapping(unittest.TestCase):
         buf = self._two_segment_buffer()
         matches = sigmaker.SignatureSearcher._find_all_simd("F1 B5 04 00", buf=buf)
         self.assertEqual([int(m.address) for m in matches], [0x1F78000])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_rejects_cross_segment_match(self):
+        buf = self._two_segment_buffer()
+        matches = sigmaker.SignatureSearcher._find_all_simd("DD F1", buf=buf)
+        self.assertEqual(matches, [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_offsets_rejects_cross_segment_match(self):
+        buf = self._two_segment_buffer()
+        offsets, returned = sigmaker.SignatureSearcher.find_all_offsets(
+            "DD F1", buf=buf
+        )
+        self.assertIs(returned, buf)
+        self.assertEqual(offsets, [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_skip_more_than_one_counts_only_valid_spans(self):
+        buf = self._three_segment_buffer()
+        matches = sigmaker.SignatureSearcher._find_all_simd(
+            "DD F1", skip_more_than_one=True, buf=buf
+        )
+        self.assertEqual(
+            [int(match.address) for match in matches],
+            [0x2001, 0x3000],
+        )
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_cancellation_returns_partial_results(self):
+        buf = self._two_segment_buffer()
+        with patch.object(
+            sigmaker, "_CANCEL_POLL_STRIDE", 1
+        ), patch.object(
+            sigmaker, "idaapi_user_canceled", return_value=True
+        ):
+            matches = sigmaker.SignatureSearcher._find_all_simd("AA", buf=buf)
+        self.assertEqual(matches, [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_offsets_cancellation_returns_partial_results(self):
+        buf = self._two_segment_buffer()
+        with patch.object(
+            sigmaker, "_CANCEL_POLL_STRIDE", 1
+        ), patch.object(
+            sigmaker, "idaapi_user_canceled", return_value=True
+        ):
+            offsets, returned = sigmaker.SignatureSearcher.find_all_offsets(
+                "AA", buf=buf
+            )
+        self.assertIs(returned, buf)
+        self.assertEqual(offsets, [])
 
 
 class TestSegmentScope(unittest.TestCase):


### PR DESCRIPTION
## Summary

- scan each loaded IDA segment as a separate SIMD range so a pattern cannot bridge two tightly concatenated segment buffers
- enforce the same full-pattern span rule in ordinary uniqueness refinement and byte-index-backed minimal-function generation
- keep indexed candidate filtering allocation-free with one ordered Cython compaction pass under `nogil`
- revalidate trailing-wildcard-trimmed output so boundary-only uniqueness cannot produce a shorter non-unique signature

## Performance

The contiguous segment buffer and global two-byte index are unchanged. Segment ends are computed once per minimal-function run and reused across anchors.

`tests/perf/segment_span_filter.py` reports both hot paths without wall-clock assertions:

- 1,048,576 indexed candidates: Cython filtering was 133.9x faster than the Python reference in the latest run
- 262,144-hit single-span direct scan: segmented scanning was within noise of the original loop (`-9.9%` in the latest run)

## Verification

- `280` unit tests passed (`3` skipped)
- `18` real-IDAPython integration tests passed (`1` skipped)
- `4` performance tests passed
- editable Cython extension build passed
- total Python coverage: `74%`; changed executable Python lines: `92.3%`
