### PR TITLE
feat: add no-SIMD nibble wildcard search fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable user-visible changes to this plugin are documented here. The format 
 - **Batch result formatting** supports text, CSV, and JSON. Results include normalized signatures, status, match counts, absolute EAs, RVAs relative to the imagebase, lazily resolved file offsets, and per-entry errors.
 - **Batch search formatters are extensible.** Power users can register custom renderers with `@BatchSearchFormatter.register("name", suffixes=(...))`, then use `results.format("name")` or export to a registered suffix. Duplicate names and suffixes are rejected atomically unless the registration explicitly passes `override=True`.
 - **Search results now expose structured metadata.** `SearchResults` keeps the existing `matches` and `signature_str` fields while adding raw pattern, name/source-line context, status/error helpers, and lazy file-offset lookup. `Match` supports f-string fields like `ea`, `rva`, and `fileoffset`. Batch search uses the same result type per pattern.
-- **Batch search loads and reuses one copied segment buffer** when SIMD speedups are available, so a batch does not reload the database for every pattern.
+- **Batch search loads and reuses one copied segment buffer** when SIMD speedups are available or a no-SIMD batch contains nibble wildcard patterns, so a batch does not reload the database for every in-memory pattern.
+- **Nibble wildcard search works without SIMD speedups.** The fallback uses the longest exact-byte run as a C-speed anchor and verifies the remaining nibble masks in Python while preserving scope, address mapping, cancellation, and uniqueness early exit. Patterns still require at least one exact byte; common anchors remain slower than the optional SIMD scanner. ([#59](https://github.com/mahmoudimus/ida-sigmaker/issues/59))
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable user-visible changes to this plugin are documented here. The format 
 ### Fixed
 
 - **Batch search now honors segment scope and cancellation.** A scoped batch uses the same containing-segment policy as ordinary search. Canceling an IDA or SIMD batch scan raises `UserCanceledError` instead of returning partial hits as a successful result; existing direct `find_all()` callers retain their partial-result behavior.
+- **Embedded search no longer depends on IDA's GUI event loop.** `SignatureSearcher` and batch search automatically retain IDA wait-box progress and cancellation when `idaapi.is_idaq()` reports the graphical host, while idalib and hosts without that API use headless services. The interactive plugin installs IDA services explicitly while handling an action, and embedders can inject their own context-local services with `UIServices.use(...)`.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,15 @@ Searching for Signatures works for supported formats:
 
 ![](./assets/sig_search.png)
 
-It also supports wildcard nibble search support:
+It also supports nibble wildcard searches such as `48 4? ?F 90`:
 
 ![](./assets/nibble_wildcard_search.png)
+
+Nibble wildcard search works with or without the optional SIMD speedups. Without
+the speedup wheel, SigMaker finds the longest exact-byte run with the standard
+library's C-speed byte search and verifies the remaining nibble masks in Python.
+The pattern must therefore contain at least one exact byte, and patterns whose
+best exact run is very common can be substantially slower without SIMD.
 
 Just enter any string containing your Signature, it will automatically try to figure out what kind of Signature format is being used:
 
@@ -237,7 +243,35 @@ for gen in xrefs.signatures:
 
 ### Batch search API
 
-The batch search feature is also available to scripts:
+#### Why batch search?
+
+Signatures are usually maintained as a collection. After a binary update, you
+need to know which patterns still match, which became ambiguous, and which no
+longer match. Searching each pattern separately repeats scan setup and leaves
+you to compare the results by hand. Batch search accepts the collection once
+and returns one result per pattern in input order.
+
+The batch layer adds little overhead:
+
+- A current profile of `BatchSignatureSearcher.from_text()` parsed a 5,003-line
+  mixed paste into 5,000 entries in 16.0 ms median, or roughly 312,000 entries
+  per second.
+- The requested segment buffer is loaded once and reused for every unique
+  normalized pattern. This design follows real-binary profiling of signature
+  generation where loading segments before every uniqueness check consumed 84%
+  of total generation time.
+- Duplicate normalized patterns share their match results, and file offsets are
+  resolved only when a caller or formatter requests them. A performance
+  [regression test](./tests/performance_test.py) constructs a 100,000-hit batch
+  result while asserting that search performs no file-offset lookups.
+
+These are focused measurements of parsing, scan setup, and result construction.
+End-to-end search time still depends on the binary, search scope, patterns, and
+whether SIMD speedups are available.
+
+#### Search a batch
+
+Batch search is available to IDAPython and idalib scripts:
 
 ```python
 import sigmaker
@@ -267,9 +301,29 @@ for result in results:
         print(f"{hit:ea}", f"{hit:rva}", file_offset_text)
 ```
 
-Batch search accepts one named or unnamed pattern per non-empty line. Names are optional and must use `name := pattern` or `name = pattern`. Quoted patterns are supported only as the right-hand side of a named pattern. Newlines are the only batch entry boundary; a semicolon remains a byte separator, so `tick := 90;90;CC` is one signature. SigMaker does not parse C declarations or join patterns across multiple lines. If a pattern has no name, SigMaker labels it by source line in the result list. `SignatureSearcher.from_many(text)` returns the parsed per-pattern searchers if you want to inspect names and source lines before searching; `BatchSignatureSearcher.from_text(text)` uses it internally. `#` and `//` comments are ignored outside quoted strings, and Markdown fence lines are skipped so you can paste snippets from issues or notes.
+#### Input format
 
-Each line is parsed through the same strict parser used by regular signature search. Supported forms include:
+Each non-empty line is one signature:
+
+- **Unnamed pattern:** Write the pattern by itself. The result is labeled with
+  its source line.
+- **Named pattern:** Use `name := pattern` or `name = pattern`.
+- **Quoted pattern:** Quotes are accepted only around the right-hand side of a
+  named pattern, as in `update = "E8 ? ? ? ? 48"`.
+- **Comments:** `#` and `//` comments are ignored outside quoted strings.
+  Markdown fence lines are also skipped, which makes snippets from issues and
+  notes safe to paste.
+- **Entry boundary:** Only a newline starts a new entry. A semicolon remains a
+  byte separator, so `tick := 90;90;CC` is one signature.
+- **Source text:** SigMaker does not parse declarations, infer signatures from
+  prose, or join a signature across multiple lines.
+
+`SignatureSearcher.from_many(text)` returns the parsed per-pattern searchers if
+you need to inspect names and source lines before searching.
+`BatchSignatureSearcher.from_text(text)` uses it internally.
+
+Each line uses the same strict parser as regular signature search. Supported
+forms include:
 
 ```text
 48 8B ? ?? 4? ?F
@@ -281,15 +335,140 @@ Each line is parsed through the same strict parser used by regular signature sea
 (48 8B ? 90)
 ```
 
-Compact input may omit separators when the complete pattern consists of fixed two-character cells: `HH`, `??`, `H?`, or `?H`. For example, `488B??9090` parses as `48 8B ? 90 90`. Single nibbles such as `E 8 4`, odd-length compact input such as `488B?9090`, hybrid glued input such as `488B ?? 90`, long integer notation such as `0x488B9090`, colon/pipe/hyphen separators, declaration text, and random prose are rejected rather than guessed. Invalid batch patterns are reported per entry instead of aborting the whole batch. Patterns must contain at least one exact byte; an all-wildcard pattern such as `?? ?? ??` is rejected because it matches almost everywhere and is not a useful search key.
+Compact input may omit separators only when the complete pattern consists of
+two-character cells: `HH`, `??`, `H?`, or `?H`. For example, `488B??9090`
+parses as `48 8B ? 90 90`.
 
-`BatchSearchResults` is iterable, so `list(results)` gives the per-pattern `SearchResults` objects. `SearchResults.raw_pattern` is the extracted user input, `SearchResults.search_pattern` is the parsed SigMaker search pattern, and `SearchResults.normalized_signature` is the canonical matcher/cache pattern. Nibble wildcard patterns such as `4? ?F ??` keep their nibble masks in both parsed and normalized forms; full-byte wildcards display as `?` in `search_pattern` and normalize to `??` in `normalized_signature`. `SearchResults.signature_str` remains available as a compatibility alias for the search pattern. `SearchResults.matches` remains the main match list, and each `Match` still acts like an int while carrying its optional RVA metadata.
+The strict parser rejects ambiguous input instead of guessing:
 
-`Match` supports f-string fields such as `f"{hit:ea}"`, `f"{hit:rva}"`, and `f"{hit:fileoffset}"`. Search populates `hit.rva` directly. File offsets are intentionally lazy because IDA must resolve them one address at a time: call `result.file_offset_for_match(hit)`, or let a built-in exporter call it for the hits it emits. The result caches both resolved and unavailable offsets. Batch search itself performs no file-offset lookups; text resolves only previewed hits, while CSV and JSON resolve every exported hit. `:rva` and `:fileoffset` do not fall back to `:ea`, because that would label an absolute address as a derived offset. If metadata is unavailable on the `Match` itself, its formatter returns `repr(hit)`, so output still shows the hit EA.
+- Single nibbles, such as `E 8 4`.
+- Odd-length compact input, such as `488B?9090`.
+- Input that mixes glued and separated cells, such as `488B ?? 90`.
+- Long integer notation, such as `0x488B9090`.
+- Colon, pipe, or hyphen separators.
+- Declaration text and random prose.
 
-When SIMD speedups are available, a batch lazily copies the requested segment (or all segments) once and reuses that buffer for every unique normalized pattern. `results = batch.search(scope_ea=ea)` uses the same containing-segment fallback policy as ordinary signature search. Supplying both `buf` and `scope_ea` is rejected because SigMaker cannot prove that the caller-provided buffer represents that segment. Canceling a batch raises `UserCanceledError`; partial hits are not cached or exported as a complete entry.
+An invalid pattern becomes an error on that entry; it does not abort the rest
+of the batch. Every searchable pattern must contain at least one exact byte.
+An all-wildcard pattern such as `?? ?? ??` is rejected because it matches almost
+everywhere and is not a useful search key.
 
-`BatchSearchResults.display()` writes the text format to `idaapi.msg` by default, or writes the selected formatter to any text file-like object or callable sink:
+#### Results
+
+`BatchSearchResults` is iterable and preserves input order. `list(results)`
+returns the per-pattern `SearchResults` objects. Each entry contains:
+
+- **Identity and input**
+  - `name` and `source_line` identify the entry.
+  - `raw_pattern` contains the extracted user input.
+- **Parsed patterns**
+  - `search_pattern` is the parsed SigMaker pattern used for display.
+  - `normalized_signature` is the canonical matcher and cache pattern.
+  - `signature_str` remains a compatibility alias for `search_pattern`.
+- **Outcome**
+  - `status` is `matched`, `no_matches`, or `error`.
+  - `matches` is the list of matching addresses.
+  - `error` contains the per-entry failure, when present.
+
+Nibble masks such as `4?` and `?F` are preserved in both parsed and normalized
+patterns. A full-byte wildcard displays as `?` in `search_pattern` and as `??`
+in `normalized_signature`.
+
+#### Match addresses and offsets
+
+Each `Match` still behaves like an `int`, so existing address-based code keeps
+working. It also carries optional RVA and file-offset metadata and supports:
+
+- `f"{hit:ea}"` for the absolute effective address.
+- `f"{hit:rva}"` for the module-relative virtual address.
+- `f"{hit:fileoffset}"` for the input-file offset.
+
+Search populates the RVA directly. File offsets are lazy because IDA resolves
+them one address at a time. Call `result.file_offset_for_match(hit)`, or let a
+formatter resolve the hits it emits. Each result caches both successful and
+unavailable lookups.
+
+Batch search itself performs no file-offset lookups. The text formatter resolves
+only previewed hits; CSV and JSON resolve every exported hit. `:rva` and
+`:fileoffset` do not fall back to `:ea`, since that would label an absolute
+address as a derived offset. When the requested metadata is absent from the
+`Match`, formatting returns `repr(hit)`, which still includes the effective
+address.
+
+#### Scope, buffer reuse, and cancellation
+
+- With SIMD speedups, a batch lazily copies the requested segment or all
+  segments once, then reuses that buffer for every unique normalized pattern.
+- Without SIMD speedups, nibble wildcard patterns use the same shared-buffer
+  path. Ordinary IDA-compatible patterns continue through IDA's native search.
+- `batch.search(scope_ea=ea)` limits the scan to the containing segment, using
+  the same fallback policy as ordinary signature search.
+- A caller may pass a preloaded `buf`. Supplying both `buf` and `scope_ea` is
+  rejected because SigMaker cannot prove that the buffer represents that
+  segment.
+- Canceling a batch raises `UserCanceledError`. Partial hits are not cached or
+  exported as a completed entry.
+
+#### GUI and headless embedding
+
+`SignatureSearcher` and `BatchSignatureSearcher` select their default services
+once from the host:
+
+| Host | Search progress and cancellation |
+| --- | --- |
+| Graphical IDA (`idaapi.is_idaq() is True`) | IDA wait box and Cancel button |
+| idalib | Headless no-op services |
+| Missing or failed `is_idaq()` probe | Headless no-op services |
+
+The interactive plugin also installs IDA-backed services explicitly while it
+runs an action. Direct calls from IDAPython therefore retain their existing UI,
+while idalib and stripped embedders do not call `idaapi.user_cancelled()`.
+
+Under idalib, no search-specific configuration is required. Initialize IDA
+before importing SigMaker, then use the same search API:
+
+```python
+import idapro
+import sigmaker
+
+results = sigmaker.BatchSignatureSearcher.from_text(text).search()
+```
+
+To force headless search even inside graphical IDA, scope an empty service set
+to the operation:
+
+```python
+with sigmaker.UIServices.use(sigmaker.UIServices()):
+    results = sigmaker.BatchSignatureSearcher.from_text(text).search()
+```
+
+An embedder may instead provide its own progress context or cancellation
+predicate. The predicate is resolved once before each scan loop and polled at
+the existing cancellation stride, so injection does not add a context lookup
+to every match:
+
+```python
+services = sigmaker.UIServices(
+    cancel_requested=cancel_event.is_set,
+)
+
+with sigmaker.UIServices.use(services):
+    results = sigmaker.BatchSignatureSearcher.from_text(text).search()
+```
+
+`progress` is any callable that accepts the progress message and returns a
+context manager. Within an explicitly constructed `UIServices`, omitted fields
+use their headless no-op defaults.
+
+`UIServices` isolates search-side UI behavior. It does not remove the plugin's
+Form, action, or menu classes from the full module; producing a distributable
+engine-only source file remains a separate packaging concern.
+
+#### Display and export
+
+`str(results)` and `f"{results:text}"` use the human-readable text formatter.
+`BatchSearchResults.display()` writes that format to `idaapi.msg` by default, or
+writes any selected formatter to a text file-like object or callable sink:
 
 ```python
 import io
@@ -299,11 +478,26 @@ results.display(output=buf, formatter="json")
 payload = buf.getvalue()
 ```
 
-The built-in batch formats are `text`, `csv`, and `json`. Export suffixes such as `.txt`, `.csv`, and `.json` select the matching built-in formatter. Loadable formatter examples live in [`examples/`](./examples/).
+The built-in formats are:
+
+- `text` and `.txt` for a human-readable summary with a bounded match preview.
+- `csv` and `.csv` for spreadsheets and line-oriented tooling.
+- `json` and `.json` for structured interchange.
+
+The built-ins intentionally stop at common interchange formats. Project-specific
+layouts belong in registered formatters, so a team can decide how to name
+symbols, handle ambiguous matches, and emit EAs, RVAs, or file offsets without
+changing SigMaker core. Loadable examples live in [`examples/`](./examples/).
 
 ### Custom batch search formatters
 
-Power users can add project-specific output formats without changing SigMaker core:
+Output conventions vary between reverse-engineering projects. One project may
+need debugger labels, another C declarations, and another a module-relative map
+for a loader. The formatter registry lets those conventions remain local while
+still supporting `results.format(...)`, f-strings, `display()`, and suffix-based
+file export.
+
+Register a formatter with a name and any file suffixes it owns:
 
 ```python
 import sigmaker
@@ -323,9 +517,21 @@ class LabelFormatter:
         return "\n".join(lines) + "\n"
 ```
 
-After registration, `results.format("labels")` and `f"{results:labels}"` use the formatter by name, and exporting to `something.labels` uses it by suffix. Formatter classes are instantiated once at registration time; formatter objects can be registered the same way.
+After registration, `results.format("labels")` and `f"{results:labels}"` use the
+formatter by name. Exporting to `something.labels` selects it by suffix.
+Formatter classes are instantiated once at registration time; formatter objects
+can be registered the same way.
 
-Formatter names and export suffixes must be unique. Registering a name or suffix that is already in use raises `ValueError` without changing either registry. When replacing an existing registration is intentional, opt in explicitly:
+#### Registration safety
+
+Formatter registration guards existing behavior, including the built-in
+`text`, `csv`, and `json` formats:
+
+- Formatter names and export suffixes must be unique.
+- A conflicting registration raises `ValueError` before either registry is
+  changed. The error points to `override=True` when replacement is intentional.
+- `override=True` is required to replace an existing name or rebind an existing
+  suffix:
 
 ```python
 @sigmaker.BatchSearchFormatter.register(
@@ -337,23 +543,103 @@ class ReplacementLabelFormatter:
     ...
 ```
 
-One `override=True` allows both replacing the formatter registered under that name and rebinding the listed suffixes. Existing suffixes that already point to the replaced name remain valid.
+One `override=True` covers both the formatter name and its listed suffixes.
+Existing suffixes that already point to a replaced name remain valid. This
+makes replacement explicit without silently disconnecting other suffixes.
 
-To install a formatter permanently, paste the same formatter registration code into `$IDAUSR/idapythonrc.py`. IDA sources that file during startup, so the formatter is available in each new IDA session.
+#### Loading personal formatters
 
-If `sigmaker` is not already importable from your IDA Python environment, add the SigMaker plugin directory to `sys.path` before the formatter code.
+To install a formatter permanently, paste its registration code into
+`$IDAUSR/idapythonrc.py`. IDA sources that file during startup, so personal and
+project-specific formats are available in each new IDA session.
 
-See [`examples/batch_search_c_formatter.py`](./examples/batch_search_c_formatter.py) for a complete C-style formatter template that emits absolute EAs, RVAs, and file offsets while keeping C output out of the built-in format list.
+If `sigmaker` is not already importable from your IDA Python environment, add
+the SigMaker plugin directory to `sys.path` before the formatter code.
+
+See
+[`examples/batch_search_c_formatter.py`](./examples/batch_search_c_formatter.py)
+for a complete C-style formatter template that emits absolute EAs, RVAs, and
+file offsets while keeping C output out of the built-in format list.
 
 ### Stability contract
 
-If you embed `sigmaker`, you can rely on the following. These are treated as a contract and are checked before any change to the public surface:
+If you embed `sigmaker`, you can rely on the following. These guarantees are
+checked before any change to the public surface:
 
-1. **Append-only config.** `SigMakerConfig` fields are never reordered or removed. New behavior arrives as new fields with safe defaults, so existing constructions keep working.
-2. **Stable public names.** These names and their documented attributes are not renamed or removed: `SignatureMaker`, `SigMakerConfig`, `SignatureType` (`IDA`, `x64Dbg`, `Mask`, `BitMask`), `XrefFinder`, `GeneratedSignature` (`signature`, `address`, `status`, `match_count`), `XrefGeneratedSignature` (`signatures`), `Match` (`address`, `rva`, `file_offset`; `__str__` returns the hex address; `__format__` supports `ea`, `rva`, and `fileoffset`), `Signature` (`__len__`, `__format__`), `SignatureSearcher` (`input_signature`, `name`, `source_line`), `SearchResults` (`matches`, `signature_str`, `raw_pattern`, `search_pattern`, `normalized_signature`, `file_offset_for_match`), `GenerationPolicy`, `GenerationStatus`, `BatchSignatureSearcher` (`input_text`, `searchers`), `BatchSearchResults` (`__str__`, `__format__`), `BatchSearchFormatter`.
-3. **Stable method signatures.** `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict())`, `XrefFinder.find_xrefs(ea, cfg)`, `XrefFinder.count_code_xrefs_to(ea)`, `XrefFinder.iter_code_xrefs_to(ea)`, `SignatureSearcher.from_signature(input_signature, *, name=None, source_line=0)`, `SignatureSearcher.from_many(text)`, and `BatchSignatureSearcher.search(*, buf=None, scope_ea=None)`.
-4. **Stable format specs.** `f"{sig:ida}"`, `f"{sig:x64dbg}"`, `f"{sig:mask}"`, and `f"{sig:bitmask}"` keep producing their current output exactly. Batch search keeps the registered built-in formatter names `text`, `csv`, and `json`.
-5. **Byte-identical defaults.** Production defaults are unchanged across optimizations: a script that does not opt into a new flag gets byte-identical signatures to previous versions.
+- **Append-only configuration**
+  - `SigMakerConfig` fields are never reordered or removed.
+  - New behavior arrives as new fields with safe defaults, so existing
+    constructions keep working.
+
+- **Stable public names**
+  - Signature generation
+    - `SignatureMaker`
+    - `SigMakerConfig`
+    - `SignatureType`
+      - Stable members: `IDA`, `x64Dbg`, `Mask`, and `BitMask`.
+    - `Signature`
+      - Stable behavior: `__len__` and `__format__`.
+    - `GeneratedSignature`
+      - Stable attributes: `signature`, `address`, `status`, and `match_count`.
+    - `GenerationPolicy`
+    - `GenerationStatus`
+  - Cross-reference generation
+    - `XrefFinder`
+    - `XrefGeneratedSignature`
+      - Stable attribute: `signatures`.
+  - Signature search
+    - `SignatureSearcher`
+      - Stable attributes: `input_signature`, `name`, and `source_line`.
+    - `SearchResults`
+      - Stable attributes: `matches`, `signature_str`, `raw_pattern`,
+        `search_pattern`, and `normalized_signature`.
+      - Stable method: `file_offset_for_match`.
+    - `Match`
+      - Stable attributes: `address`, `rva`, and `file_offset`.
+      - `__str__` returns the hexadecimal address.
+      - `__format__` supports `ea`, `rva`, and `fileoffset`.
+    - `UIServices`
+      - Stable attributes: `progress` and `cancel_requested`.
+      - `current()` returns the services active in the current context.
+      - `use(services)` scopes services to one context and restores the
+        previous value on exit.
+  - Batch search
+    - `BatchSignatureSearcher`
+      - Stable attributes: `input_text` and `searchers`.
+    - `BatchSearchResults`
+      - Stable behavior: `__str__` and `__format__`.
+    - `BatchSearchFormatter`
+
+- **Stable method signatures**
+  - Signature generation
+    - `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict())`
+  - Cross-reference generation
+    - `XrefFinder.find_xrefs(ea, cfg)`
+    - `XrefFinder.count_code_xrefs_to(ea)`
+    - `XrefFinder.iter_code_xrefs_to(ea)`
+  - Signature search
+    - `SignatureSearcher.from_signature(input_signature, *, name=None, source_line=0)`
+    - `SignatureSearcher.from_many(text)`
+    - `UIServices.current()`
+    - `UIServices.use(services)`
+  - Batch search
+    - `BatchSignatureSearcher.search(*, buf=None, scope_ea=None)`
+
+- **Stable format specifications**
+  - Signature formats keep producing their current output exactly:
+    - `f"{sig:ida}"`
+    - `f"{sig:x64dbg}"`
+    - `f"{sig:mask}"`
+    - `f"{sig:bitmask}"`
+  - Batch search keeps the registered built-in formatter names:
+    - `text`
+    - `csv`
+    - `json`
+
+- **Byte-identical defaults**
+  - Production defaults are unchanged across optimizations.
+  - A script that does not opt into a new flag gets byte-identical signatures
+    to previous versions.
 
 ### Used by
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -39,6 +39,47 @@ PLUGIN_AUTHOR: str = __author__
 WILDCARD_POLICY_CTX: contextvars.ContextVar["WildcardPolicy"] = contextvars.ContextVar(
     "wildcard_policy"
 )
+_UI_SERVICES_CTX: contextvars.ContextVar["UIServices"] = contextvars.ContextVar(
+    "ui_services"
+)
+
+
+@contextlib.contextmanager
+def _null_progress(*args, **kwargs) -> typing.Iterator[None]:
+    """Provide a headless progress context."""
+    yield
+
+
+def _never_cancel() -> bool:
+    return False
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class UIServices:
+    """Context-local UI hooks selected for the current IDA host."""
+
+    #: Factory for the progress context used while loading and searching.
+    progress: typing.Callable[..., typing.ContextManager[object]] = _null_progress
+    #: Cheap predicate polled periodically by long-running search loops.
+    cancel_requested: typing.Callable[[], bool] = _never_cancel
+    _ctx = _UI_SERVICES_CTX
+
+    @classmethod
+    def current(cls) -> "UIServices":
+        return cls._ctx.get(_DEFAULT_UI_SERVICES)
+
+    @classmethod
+    @contextlib.contextmanager
+    def use(cls, services: "UIServices") -> typing.Iterator["UIServices"]:
+        token = cls._ctx.set(services)
+        try:
+            yield services
+        finally:
+            cls._ctx.reset(token)
+
+
+_HEADLESS_UI = UIServices()
+_DEFAULT_UI_SERVICES = _HEADLESS_UI
 
 
 SIMD_SPEEDUP_AVAILABLE = False
@@ -145,9 +186,18 @@ LOGGER = configure_logging()
 # Set to True to enable verbose debug logging for progress reporter initialization
 DEBUGGING_MODE = False
 
-# Wrapper for IDA's British English spelling
-# IDA uses 'cancelled' but we use American English 'canceled' throughout our code
-idaapi_user_canceled = idaapi.user_cancelled
+_IDA_USER_CANCELLED = getattr(idaapi, "user_cancelled", None)
+_IDA_IS_IDAQ = getattr(idaapi, "is_idaq", None)
+
+
+def idaapi_user_canceled() -> bool:
+    """Poll IDA cancellation when its UI API is available."""
+    if not callable(_IDA_USER_CANCELLED):
+        return False
+    try:
+        return bool(_IDA_USER_CANCELLED())
+    except Exception:
+        return False
 
 
 def _load_qmessage_box_cls():
@@ -526,6 +576,23 @@ class InMemoryBuffer:
             return seg_ea + (offset - buf_off)
 
         return _map
+
+    def _search_ranges(
+        self,
+        scope: typing.Optional[tuple[int, int]] = None,
+    ) -> typing.Iterator[tuple[int, int]]:
+        """Yield contiguous buffer ranges, optionally clipped to an EA scope."""
+        segments = self._segments or (
+            (0, self.imagebase, len(self._buffer)),
+        )
+        for offset, segment_ea, size in segments:
+            if scope is None:
+                yield offset, offset + size
+                continue
+            start_ea = max(segment_ea, scope[0])
+            end_ea = min(segment_ea + size, scope[1])
+            if start_ea < end_ea:
+                yield offset + start_ea - segment_ea, offset + end_ea - segment_ea
 
     def _load_single_segment(self, ea: int):
         """Load only the segment containing ``ea`` (issue #64), recording it in
@@ -3039,6 +3106,56 @@ class SignatureParser:
         return " ".join(tokens)
 
 
+def _masked_signature_bytes(ida_signature: str) -> tuple[bytes, bytes]:
+    """Return normalized pattern values and per-nibble comparison masks."""
+    normalized, _ = SigText.normalize(ida_signature)
+    values = bytearray()
+    masks = bytearray()
+    for token in normalized.split():
+        values.append(int(token.replace("?", "0"), 16))
+        masks.append(
+            (0xF0 if token[0] != "?" else 0)
+            | (0x0F if token[1] != "?" else 0)
+        )
+    return bytes(values), bytes(masks)
+
+
+def _longest_exact_run(masks: bytes) -> tuple[int, int]:
+    """Return ``(start, length)`` for the longest 0xFF mask run."""
+    best_start = 0
+    best_length = 0
+    run_start = 0
+    for index, mask in enumerate(masks):
+        if mask == 0xFF:
+            continue
+        if index - run_start > best_length:
+            best_start = run_start
+            best_length = index - run_start
+        run_start = index + 1
+    if len(masks) - run_start > best_length:
+        best_start = run_start
+        best_length = len(masks) - run_start
+    if best_length == 0:
+        raise ValueError("Nibble wildcard search requires at least one exact byte")
+    return best_start, best_length
+
+
+def _load_search_buffer(
+    scope: typing.Optional[tuple[int, int]] = None,
+) -> InMemoryBuffer:
+    message = (
+        "Please stand by, copying the segment..."
+        if scope is not None
+        else "Please stand by, copying segments..."
+    )
+    scope_kwargs = {"scope_ea": scope[0]} if scope is not None else {}
+    with UIServices.current().progress(message):
+        return InMemoryBuffer.load(
+            mode=InMemoryBuffer.LoadMode.SEGMENTS,
+            **scope_kwargs,
+        )
+
+
 @dataclasses.dataclass(slots=True)
 class SignatureSearcher:
     """Parses a signature string and searches the DB for matches."""
@@ -3162,11 +3279,6 @@ class SignatureSearcher:
             not is_wildcard for _, is_wildcard in pattern
         ):
             raise ValueError("Unrecognized signature format")
-        if (
-            not SIMD_SPEEDUP_AVAILABLE
-            and SignatureSearcher._has_nibble_wildcards(normalized)
-        ):
-            raise ValueError("Nibble wildcard search requires SIMD speedups")
         return sig_str, normalized
 
     def search(self, scope_ea: typing.Optional[int] = None) -> SearchResults:
@@ -3196,8 +3308,7 @@ class SignatureSearcher:
 
         where = "the current segment" if scope else "the whole database"
         imagebase = SearchResults.current_imagebase()
-        # Wrap the search in a ProgressDialog to allow cancellation
-        with ProgressDialog(
+        with UIServices.current().progress(
             "Search for a signature\n\n"
             f"Scanning {where} for your pattern.\n\n"
             "Press Cancel to stop"
@@ -3218,6 +3329,83 @@ class SignatureSearcher:
         )
 
     @staticmethod
+    def _find_all_nibble_fallback(
+        ida_signature: str,
+        skip_more_than_one: bool = False,
+        buf: typing.Optional["InMemoryBuffer"] = None,
+        scope: typing.Optional[tuple[int, int]] = None,
+        *,
+        imagebase: typing.Optional[int] = None,
+        raise_on_cancel: bool = False,
+    ) -> list[Match]:
+        values, masks = _masked_signature_bytes(ida_signature)
+        anchor_start, anchor_size = _longest_exact_run(masks)
+        pattern_size = len(values)
+        anchor = values[anchor_start : anchor_start + anchor_size]
+
+        if buf is None:
+            buf = _load_search_buffer(scope)
+
+        data_mv = buf.data()
+        # Search the owned bytearray directly so bytearray.find stays in C and
+        # the fallback does not duplicate the full segment buffer.
+        haystack = buf._buffer
+        checks = tuple(
+            (index, mask, values[index] & mask)
+            for index, mask in enumerate(masks)
+            if mask != 0
+            and not anchor_start <= index < anchor_start + anchor_size
+        )
+        to_addr = buf.offset_mapper()
+        results: list[Match] = []
+        since_poll = 0
+        cancel_requested = UIServices.current().cancel_requested
+
+        def stop_requested() -> bool:
+            if not cancel_requested():
+                return False
+            LOGGER.info("Search canceled by user")
+            if raise_on_cancel:
+                raise UserCanceledError("Search canceled by user")
+            return True
+
+        if stop_requested():
+            return results
+
+        for range_start, range_end in buf._search_ranges(scope):
+            if range_end - range_start < pattern_size:
+                continue
+            search_from = range_start + anchor_start
+            search_end = range_end - pattern_size + anchor_start + anchor_size
+            while search_from < search_end:
+                anchor_hit = haystack.find(anchor, search_from, search_end)
+                if anchor_hit < 0:
+                    break
+                candidate = anchor_hit - anchor_start
+                matched = True
+                for index, mask, target in checks:
+                    if (data_mv[candidate + index] & mask) != target:
+                        matched = False
+                        break
+                if matched:
+                    address = to_addr(candidate)
+                    results.append(
+                        Match(
+                            address,
+                            rva=None if imagebase is None else address - imagebase,
+                        )
+                    )
+                    if skip_more_than_one and len(results) > 1:
+                        return results
+                search_from = anchor_hit + 1
+                since_poll += 1
+                if since_poll >= _CANCEL_POLL_STRIDE:
+                    since_poll = 0
+                    if stop_requested():
+                        return results
+        return results
+
+    @staticmethod
     def _find_all_simd(
         ida_signature: str,
         skip_more_than_one: bool = False,
@@ -3228,8 +3416,7 @@ class SignatureSearcher:
     ) -> list[Match]:
         simd_signature, _ = SigText.normalize(ida_signature)
         if buf is None:
-            with ProgressDialog("Please stand by, copying segments..."):
-                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+            buf = _load_search_buffer()
         data_mv = buf.data()
         LOGGER.debug(
             "searching for",
@@ -3263,11 +3450,12 @@ class SignatureSearcher:
         # find_all_offsets) so per-match user_cancelled() overhead does not
         # dominate a scan over a short, common pattern.
         since_poll = 0
+        cancel_requested = UIServices.current().cancel_requested
         while off <= n - k:
             since_poll += 1
             if since_poll >= _CANCEL_POLL_STRIDE:
                 since_poll = 0
-                if idaapi_user_canceled():
+                if cancel_requested():
                     LOGGER.info("Search canceled by user")
                     if raise_on_cancel:
                         raise UserCanceledError("Search canceled by user")
@@ -3300,8 +3488,7 @@ class SignatureSearcher:
         """
         simd_signature, _ = SigText.normalize(ida_signature)
         if buf is None:
-            with ProgressDialog("Please stand by, copying segments..."):
-                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+            buf = _load_search_buffer()
         data_mv = buf.data()
         sig = _SimdSignature(simd_signature)
         offsets: list[int] = []
@@ -3315,11 +3502,12 @@ class SignatureSearcher:
         # short, common seed can produce millions of matches, so per-match
         # polling alone can dominate the scan (observed: 44s of a 76s seed).
         since_poll = 0
+        cancel_requested = UIServices.current().cancel_requested
         while off <= n - k:
             since_poll += 1
             if since_poll >= _CANCEL_POLL_STRIDE:
                 since_poll = 0
-                if idaapi_user_canceled():
+                if cancel_requested():
                     break
             idx = _simd_scan_bytes(data_mv[off:], sig)
             if idx < 0:
@@ -3344,10 +3532,7 @@ class SignatureSearcher:
                 # Scope the SIMD scan to one segment by loading only its bytes;
                 # offset_mapper resolves the match offsets back to real
                 # addresses (issue #64 search-scope, on top of #68).
-                with ProgressDialog("Please stand by, copying the segment..."):
-                    buf = InMemoryBuffer.load(
-                        mode=InMemoryBuffer.LoadMode.SEGMENTS, scope_ea=scope[0]
-                    )
+                buf = _load_search_buffer(scope)
             return SignatureSearcher._find_all_simd(
                 ida_signature,
                 skip_more_than_one=skip_more_than_one,
@@ -3356,7 +3541,14 @@ class SignatureSearcher:
                 raise_on_cancel=raise_on_cancel,
             )
         if SignatureSearcher._has_nibble_wildcards(ida_signature):
-            raise ValueError("Nibble wildcard search requires SIMD speedups")
+            return SignatureSearcher._find_all_nibble_fallback(
+                ida_signature,
+                skip_more_than_one=skip_more_than_one,
+                buf=buf,
+                scope=scope,
+                imagebase=imagebase,
+                raise_on_cancel=raise_on_cancel,
+            )
         binary = idaapi.compiled_binpat_vec_t()
         idaapi.parse_binpat_str(binary, idaapi.inf_get_min_ea(), ida_signature, 16)
         out: list[Match] = []
@@ -3369,9 +3561,10 @@ class SignatureSearcher:
             idaapi, "bin_search3"
         )
         flags = idaapi.BIN_SEARCH_NOCASE | idaapi.BIN_SEARCH_FORWARD
+        cancel_requested = UIServices.current().cancel_requested
         while True:
             # Check for user cancellation
-            if idaapi_user_canceled():
+            if cancel_requested():
                 LOGGER.info("Search canceled by user")
                 if raise_on_cancel:
                     raise UserCanceledError("Search canceled by user")
@@ -3463,25 +3656,17 @@ class BatchSignatureSearcher:
 
                 matches = match_cache.get(normalized)
                 if matches is None:
-                    if SIMD_SPEEDUP_AVAILABLE and active_buf is None:
-                        message = (
-                            "Please stand by, copying the segment..."
-                            if scope is not None
-                            else "Please stand by, copying segments..."
-                        )
-                        load_kwargs: dict[str, typing.Any] = {
-                            "mode": InMemoryBuffer.LoadMode.SEGMENTS,
-                        }
-                        if scope is not None:
-                            load_kwargs["scope_ea"] = scope[0]
-                        with ProgressDialog(message):
-                            active_buf = InMemoryBuffer.load(**load_kwargs)
+                    uses_buffer = SIMD_SPEEDUP_AVAILABLE or (
+                        SignatureSearcher._has_nibble_wildcards(normalized)
+                    )
+                    if uses_buffer and active_buf is None:
+                        active_buf = _load_search_buffer(scope)
                         imagebase = SearchResults.current_imagebase(active_buf)
 
                     matches = SignatureSearcher.find_all(
                         normalized,
                         buf=active_buf,
-                        scope=None if SIMD_SPEEDUP_AVAILABLE else scope,
+                        scope=None if uses_buffer else scope,
                         imagebase=imagebase,
                         raise_on_cancel=True,
                     )
@@ -3696,6 +3881,28 @@ class ProgressDialog:
 
     # Provide alias with alternative spelling for backwards compatibility.
     user_cancelled = user_canceled
+
+
+def _ida_ui_services() -> UIServices:
+    """Build the UI services installed by the interactive IDA plugin."""
+    return UIServices(
+        progress=ProgressDialog,
+        cancel_requested=idaapi_user_canceled,
+    )
+
+
+def _select_default_ui_services() -> UIServices:
+    """Use IDA UI services only when IDAPython is hosted by the GUI."""
+    if callable(_IDA_IS_IDAQ):
+        try:
+            if _IDA_IS_IDAQ() is True:
+                return _ida_ui_services()
+        except Exception:
+            pass
+    return _HEADLESS_UI
+
+
+_DEFAULT_UI_SERVICES = _select_default_ui_services()
 
 
 @dataclasses.dataclass(slots=True)
@@ -4302,6 +4509,7 @@ class SigMakerPlugin(idaapi.plugin_t):
             scope_to_segment=scope_to_segment,
         )
 
+        ui_token = _UI_SERVICES_CTX.set(_ida_ui_services())
         try:
             if action == Action.CREATE_UNIQUE:
                 ea = idaapi.get_screen_ea()
@@ -4364,6 +4572,8 @@ class SigMakerPlugin(idaapi.plugin_t):
         except Exception as e:
             LOGGER.error("Exception occurred: %s%s%s", e, os.linesep, traceback.format_exc())
             return
+        finally:
+            _UI_SERVICES_CTX.reset(ui_token)
 
     def _run_find_function_sig(self, config: SigMakerConfig) -> None:
         """Action.FIND_FUNCTION_SIG: shortest unique sig within the function,

--- a/tests/integration_test_sigmaker.py
+++ b/tests/integration_test_sigmaker.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 import warnings
+from unittest.mock import patch
 
 sys.path.insert(0, pathlib.Path(__file__).parent.as_posix())
 
@@ -145,6 +146,10 @@ class TestIntegrationWithRealBinary(CoveredIntegrationTest):
         self.assertEqual(sigmaker.IDAVersionInfo.ida_version().sdk_version, idaapi.IDA_SDK_VERSION)
         self.assertEqual(sigmaker.IDAVersionInfo.ida_version().major, major)
         self.assertEqual(sigmaker.IDAVersionInfo.ida_version().minor, minor)
+
+    def test_idalib_defaults_to_headless_search_services(self):
+        self.assertFalse(idaapi.is_idaq())
+        self.assertIs(sigmaker.UIServices.current(), sigmaker._HEADLESS_UI)
 
     def test_load_binary_with_ida(self):
         """Test loading the binary with IDA and basic analysis"""
@@ -298,6 +303,20 @@ class TestIntegrationWithRealBinary(CoveredIntegrationTest):
         self.assertEqual(payload["entry_count"], 3)
         self.assertEqual(payload["entries"][0]["match_count"], 4)
         self.assertIn("match_file_offsets", f"{results:csv}")
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_no_simd_nibble_fallback_matches_simd_results(self):
+        pattern = "E? 8? 0A 00 00 48 89 C7"
+        buf = sigmaker.InMemoryBuffer.load(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS
+        )
+        expected = sigmaker.SignatureSearcher.find_all(pattern, buf=buf)
+        self.assertGreater(len(expected), 0)
+
+        with patch.object(sigmaker, "SIMD_SPEEDUP_AVAILABLE", False):
+            actual = sigmaker.SignatureSearcher.find_all(pattern, buf=buf)
+
+        self.assertEqual(actual, expected)
 
     def test_signature_occurrence_finding(self):
         test_signatures = [

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -6,6 +6,7 @@ to ensure reliable testing across different platforms and architectures.
 """
 
 import array
+import contextlib
 import csv
 import dataclasses
 import gc
@@ -1740,25 +1741,30 @@ class TestSignatureSearcherInput(CoveredUnitTest):
         self.assertIn("Unrecognized", result.error)
         msg.assert_called_once_with("Unrecognized signature type\n")
 
-    def test_search_reports_nibble_wildcard_error_without_simd(self):
-        original_simd = sigmaker.SIMD_SPEEDUP_AVAILABLE
-        try:
-            sigmaker.SIMD_SPEEDUP_AVAILABLE = False
-            with patch.object(sigmaker.idaapi, "msg") as msg, patch.object(
-                sigmaker.SignatureSearcher,
-                "find_all",
-            ) as find_all:
-                result = sigmaker.SignatureSearcher.from_signature("48 4? ?F").search()
+    def test_search_accepts_nibble_wildcards_without_simd(self):
+        with patch.object(
+            sigmaker,
+            "SIMD_SPEEDUP_AVAILABLE",
+            False,
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all",
+            return_value=[],
+        ) as find_all, patch.object(
+            sigmaker.idaapi,
+            "get_imagebase",
+            return_value=None,
+        ), patch.object(sigmaker.idaapi, "msg") as msg:
+            result = sigmaker.SignatureSearcher.from_signature("48 4? ?F").search()
 
-            find_all.assert_not_called()
-            self.assertEqual(result.status, "error")
-            self.assertEqual(
-                result.error,
-                "Nibble wildcard search requires SIMD speedups",
-            )
-            msg.assert_called_once_with("Unrecognized signature type\n")
-        finally:
-            sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
+        find_all.assert_called_once_with(
+            "48 4? ?F",
+            scope=None,
+            imagebase=None,
+        )
+        self.assertEqual(result.status, "no_matches")
+        self.assertEqual(result.error, "")
+        msg.assert_not_called()
 
     def test_searcher_metadata_flows_to_results(self):
         with patch.object(
@@ -1921,41 +1927,79 @@ class TestBatchSignatureSearcher(CoveredUnitTest):
                 scope_ea=0x1010,
             )
 
-    def test_search_reuses_one_automatic_simd_buffer(self):
+    def test_search_reuses_one_automatic_buffer(self):
+        cases = (
+            (True, "first = 90\nsecond = CC"),
+            (False, "first = 48 4? ?F\nsecond = 90 ?A CC"),
+        )
+        for simd_available, text in cases:
+            with self.subTest(simd_available=simd_available):
+                loaded = MagicMock(imagebase=0x140000000)
+                with patch.object(
+                    sigmaker,
+                    "SIMD_SPEEDUP_AVAILABLE",
+                    simd_available,
+                ), patch.object(
+                    sigmaker,
+                    "ProgressDialog",
+                    MagicMock(),
+                ), patch.object(
+                    sigmaker.InMemoryBuffer,
+                    "load",
+                    return_value=loaded,
+                ) as load, patch.object(
+                    sigmaker.SignatureSearcher,
+                    "find_all",
+                    return_value=[],
+                ) as find_all:
+                    results = sigmaker.BatchSignatureSearcher.from_text(text).search()
+
+                load.assert_called_once_with(
+                    mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
+                )
+                self.assertEqual(find_all.call_count, 2)
+                for call in find_all.call_args_list:
+                    self.assertIs(call.kwargs["buf"], loaded)
+                    self.assertIsNone(call.kwargs["scope"])
+                    self.assertEqual(call.kwargs["imagebase"], 0x140000000)
+                    self.assertIs(call.kwargs["raise_on_cancel"], True)
+                self.assertEqual(results.imagebase, 0x140000000)
+
+    def test_no_simd_batch_keeps_native_scope_after_loading_nibble_buffer(self):
+        seg = MagicMock(start_ea=0x3000, end_ea=0x3400)
         loaded = MagicMock()
-        loaded.imagebase = 0x140000000
+        loaded.imagebase = 0x1000
 
         with patch.object(
             sigmaker,
             "SIMD_SPEEDUP_AVAILABLE",
-            True,
+            False,
         ), patch.object(
             sigmaker,
             "ProgressDialog",
             MagicMock(),
         ), patch.object(
+            sigmaker.idaapi,
+            "getseg",
+            return_value=seg,
+        ), patch.object(
             sigmaker.InMemoryBuffer,
             "load",
             return_value=loaded,
-        ) as load, patch.object(
+        ), patch.object(
             sigmaker.SignatureSearcher,
             "find_all",
             return_value=[],
         ) as find_all:
-            results = sigmaker.BatchSignatureSearcher.from_text(
-                "first = 90\nsecond = CC"
-            ).search()
+            sigmaker.BatchSignatureSearcher.from_text(
+                "nibble = 48 4? ?F\nnormal = 90 90"
+            ).search(scope_ea=0x3200)
 
-        load.assert_called_once_with(
-            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
-        )
-        self.assertEqual(find_all.call_count, 2)
-        for call in find_all.call_args_list:
-            self.assertIs(call.kwargs["buf"], loaded)
-            self.assertIsNone(call.kwargs["scope"])
-            self.assertEqual(call.kwargs["imagebase"], 0x140000000)
-            self.assertIs(call.kwargs["raise_on_cancel"], True)
-        self.assertEqual(results.imagebase, 0x140000000)
+        nibble_call, normal_call = find_all.call_args_list
+        self.assertIs(nibble_call.kwargs["buf"], loaded)
+        self.assertIsNone(nibble_call.kwargs["scope"])
+        self.assertIs(normal_call.kwargs["buf"], loaded)
+        self.assertEqual(normal_call.kwargs["scope"], (0x3000, 0x3400))
 
     def test_search_does_not_load_simd_buffer_for_invalid_or_empty_batch(self):
         with patch.object(
@@ -2224,10 +2268,6 @@ class TestBatchSignatureSearcher(CoveredUnitTest):
             "SIMD_SPEEDUP_AVAILABLE",
             False,
         ), patch.object(
-            sigmaker,
-            "idaapi_user_canceled",
-            side_effect=[False, True],
-        ), patch.object(
             sigmaker.idaapi,
             "BADADDR",
             0xFFFFFFFFFFFFFFFF,
@@ -2258,6 +2298,10 @@ class TestBatchSignatureSearcher(CoveredUnitTest):
             sigmaker.idaapi,
             "bin_search",
             return_value=(0x1000, None),
+        ), sigmaker.UIServices.use(
+            sigmaker.UIServices(
+                cancel_requested=MagicMock(side_effect=[False, True])
+            )
         ):
             with self.assertRaises(sigmaker.UserCanceledError):
                 sigmaker.BatchSignatureSearcher.from_text("48 8B C4").search()
@@ -2279,16 +2323,16 @@ class TestBatchSignatureSearcher(CoveredUnitTest):
             1,
         ), patch.object(
             sigmaker,
-            "idaapi_user_canceled",
-            side_effect=[False, True],
-        ), patch.object(
-            sigmaker,
             "_simd_scan_bytes",
             return_value=0,
         ), patch.object(
             sigmaker.idaapi,
             "inf_get_min_ea",
             return_value=0x1000,
+        ), sigmaker.UIServices.use(
+            sigmaker.UIServices(
+                cancel_requested=MagicMock(side_effect=[False, True])
+            )
         ):
             with self.assertRaises(sigmaker.UserCanceledError):
                 sigmaker.BatchSignatureSearcher.from_text("90").search(
@@ -3256,7 +3300,6 @@ class TestSearchCancellation(CoveredUnitTest):
             return call_count[0] > 2
 
         # Setup idaapi mocks
-        sigmaker.idaapi_user_canceled = mock_user_canceled
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
         sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
         sigmaker.idaapi.inf_get_max_ea = MagicMock(return_value=0xFFFF)
@@ -3280,7 +3323,10 @@ class TestSearchCancellation(CoveredUnitTest):
         sigmaker.SIMD_SPEEDUP_AVAILABLE = False
 
         try:
-            results = sigmaker.SignatureSearcher.find_all("48 8B C4")
+            with sigmaker.UIServices.use(
+                sigmaker.UIServices(cancel_requested=mock_user_canceled)
+            ):
+                results = sigmaker.SignatureSearcher.find_all("48 8B C4")
 
             # Should have found at least one match before cancellation
             self.assertGreater(len(results), 0)
@@ -3295,7 +3341,9 @@ class TestSearchCancellation(CoveredUnitTest):
     def test_find_all_no_cancellation(self):
         """Test that find_all works normally when not canceled."""
         # Setup idaapi mocks
-        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+        sigmaker.idaapi_user_canceled = MagicMock(
+            side_effect=AssertionError("headless search polled IDA UI")
+        )
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
         sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
         sigmaker.idaapi.inf_get_max_ea = MagicMock(return_value=0xFFFF)
@@ -3330,21 +3378,6 @@ class TestSearchCancellation(CoveredUnitTest):
             # Restore SIMD setting
             sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
 
-    def test_find_all_rejects_nibble_wildcards_without_simd(self):
-        original_simd = sigmaker.SIMD_SPEEDUP_AVAILABLE
-        sigmaker.SIMD_SPEEDUP_AVAILABLE = False
-        sigmaker.idaapi.parse_binpat_str = MagicMock()
-
-        try:
-            with self.assertRaisesRegex(
-                ValueError,
-                "Nibble wildcard search requires SIMD speedups",
-            ):
-                sigmaker.SignatureSearcher.find_all("48 4? ?F")
-            sigmaker.idaapi.parse_binpat_str.assert_not_called()
-        finally:
-            sigmaker.SIMD_SPEEDUP_AVAILABLE = original_simd
-
     def test_cancellation_returns_partial_results(self):
         """Test that cancellation returns partial results found so far."""
         # Mock user_canceled to cancel after finding 2 matches
@@ -3355,7 +3388,6 @@ class TestSearchCancellation(CoveredUnitTest):
             return call_count[0] > 3
 
         # Setup idaapi mocks
-        sigmaker.idaapi_user_canceled = mock_user_canceled
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
         sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
         sigmaker.idaapi.inf_get_max_ea = MagicMock(return_value=0xFFFF)
@@ -3380,7 +3412,10 @@ class TestSearchCancellation(CoveredUnitTest):
         sigmaker.SIMD_SPEEDUP_AVAILABLE = False
 
         try:
-            results = sigmaker.SignatureSearcher.find_all("48 8B C4")
+            with sigmaker.UIServices.use(
+                sigmaker.UIServices(cancel_requested=mock_user_canceled)
+            ):
+                results = sigmaker.SignatureSearcher.find_all("48 8B C4")
 
             # Should return partial results (at least 1, but not all 4)
             self.assertGreater(len(results), 0)
@@ -3406,20 +3441,422 @@ class TestSearchCancellation(CoveredUnitTest):
             1,
         ), patch.object(
             sigmaker,
-            "idaapi_user_canceled",
-            side_effect=[False, True],
-        ), patch.object(
-            sigmaker,
             "_simd_scan_bytes",
             return_value=0,
         ), patch.object(
             sigmaker.idaapi,
             "inf_get_min_ea",
             return_value=0x1000,
+        ), sigmaker.UIServices.use(
+            sigmaker.UIServices(
+                cancel_requested=MagicMock(side_effect=[False, True])
+            )
         ):
             results = sigmaker.SignatureSearcher.find_all("90", buf=shared_buf)
 
         self.assertEqual(results, [sigmaker.Match(0x1000)])
+
+
+class TestUIServices(CoveredUnitTest):
+    @staticmethod
+    def _recording_progress(events):
+        @contextlib.contextmanager
+        def progress(message="", hide_cancel=False):
+            events.append(("init", message, hide_cancel))
+            events.append(("enter",))
+            try:
+                yield
+            finally:
+                events.append(("exit",))
+
+        return progress
+
+    def test_ida_cancel_wrapper_uses_safe_cached_binding(self):
+        cached = MagicMock(return_value=True)
+        with patch.object(sigmaker, "_IDA_USER_CANCELLED", cached), patch.object(
+            sigmaker.idaapi,
+            "user_cancelled",
+            side_effect=AssertionError("wrapper repeated the module lookup"),
+        ):
+            self.assertTrue(sigmaker.idaapi_user_canceled())
+        cached.assert_called_once_with()
+
+        with patch.object(sigmaker, "_IDA_USER_CANCELLED", None):
+            self.assertFalse(sigmaker.idaapi_user_canceled())
+
+        with patch.object(
+            sigmaker,
+            "_IDA_USER_CANCELLED",
+            side_effect=RuntimeError("no UI event loop"),
+        ):
+            self.assertFalse(sigmaker.idaapi_user_canceled())
+
+    def test_current_uses_environment_default_services(self):
+        services = sigmaker.UIServices(
+            cancel_requested=MagicMock(return_value=False)
+        )
+        with patch.object(sigmaker, "_DEFAULT_UI_SERVICES", services):
+            self.assertIs(sigmaker.UIServices.current(), services)
+
+    def test_default_services_follow_idaq_host(self):
+        ida_services = sigmaker.UIServices(
+            cancel_requested=MagicMock(return_value=False)
+        )
+        with patch.object(
+            sigmaker,
+            "_IDA_IS_IDAQ",
+            return_value=True,
+        ), patch.object(
+            sigmaker,
+            "_ida_ui_services",
+            return_value=ida_services,
+        ):
+            self.assertIs(sigmaker._select_default_ui_services(), ida_services)
+
+        for is_idaq in (
+            None,
+            MagicMock(return_value=False),
+            MagicMock(return_value=1),
+        ):
+            with self.subTest(is_idaq=is_idaq), patch.object(
+                sigmaker,
+                "_IDA_IS_IDAQ",
+                is_idaq,
+            ):
+                self.assertIs(
+                    sigmaker._select_default_ui_services(),
+                    sigmaker._HEADLESS_UI,
+                )
+
+        with patch.object(
+            sigmaker,
+            "_IDA_IS_IDAQ",
+            side_effect=RuntimeError("no host UI"),
+        ):
+            self.assertIs(
+                sigmaker._select_default_ui_services(),
+                sigmaker._HEADLESS_UI,
+            )
+
+    def test_default_is_headless_noop(self):
+        with patch.object(
+            sigmaker,
+            "idaapi_user_canceled",
+            side_effect=AssertionError("headless service polled IDA UI"),
+        ):
+            ui = sigmaker.UIServices.current()
+            with ui.progress("copying"):
+                pass
+            self.assertFalse(ui.cancel_requested())
+
+    def test_use_scopes_and_resets(self):
+        outer = sigmaker.UIServices.current()
+        cancel_requested = MagicMock(return_value=True)
+        services = sigmaker.UIServices(cancel_requested=cancel_requested)
+
+        with self.assertRaisesRegex(RuntimeError, "leave context"):
+            with sigmaker.UIServices.use(services) as active:
+                self.assertIs(active, services)
+                self.assertIs(sigmaker.UIServices.current(), services)
+                self.assertTrue(sigmaker.UIServices.current().cancel_requested())
+                raise RuntimeError("leave context")
+
+        self.assertIs(sigmaker.UIServices.current(), outer)
+        cancel_requested.assert_called_once_with()
+
+    def test_load_search_buffer_uses_injected_progress(self):
+        events = []
+        loaded = MagicMock()
+        services = sigmaker.UIServices(progress=self._recording_progress(events))
+        with sigmaker.UIServices.use(services), patch.object(
+            sigmaker.InMemoryBuffer,
+            "load",
+            return_value=loaded,
+        ) as load:
+            result = sigmaker._load_search_buffer((0x2000, 0x2100))
+
+        self.assertIs(result, loaded)
+        self.assertEqual(
+            events,
+            [
+                ("init", "Please stand by, copying the segment...", False),
+                ("enter",),
+                ("exit",),
+            ],
+        )
+        load.assert_called_once_with(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
+            scope_ea=0x2000,
+        )
+
+    def test_signature_search_uses_injected_progress(self):
+        events = []
+        services = sigmaker.UIServices(progress=self._recording_progress(events))
+        with sigmaker.UIServices.use(services), patch.object(
+            sigmaker,
+            "ProgressDialog",
+            side_effect=AssertionError("library search opened IDA UI"),
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all",
+            return_value=[],
+        ), patch.object(
+            sigmaker.SearchResults,
+            "current_imagebase",
+            return_value=0x1000,
+        ):
+            result = sigmaker.SignatureSearcher.from_signature("90").search()
+
+        self.assertEqual(result.status, "no_matches")
+        self.assertEqual(events[0][0], "init")
+        self.assertIn("Search for a signature", events[0][1])
+        self.assertEqual(events[1:], [("enter",), ("exit",)])
+
+    def test_ida_ui_services_use_real_progress_and_safe_cancel_wrapper(self):
+        with patch.object(sigmaker, "ProgressDialog") as progress, patch.object(
+            sigmaker,
+            "idaapi_user_canceled",
+        ) as cancel_requested:
+            services = sigmaker._ida_ui_services()
+
+        self.assertIs(services.progress, progress)
+        self.assertIs(services.cancel_requested, cancel_requested)
+
+
+class TestNibbleWildcardFallback(CoveredUnitTest):
+    def setUp(self):
+        self._simd_available = sigmaker.SIMD_SPEEDUP_AVAILABLE
+        self._user_canceled = sigmaker.idaapi_user_canceled
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = False
+        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
+
+    def tearDown(self):
+        sigmaker.SIMD_SPEEDUP_AVAILABLE = self._simd_available
+        sigmaker.idaapi_user_canceled = self._user_canceled
+
+    @staticmethod
+    def _buffer(
+        data: bytes,
+        *,
+        segments: list[tuple[int, int, int]] | None = None,
+    ) -> sigmaker.InMemoryBuffer:
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        buf._buffer.extend(data)
+        buf._segments.extend(segments or [(0, 0x1000, len(data))])
+        return buf
+
+    def test_find_all_matches_nibble_wildcards_without_simd(self):
+        buf = self._buffer(
+            b"\x48\x4A\x1F\x90\xCC\x48\x5B\x2F\x90"
+        )
+
+        with patch.object(sigmaker.idaapi, "parse_binpat_str") as parse_binpat_str:
+            matches = sigmaker.SignatureSearcher.find_all(
+                "48 4? ?F 90",
+                buf=buf,
+                imagebase=0x1000,
+            )
+
+        self.assertEqual(matches, [sigmaker.Match(0x1000, rva=0)])
+        parse_binpat_str.assert_not_called()
+
+    def test_find_all_returns_no_matches_for_common_anchor(self):
+        buf = self._buffer(b"\x00" * 4096)
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "00 4? ?F",
+            buf=buf,
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_middle_exact_run_matches_at_both_buffer_edges(self):
+        buf = self._buffer(
+            b"\x4A\x11\x22\x99\x3F\xCC\x4B\x11\x22\x00\x4F"
+        )
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "4? 11 22 ?? ?F",
+            buf=buf,
+        )
+
+        self.assertEqual(
+            matches,
+            [sigmaker.Match(0x1000), sigmaker.Match(0x1006)],
+        )
+
+    def test_skip_more_than_one_stops_after_second_nibble_match(self):
+        occurrence = b"\x00\x4A\x1F"
+        buf = self._buffer(occurrence * 256)
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "00 4? ?F",
+            buf=buf,
+            skip_more_than_one=True,
+        )
+
+        self.assertEqual(
+            matches,
+            [sigmaker.Match(0x1000), sigmaker.Match(0x1003)],
+        )
+
+    def test_nibble_fallback_cancellation_returns_partial_results(self):
+        buf = self._buffer(b"\x48\x4A\x1F\x90" * 3)
+        cancel_requested = MagicMock(side_effect=[False, True])
+
+        with patch.object(
+            sigmaker,
+            "_CANCEL_POLL_STRIDE",
+            1,
+        ), sigmaker.UIServices.use(
+            sigmaker.UIServices(cancel_requested=cancel_requested)
+        ):
+            matches = sigmaker.SignatureSearcher.find_all("48 4? ?F 90", buf=buf)
+
+        self.assertEqual(matches, [sigmaker.Match(0x1000)])
+        self.assertEqual(cancel_requested.call_count, 2)
+
+    def test_nibble_fallback_cancellation_can_raise(self):
+        buf = self._buffer(b"\x48\x4A\x1F\x90")
+
+        with sigmaker.UIServices.use(
+            sigmaker.UIServices(cancel_requested=lambda: True)
+        ):
+            with self.assertRaises(sigmaker.UserCanceledError):
+                sigmaker.SignatureSearcher.find_all(
+                    "48 4? ?F 90",
+                    buf=buf,
+                    raise_on_cancel=True,
+                )
+
+    def test_nibble_fallback_headless_default_does_not_poll_ida_ui(self):
+        buf = self._buffer(b"\x48\x4A\x1F\x90" * 3)
+
+        with patch.object(
+            sigmaker,
+            "_CANCEL_POLL_STRIDE",
+            1,
+        ), patch.object(
+            sigmaker,
+            "idaapi_user_canceled",
+            side_effect=AssertionError("headless search polled IDA UI"),
+        ):
+            matches = sigmaker.SignatureSearcher.find_all(
+                "48 4? ?F 90",
+                buf=buf,
+            )
+
+        self.assertEqual(
+            matches,
+            [
+                sigmaker.Match(0x1000),
+                sigmaker.Match(0x1004),
+                sigmaker.Match(0x1008),
+            ],
+        )
+
+    def test_nibble_fallback_loads_the_requested_scope(self):
+        buf = self._buffer(b"\x48\x4A\x1F\x90", segments=[(0, 0x2000, 4)])
+
+        with patch.object(
+            sigmaker.InMemoryBuffer,
+            "load",
+            return_value=buf,
+        ) as load, patch.object(
+            sigmaker,
+            "idaapi_user_canceled",
+            return_value=False,
+        ):
+            matches = sigmaker.SignatureSearcher.find_all(
+                "48 4? ?F 90",
+                scope=(0x2000, 0x2010),
+            )
+
+        load.assert_called_once_with(
+            mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
+            scope_ea=0x2000,
+        )
+        self.assertEqual(matches, [sigmaker.Match(0x2000)])
+
+    def test_nibble_fallback_intersects_supplied_buffer_with_scope(self):
+        buf = self._buffer(
+            b"\x90\x90\x90\x90\x48\x4A\x1F\x90",
+            segments=[(0, 0x1000, 4), (4, 0x2000, 4)],
+        )
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "48 4? ?F 90",
+            buf=buf,
+            scope=(0x1000, 0x1004),
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_nibble_fallback_maps_noncontiguous_segments(self):
+        buf = self._buffer(
+            b"\x90\x90\x90\x90\x48\x4A\x1F\x90",
+            segments=[(0, 0x1000, 4), (4, 0x2000, 4)],
+        )
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "48 4? ?F 90",
+            buf=buf,
+        )
+
+        self.assertEqual(matches, [sigmaker.Match(0x2000)])
+
+    def test_nibble_fallback_does_not_match_across_segment_boundaries(self):
+        buf = self._buffer(
+            b"\x48\x4A\x1F\x90",
+            segments=[(0, 0x1000, 2), (2, 0x2000, 2)],
+        )
+
+        matches = sigmaker.SignatureSearcher.find_all(
+            "48 4? ?F 90",
+            buf=buf,
+        )
+
+        self.assertEqual(matches, [])
+
+    def test_nibble_fallback_requires_an_exact_byte(self):
+        buf = self._buffer(b"\x4A\x1F")
+
+        with self.assertRaisesRegex(ValueError, "at least one exact byte"):
+            sigmaker.SignatureSearcher.find_all("4? ?F", buf=buf)
+
+    def test_nibble_fallback_matches_bruteforce_oracle(self):
+        rng = random.Random(0x59)
+        for case in range(100):
+            data = rng.randbytes(128)
+            cells: list[tuple[str, int, int]] = []
+            for _ in range(rng.randrange(2, 9)):
+                value = rng.randrange(256)
+                kind = rng.randrange(4)
+                if kind == 0:
+                    cells.append((f"{value:02X}", value, 0xFF))
+                elif kind == 1:
+                    cells.append((f"?{value & 0xF:X}", value, 0x0F))
+                elif kind == 2:
+                    cells.append((f"{value >> 4:X}?", value, 0xF0))
+                else:
+                    cells.append(("??", 0, 0))
+            cells[0] = (f"{data[0]:02X}", data[0], 0xFF)
+            cells[1] = (f"?{data[1] & 0xF:X}", data[1], 0x0F)
+
+            size = len(cells)
+            expected = [
+                sigmaker.Match(0x1000 + start)
+                for start in range(len(data) - size + 1)
+                if all(
+                    (data[start + index] & mask) == (value & mask)
+                    for index, (_token, value, mask) in enumerate(cells)
+                )
+            ]
+            actual = sigmaker.SignatureSearcher.find_all(
+                " ".join(token for token, _value, _mask in cells),
+                buf=self._buffer(data),
+            )
+            self.assertEqual(actual, expected, f"random case {case}")
 
 
 class TestSigMakerConfigDefaults(CoveredUnitTest):
@@ -4555,7 +4992,6 @@ class TestSignatureSearcherBufferCache(CoveredUnitTest):
     """The SignatureSearcher scan API accepts an optional cached buffer."""
 
     def setUp(self):
-        sigmaker.idaapi_user_canceled = MagicMock(return_value=False)
         sigmaker.idaapi.BADADDR = 0xFFFFFFFFFFFFFFFF
         sigmaker.idaapi.inf_get_min_ea = MagicMock(return_value=0x1000)
 


### PR DESCRIPTION
## Summary

- add a pure-Python nibble wildcard fallback when SIMD speedups are unavailable
- use the longest exact-byte run as a `bytearray.find()` anchor, then verify the remaining masks in Python
- reuse one loaded segment buffer for batch patterns that need in-memory scanning
- preserve scope, non-contiguous segment mapping, cancellation, and `skip_more_than_one`
- select context-local `UIServices` from `idaapi.is_idaq()`: graphical IDA retains automatic wait-box progress and cancellation, while idalib and stripped hosts default to headless services
- cache the stable IDA host and cancellation callables once instead of repeating module lookups
- document GUI, idalib, forced-headless, and custom-cancellation embedding workflows
- document the exact-byte requirement and common-anchor performance caveat

Closes #59

## Validation

- exact CI discovery command: 361 passed, 4 skipped
- real-idalib integration suite includes a headless-service assertion
- performance suite: 5 passed
- randomized 100-pattern brute-force differential coverage and real-binary SIMD parity are included in those suites

## Performance

The SIMD kernel and cancellation polling stride are unchanged. Each scan resolves the context-local cancellation predicate once before entering its hot loop, so there is no per-match context lookup. The focused SIMD benchmark remains three orders of magnitude faster than the Python reference.

Local no-SIMD measurements:

- rare exact anchor over 16 MiB: about 3-5 ms
- common `00` anchor over 1 MiB with no matches: about 180-220 ms

The common-anchor case is intentionally documented as slower without SIMD.