### PR TITLE
fix: reject signature matches across address gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable user-visible changes to this plugin are documented here. The format 
 - **Batch search now honors segment scope and cancellation.** A scoped batch uses the same containing-segment policy as ordinary search. Canceling an IDA or SIMD batch scan raises `UserCanceledError` instead of returning partial hits as a successful result; existing direct `find_all()` callers retain their partial-result behavior.
 - **Embedded search no longer depends on IDA's GUI event loop.** `SignatureSearcher` and batch search automatically retain IDA wait-box progress and cancellation when `idaapi.is_idaq()` reports the graphical host, while idalib and hosts without that API use headless services. The interactive plugin installs IDA services explicitly while handling an action, and embedders can inject their own context-local services with `UIServices.use(...)`.
 - **Native search rejects non-advancing backend results.** If IDA or a test double returns the same or an earlier address repeatedly, search now raises instead of appending matches without bound.
+- **SIMD search no longer matches across address gaps.** Direct and batch search, ordinary uniqueness checks, and shortest-function signature generation reject synthetic matches across non-contiguous IDA segments. Adjacent segments remain one searchable range when their buffer offsets and IDA addresses are both contiguous.
 
 ### Documentation
 

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -581,18 +581,41 @@ class InMemoryBuffer:
         self,
         scope: typing.Optional[tuple[int, int]] = None,
     ) -> typing.Iterator[tuple[int, int]]:
-        """Yield contiguous buffer ranges, optionally clipped to an EA scope."""
+        """Yield ranges contiguous in both buffer offsets and IDA addresses."""
         segments = self._segments or (
             (0, self.imagebase, len(self._buffer)),
         )
+        pending_start: typing.Optional[int] = None
+        pending_end = 0
+        pending_ea_end = 0
         for offset, segment_ea, size in segments:
-            if scope is None:
-                yield offset, offset + size
+            start_ea = segment_ea
+            end_ea = segment_ea + size
+            if scope is not None:
+                start_ea = max(start_ea, scope[0])
+                end_ea = min(end_ea, scope[1])
+                if start_ea >= end_ea:
+                    continue
+
+            start = offset + start_ea - segment_ea
+            end = offset + end_ea - segment_ea
+            if (
+                pending_start is not None
+                and pending_end == start
+                and pending_ea_end == start_ea
+            ):
+                pending_end = end
+                pending_ea_end = end_ea
                 continue
-            start_ea = max(segment_ea, scope[0])
-            end_ea = min(segment_ea + size, scope[1])
-            if start_ea < end_ea:
-                yield offset + start_ea - segment_ea, offset + end_ea - segment_ea
+
+            if pending_start is not None:
+                yield pending_start, pending_end
+            pending_start = start
+            pending_end = end
+            pending_ea_end = end_ea
+
+        if pending_start is not None:
+            yield pending_start, pending_end
 
     def _load_single_segment(self, ea: int):
         """Load only the segment containing ``ea`` (issue #64), recording it in
@@ -1699,8 +1722,12 @@ class UniqueSignatureGenerator:
         # then refine that set in memory as the pattern grows instead of
         # re-scanning per appended instruction. offsets is None until the
         # first scan; buf holds the segment buffer the offsets index into.
-        offsets: typing.Optional[list[int]] = None
+        offsets: typing.Optional["array.array"] = None
+        offset_count = 0
         buf: typing.Optional["InMemoryBuffer"] = None
+        search_ranges: typing.Optional[
+            tuple["array.array", "array.array"]
+        ] = None
         if cfg.scope_to_segment:
             # Issue #64: scope uniqueness to the anchor's segment. Pre-load it so
             # the seed scan and every refinement stay within the segment.
@@ -1774,19 +1801,31 @@ class UniqueSignatureGenerator:
                 elif offsets is None:
                     # Seed once: scan the whole database, keep every match
                     # offset. The candidate count is the exact match count.
-                    offsets, buf = SignatureSearcher.find_all_offsets(
+                    found_offsets, buf = SignatureSearcher.find_all_offsets(
                         f"{sig:ida}", buf=buf
                     )
-                    count = len(offsets)
+                    offsets = array.array("Q", found_offsets)
+                    offset_count = len(offsets)
+                    count = offset_count
+                    if search_ranges is None:
+                        search_ranges = _buffer_search_range_arrays(
+                            buf, len(buf.data())
+                        )
                 else:
                     # Refine the surviving candidates in memory for each byte
                     # appended this iteration; no rescan of the database.
                     data_mv = buf.data()
-                    for j in range(prev_len, len(sig)):
-                        sb = sig[j]
-                        mask = 0x00 if sb.is_wildcard else 0xFF
-                        offsets = _refine_offsets(data_mv, offsets, j, sb.value, mask)
-                    count = len(offsets)
+                    if search_ranges is None:
+                        raise RuntimeError("search ranges are unavailable")
+                    offset_count = _refine_candidate_offsets(
+                        data_mv,
+                        offsets,
+                        offset_count,
+                        sig,
+                        prev_len,
+                        search_ranges,
+                    )
+                    count = offset_count
                 # find_all_offsets polls idaapi_user_canceled inside its scan
                 # loop and bails when set, returning whatever partial offsets
                 # it had so far (often 0). When the call was interrupted, keep
@@ -1797,31 +1836,18 @@ class UniqueSignatureGenerator:
                 if not idaapi_user_canceled():
                     progress.last_match_count = count
                     if count == 1:
-                        sig.trim_signature()
-                        return GeneratedSignature(sig, Match(ea))
+                        result_signature = _validated_trimmed_signature(
+                            sig,
+                            buf,
+                            search_ranges=search_ranges,
+                        )
+                        if result_signature is None:
+                            continue
+                        return GeneratedSignature(result_signature, Match(ea))
 
         if cancel.partial is not None:
             return cancel.partial
         raise Unexpected("Signature not unique (reached end of analysis)")
-
-
-def _refine_offsets(
-    data_mv: memoryview,
-    offsets: list[int],
-    j: int,
-    value: int,
-    mask: int,
-) -> list[int]:
-    """Keep offsets c where (data_mv[c + j] & mask) == (value & mask).
-
-    j is the pattern-relative index of the byte being checked; c is a match
-    start offset into data_mv. Candidates whose c + j runs past the buffer
-    cannot match and are dropped. Used to refine a shrinking candidate set
-    as a signature grows, instead of re-scanning the whole database.
-    """
-    n = len(data_mv)
-    target = value & mask
-    return [c for c in offsets if c + j < n and (data_mv[c + j] & mask) == target]
 
 
 def _refine_offsets_into(
@@ -1832,10 +1858,11 @@ def _refine_offsets_into(
     value: int,
     mask: int,
 ) -> int:
-    """Refine the first ``count`` entries of the uint32 array ``cands`` in
-    place (Cython when available), returning the new count. The function-sig
+    """Refine the first ``count`` unsigned candidates in place.
+
+    Uses Cython when available and returns the new count. The function-sig
     path only reaches this on the SIMD path; the Python branch is a defensive
-    fallback that mirrors _refine_offsets.
+    fallback with identical in-place semantics.
     """
     if SIMD_SPEEDUP_AVAILABLE:
         return simd_scan.refine_offsets(data_mv, cands, count, j, value, mask)
@@ -1848,6 +1875,96 @@ def _refine_offsets_into(
             cands[w] = cands[r]
             w += 1
     return w
+
+
+def _buffer_search_range_arrays(
+    buf: "InMemoryBuffer",
+    buffer_size: int,
+) -> tuple["array.array", "array.array"]:
+    """Materialize the buffer's contiguous search ranges for hot loops."""
+    ranges = (
+        tuple(buf._search_ranges())
+        if isinstance(buf, InMemoryBuffer)
+        else ((0, buffer_size),)
+    )
+    return (
+        array.array("Q", (start for start, _end in ranges)),
+        array.array("Q", (end for _start, end in ranges)),
+    )
+
+
+def _filter_offsets_into_search_ranges(
+    cands: "array.array",
+    count: int,
+    pattern_size: int,
+    range_starts: typing.Sequence[int],
+    range_ends: typing.Sequence[int],
+) -> int:
+    """Compact sorted candidates whose full pattern fits one search range."""
+    if SIMD_SPEEDUP_AVAILABLE:
+        return simd_scan.filter_offsets_by_search_ranges(
+            cands,
+            count,
+            pattern_size,
+            range_starts,
+            range_ends,
+        )
+
+    if count < 0 or count > len(cands):
+        raise ValueError("count is outside the candidate array")
+    if pattern_size <= 0:
+        raise ValueError("pattern_size must be positive")
+    if not range_starts or len(range_starts) != len(range_ends):
+        raise ValueError("search ranges must be non-empty pairs")
+    previous_end: typing.Optional[int] = None
+    for start, end in zip(range_starts, range_ends):
+        if start > end or (previous_end is not None and start < previous_end):
+            raise ValueError("search ranges must be ordered and non-overlapping")
+        previous_end = end
+
+    range_index = 0
+    write_index = 0
+    for read_index in range(count):
+        start = cands[read_index]
+        while range_index < len(range_ends) and start >= range_ends[range_index]:
+            range_index += 1
+        if range_index == len(range_ends):
+            break
+        if (
+            start >= range_starts[range_index]
+            and start + pattern_size <= range_ends[range_index]
+        ):
+            cands[write_index] = start
+            write_index += 1
+    return write_index
+
+
+def _refine_candidate_offsets(
+    data_mv: memoryview,
+    candidates: "array.array",
+    count: int,
+    signature: Signature,
+    start_index: int,
+    search_ranges: tuple[typing.Sequence[int], typing.Sequence[int]],
+) -> int:
+    """Refine and range-compact one persistent candidate array."""
+    for index in range(start_index, len(signature)):
+        signature_byte = signature[index]
+        mask = 0x00 if signature_byte.is_wildcard else 0xFF
+        count = _refine_offsets_into(
+            data_mv,
+            candidates,
+            count,
+            index,
+            signature_byte.value,
+            mask,
+        )
+    return _filter_offsets_into_search_ranges(
+        candidates,
+        count,
+        len(signature),
+        *search_ranges,
+    )
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -1923,6 +2040,9 @@ def _seed_via_index(
     sig: "Signature",
     index: typing.Optional["_ByteIndex"],
     buf: "InMemoryBuffer",
+    search_ranges: typing.Optional[
+        tuple[typing.Sequence[int], typing.Sequence[int]]
+    ] = None,
 ) -> typing.Optional[tuple["array.array", int]]:
     """Seed the candidate set from the byte index instead of scanning.
 
@@ -1975,7 +2095,50 @@ def _seed_via_index(
         if sb.is_wildcard:
             continue
         count = _refine_offsets_into(data_mv, cands, count, j, sb.value, 0xFF)
+    if search_ranges is None:
+        search_ranges = _buffer_search_range_arrays(buf, n)
+    count = _filter_offsets_into_search_ranges(
+        cands,
+        count,
+        m,
+        *search_ranges,
+    )
     return cands, count
+
+
+def _validated_trimmed_signature(
+    signature: Signature,
+    buf: typing.Optional["InMemoryBuffer"],
+    *,
+    index: typing.Optional["_ByteIndex"] = None,
+    search_ranges: typing.Optional[
+        tuple[typing.Sequence[int], typing.Sequence[int]]
+    ] = None,
+) -> typing.Optional[Signature]:
+    """Return a unique trimmed form, reusing unchanged signatures."""
+    trim_at = len(signature)
+    while trim_at > 0 and signature[trim_at - 1].is_wildcard:
+        trim_at -= 1
+    if trim_at == len(signature):
+        return signature
+    if trim_at == 0:
+        return None
+
+    trimmed = Signature(signature)
+    del trimmed[trim_at:]
+    if index is not None and buf is not None:
+        seeded = _seed_via_index(
+            trimmed,
+            index,
+            buf,
+            search_ranges=search_ranges,
+        )
+        if seeded is not None:
+            _offsets, count = seeded
+            return trimmed if count == 1 else None
+    if SignatureSearcher.is_unique(f"{trimmed:ida}", buf=buf):
+        return trimmed
+    return None
 
 
 def _decode_function_for_anchors(
@@ -2085,6 +2248,9 @@ class MinimalFunctionSignatureGenerator:
         # 84% of generate() wall time when called per-is_unique.
         buf: typing.Optional["InMemoryBuffer"] = None
         index: typing.Optional["_ByteIndex"] = None
+        search_ranges: typing.Optional[
+            tuple["array.array", "array.array"]
+        ] = None
         if SIMD_SPEEDUP_AVAILABLE:
             with ProgressDialog("Please stand by, copying segments..."):
                 buf = InMemoryBuffer.load(
@@ -2093,7 +2259,9 @@ class MinimalFunctionSignatureGenerator:
                 )
             # Build the 2-byte position index once for the whole search so each
             # anchor seeds with an O(1) lookup instead of a full-buffer scan.
-            index = _ByteIndex.build(buf.data())
+            data_mv = buf.data()
+            index = _ByteIndex.build(data_mv)
+            search_ranges = _buffer_search_range_arrays(buf, len(data_mv))
 
         # Iterate the pre-decoded anchors inside a ProgressBox so the wait
         # box shows live progress (issue #27). enumerate() keeps the index
@@ -2127,7 +2295,10 @@ class MinimalFunctionSignatureGenerator:
 
             sig = self._grow_unique_from_decoded(
                 decoded, anchor_idx, progress.best_size, cfg,
-                buf=buf, progress=progress, index=index,
+                buf=buf,
+                progress=progress,
+                index=index,
+                search_ranges=search_ranges,
             )
             if sig is None:
                 continue
@@ -2157,6 +2328,9 @@ class MinimalFunctionSignatureGenerator:
         buf: typing.Optional["InMemoryBuffer"] = None,
         progress: typing.Optional["_FunctionSigProgress"] = None,
         index: typing.Optional["_ByteIndex"] = None,
+        search_ranges: typing.Optional[
+            tuple[typing.Sequence[int], typing.Sequence[int]]
+        ] = None,
     ) -> typing.Optional[Signature]:
         """Grow a signature from ``decoded[anchor_idx]`` forward until unique.
 
@@ -2173,11 +2347,15 @@ class MinimalFunctionSignatureGenerator:
         fields for the live wait-box display.
         """
         sig = Signature()
-        # SIMD seed-then-refine state: candidates as a uint32 array.array plus a
-        # live count, refined in place by the Cython refine_offsets.
+        # SIMD seed-then-refine state: an unsigned candidate array plus a live
+        # count, refined in place by the Cython refine_offsets.
         offsets: typing.Optional["array.array"] = None
         ocount = 0
         seed_buf = buf
+        if search_ranges is None and seed_buf is not None:
+            search_ranges = _buffer_search_range_arrays(
+                seed_buf, len(seed_buf.data())
+            )
         min_useful = self.MIN_USEFUL_SIG_BYTES
         for i in range(anchor_idx, len(decoded)):
             if (
@@ -2209,8 +2387,14 @@ class MinimalFunctionSignatureGenerator:
                     progress.inner_length = len(sig)
                     progress.inner_matches = None
                 if SignatureSearcher.is_unique(f"{sig:ida}", buf=buf):
-                    sig.trim_signature()
-                    return sig
+                    result_signature = _validated_trimmed_signature(
+                        sig,
+                        seed_buf,
+                        index=index,
+                        search_ranges=search_ranges,
+                    )
+                    if result_signature is not None:
+                        return result_signature
                 continue
 
             if not SIMD_SPEEDUP_AVAILABLE or seed_buf is None:
@@ -2219,7 +2403,12 @@ class MinimalFunctionSignatureGenerator:
                 count = SignatureSearcher.count_matches(f"{sig:ida}", buf=buf)
             elif offsets is None:
                 # Seed once. Prefer the byte index (Dynamic Seed Selection).
-                seeded = _seed_via_index(sig, index, seed_buf)
+                seeded = _seed_via_index(
+                    sig,
+                    index,
+                    seed_buf,
+                    search_ranges=search_ranges,
+                )
                 if seeded is not None:
                     offsets, ocount = seeded
                     count = ocount
@@ -2246,20 +2435,30 @@ class MinimalFunctionSignatureGenerator:
                 # Refine the surviving candidates in place for each byte
                 # appended this iteration; no rescan of the database.
                 data_mv = seed_buf.data()
-                for j in range(prev_len, len(sig)):
-                    sb = sig[j]
-                    mask = 0x00 if sb.is_wildcard else 0xFF
-                    ocount = _refine_offsets_into(
-                        data_mv, offsets, ocount, j, sb.value, mask
-                    )
+                if search_ranges is None:
+                    raise RuntimeError("search ranges are unavailable")
+                ocount = _refine_candidate_offsets(
+                    data_mv,
+                    offsets,
+                    ocount,
+                    sig,
+                    prev_len,
+                    search_ranges,
+                )
                 count = ocount
 
             if progress is not None:
                 progress.inner_length = len(sig)
                 progress.inner_matches = count
             if count == 1:
-                sig.trim_signature()
-                return sig
+                result_signature = _validated_trimmed_signature(
+                    sig,
+                    seed_buf,
+                    index=index,
+                    search_ranges=search_ranges,
+                )
+                if result_signature is not None:
+                    return result_signature
 
         return None
 
@@ -3430,9 +3629,8 @@ class SignatureSearcher:
         )
 
         sig = _SimdSignature(simd_signature)
-        results: list[Match] = []
         base = idaapi.inf_get_min_ea()
-        if (k := sig.size_bytes) == 0:
+        if sig.size_bytes == 0:
             return [
                 Match(
                     base,
@@ -3440,41 +3638,79 @@ class SignatureSearcher:
                 )
             ]
 
-        n = len(data_mv)
-        off = 0
-        # Matches arrive in ascending offset order, so map each offset to its
-        # real address with a forward cursor (amortized O(1) per match); see
-        # InMemoryBuffer.offset_mapper.
-        to_addr = buf.offset_mapper()
-        # Poll cancellation every _CANCEL_POLL_STRIDE matches (see
-        # find_all_offsets) so per-match user_cancelled() overhead does not
-        # dominate a scan over a short, common pattern.
+        return typing.cast(
+            list[Match],
+            SignatureSearcher._scan_simd_ranges(
+                sig,
+                buf,
+                offsets_only=False,
+                imagebase=imagebase,
+                skip_more_than_one=skip_more_than_one,
+                raise_on_cancel=raise_on_cancel,
+            ),
+        )
+
+    @staticmethod
+    def _scan_simd_ranges(
+        sig: "_SimdSignature",
+        buf: "InMemoryBuffer",
+        *,
+        offsets_only: bool,
+        imagebase: typing.Optional[int] = None,
+        skip_more_than_one: bool = False,
+        raise_on_cancel: bool = False,
+    ) -> typing.Union[list[Match], list[int]]:
+        """Scan contiguous ranges into either offsets or address matches."""
+        data_mv = buf.data()
+        ranges = (
+            buf._search_ranges()
+            if isinstance(buf, InMemoryBuffer)
+            else ((0, len(data_mv)),)
+        )
+        offsets: list[int] = []
+        matches: list[Match] = []
+        to_addr = None if offsets_only else buf.offset_mapper()
+        pattern_size = sig.size_bytes
+        scan_bytes = _simd_scan_bytes
+        append_offset = offsets.append
+        append_match = matches.append
         since_poll = 0
         cancel_requested = UIServices.current().cancel_requested
-        while off <= n - k:
-            since_poll += 1
-            if since_poll >= _CANCEL_POLL_STRIDE:
-                since_poll = 0
-                if cancel_requested():
-                    LOGGER.info("Search canceled by user")
-                    if raise_on_cancel:
-                        raise UserCanceledError("Search canceled by user")
-                    break
+        for range_start, range_end in ranges:
+            off = range_start
+            while off <= range_end - pattern_size:
+                since_poll += 1
+                if since_poll >= _CANCEL_POLL_STRIDE:
+                    since_poll = 0
+                    if cancel_requested():
+                        if not offsets_only:
+                            LOGGER.info("Search canceled by user")
+                        if raise_on_cancel:
+                            raise UserCanceledError("Search canceled by user")
+                        return offsets if offsets_only else matches
 
-            idx = _simd_scan_bytes(data_mv[off:], sig)
-            if idx < 0:
-                break
-            address = to_addr(off + idx)
-            results.append(
-                Match(
-                    address,
-                    rva=None if imagebase is None else address - imagebase,
-                )
-            )
-            if skip_more_than_one and len(results) > 1:
-                break
-            off += idx + 1
-        return results
+                idx = scan_bytes(data_mv[off:range_end], sig)
+                if idx < 0:
+                    break
+                off += idx
+                if offsets_only:
+                    append_offset(off)
+                else:
+                    address = to_addr(off)
+                    append_match(
+                        Match(
+                            address,
+                            rva=(
+                                None
+                                if imagebase is None
+                                else address - imagebase
+                            ),
+                        )
+                    )
+                    if skip_more_than_one and len(matches) > 1:
+                        return matches
+                off += 1
+        return offsets if offsets_only else matches
 
     @staticmethod
     def find_all_offsets(
@@ -3489,31 +3725,19 @@ class SignatureSearcher:
         simd_signature, _ = SigText.normalize(ida_signature)
         if buf is None:
             buf = _load_search_buffer()
-        data_mv = buf.data()
         sig = _SimdSignature(simd_signature)
         offsets: list[int] = []
         k = sig.size_bytes
         if k == 0:
             return [0], buf
-        n = len(data_mv)
-        off = 0
-        # Poll cancellation every _CANCEL_POLL_STRIDE matches rather than on
-        # every match: idaapi.user_cancelled() costs ~0.5us per call and a
-        # short, common seed can produce millions of matches, so per-match
-        # polling alone can dominate the scan (observed: 44s of a 76s seed).
-        since_poll = 0
-        cancel_requested = UIServices.current().cancel_requested
-        while off <= n - k:
-            since_poll += 1
-            if since_poll >= _CANCEL_POLL_STRIDE:
-                since_poll = 0
-                if cancel_requested():
-                    break
-            idx = _simd_scan_bytes(data_mv[off:], sig)
-            if idx < 0:
-                break
-            offsets.append(off + idx)
-            off += idx + 1
+        offsets = typing.cast(
+            list[int],
+            SignatureSearcher._scan_simd_ranges(
+                sig,
+                buf,
+                offsets_only=True,
+            ),
+        )
         return offsets, buf
 
     @staticmethod

--- a/src/sigmaker/_speedups/simd_scan.pyx
+++ b/src/sigmaker/_speedups/simd_scan.pyx
@@ -9,6 +9,12 @@ import array as py_stdlib_arr_mod        # run-time: the Python array module (co
 
 from sigmaker._speedups.simd_scan cimport Signature, SimdLevel, simd_support_best_level
 
+
+ctypedef fused candidate_offset_t:
+    unsigned int
+    unsigned long long
+
+
 cdef extern from "simd_support.hpp":
     unsigned _tzcnt32_inline(unsigned x) noexcept nogil
     unsigned _scan32_anchors_inline(const unsigned char* base,
@@ -762,7 +768,7 @@ def build_byte_index(const unsigned char[:] data_view):
 
 
 def refine_offsets(const unsigned char[:] data_view,
-                   unsigned int[:] cands,
+                   candidate_offset_t[:] cands,
                    Py_ssize_t count,
                    Py_ssize_t j,
                    unsigned int value,
@@ -775,15 +781,62 @@ def refine_offsets(const unsigned char[:] data_view,
     cdef unsigned int target = value & mask
     cdef Py_ssize_t r = 0
     cdef Py_ssize_t w = 0
-    cdef Py_ssize_t c
+    cdef unsigned long long c
+    cdef unsigned long long data_size = <unsigned long long>n
+    cdef unsigned long long relative_offset
+    if j < 0:
+        raise ValueError("relative offset must be non-negative")
+    relative_offset = <unsigned long long>j
     with nogil:
         while r < count:
-            c = <Py_ssize_t>cands[r]
-            if c + j < n and (data_view[c + j] & mask) == target:
+            c = <unsigned long long>cands[r]
+            if (c < data_size and relative_offset < data_size - c and
+                    (data_view[<Py_ssize_t>(c + relative_offset)] & mask) == target):
                 cands[w] = cands[r]
                 w += 1
             r += 1
     return w
+
+
+def filter_offsets_by_search_ranges(candidate_offset_t[:] cands,
+                                    Py_ssize_t count,
+                                    Py_ssize_t pattern_size,
+                                    const unsigned long long[:] range_starts,
+                                    const unsigned long long[:] range_ends):
+    """Compact sorted candidates whose full pattern fits one search range."""
+    cdef Py_ssize_t range_count = range_starts.shape[0]
+    cdef Py_ssize_t i
+    if count < 0 or count > cands.shape[0]:
+        raise ValueError("count is outside the candidate array")
+    if pattern_size <= 0:
+        raise ValueError("pattern_size must be positive")
+    if range_count == 0 or range_count != range_ends.shape[0]:
+        raise ValueError("search ranges must be non-empty pairs")
+    for i in range(range_count):
+        if range_starts[i] > range_ends[i]:
+            raise ValueError("search ranges must be ordered and non-overlapping")
+        if i > 0 and range_starts[i] < range_ends[i - 1]:
+            raise ValueError("search ranges must be ordered and non-overlapping")
+
+    cdef Py_ssize_t read_index = 0
+    cdef Py_ssize_t write_index = 0
+    cdef Py_ssize_t range_index = 0
+    cdef unsigned long long start
+    cdef unsigned long long end
+    with nogil:
+        while read_index < count:
+            start = <unsigned long long>cands[read_index]
+            while range_index < range_count and start >= range_ends[range_index]:
+                range_index += 1
+            if range_index == range_count:
+                break
+            end = range_ends[range_index]
+            if (start >= range_starts[range_index] and
+                    <unsigned long long>pattern_size <= end - start):
+                cands[write_index] = cands[read_index]
+                write_index += 1
+            read_index += 1
+    return write_index
 
 
 def seed_offsets(const unsigned int[:] bucket,

--- a/tests/perf/segment_span_filter.py
+++ b/tests/perf/segment_span_filter.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+"""Report segment-safe scan and candidate-filter overhead.
+
+This benchmark has no wall-clock assertions. It fails only when the compared
+implementations produce different results. Build the extension before running:
+
+    pip install -e .
+    PYTHONPATH=src python tests/perf/segment_span_filter.py
+"""
+
+import array
+import pathlib
+import statistics
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "src"))
+
+with patch.dict("sys.modules", {"idaapi": MagicMock(), "idc": MagicMock()}):
+    import sigmaker
+
+
+SEGMENT_SIZE = 4096
+SEGMENT_COUNT = 1024
+PATTERN_SIZE = 16
+
+
+def _interleaved_medians(left, right, iterations=7):
+    left()
+    right()
+    left_elapsed = []
+    right_elapsed = []
+    left_result = None
+    right_result = None
+    for iteration in range(iterations):
+        functions = ((left, left_elapsed), (right, right_elapsed))
+        if iteration % 2:
+            functions = reversed(functions)
+        for function, elapsed_samples in functions:
+            start = time.perf_counter()
+            result = function()
+            elapsed_samples.append(time.perf_counter() - start)
+            if function is left:
+                left_result = result
+            else:
+                right_result = result
+    return (
+        statistics.median(left_elapsed),
+        left_result,
+        statistics.median(right_elapsed),
+        right_result,
+    )
+
+
+def _python_filter(candidates, pattern_size, range_starts, range_ends):
+    range_index = 0
+    survivors = []
+    for start in candidates:
+        while (
+            range_index < len(range_ends)
+            and start >= range_ends[range_index]
+        ):
+            range_index += 1
+        if range_index == len(range_ends):
+            break
+        if (
+            start >= range_starts[range_index]
+            and start + pattern_size <= range_ends[range_index]
+        ):
+            survivors.append(start)
+    return survivors
+
+
+def _benchmark_direct_single_range():
+    payload = bytearray((b"\x90" + b"\x00" * 15) * (1 << 18))
+    data = memoryview(payload)
+    signature = sigmaker._SimdSignature("90")
+    size = len(data)
+
+    def original_loop():
+        offsets = []
+        offset = 0
+        since_poll = 0
+        cancel_requested = sigmaker.UIServices.current().cancel_requested
+        while offset < size:
+            since_poll += 1
+            if since_poll >= sigmaker._CANCEL_POLL_STRIDE:
+                since_poll = 0
+                if cancel_requested():
+                    break
+            index = sigmaker._simd_scan_bytes(data[offset:], signature)
+            if index < 0:
+                break
+            offsets.append(offset + index)
+            offset += index + 1
+        return offsets
+
+    buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+    buf._buffer = payload
+    buf._segments.append((0, 0x1000, size))
+
+    def range_loop():
+        return sigmaker.SignatureSearcher._scan_simd_ranges(
+            signature,
+            buf,
+            offsets_only=True,
+        )
+
+    (
+        original_elapsed,
+        original_offsets,
+        range_elapsed,
+        range_offsets,
+    ) = _interleaved_medians(original_loop, range_loop)
+    if range_offsets != original_offsets:
+        raise AssertionError("Range iteration changed the direct match count")
+
+    delta = range_elapsed / original_elapsed - 1
+    print("\ndirect single-range scan:")
+    print(f"hits:       {len(original_offsets):,}")
+    print(f"original:   {original_elapsed * 1000:.3f} ms")
+    print(f"range:      {range_elapsed * 1000:.3f} ms")
+    print(f"delta:      {delta:+.1%}")
+
+
+def _benchmark_candidate_refinement(
+    candidate_list,
+    total_size,
+    range_starts,
+    range_ends,
+):
+    data = memoryview(bytearray(b"\x90" * total_size))
+    signature = sigmaker.Signature(
+        [
+            sigmaker.SignatureByte(0x90, False),
+            sigmaker.SignatureByte(0x90, False),
+        ]
+    )
+    search_ranges = (range_starts, range_ends)
+
+    def temporary_copy_path():
+        refined = [
+            candidate
+            for candidate in candidate_list
+            if candidate + 1 < len(data) and data[candidate + 1] == 0x90
+        ]
+        candidates = array.array("Q", refined)
+        count = sigmaker._filter_offsets_into_search_ranges(
+            candidates,
+            len(candidates),
+            len(signature),
+            *search_ranges,
+        )
+        return candidates, count
+
+    def persistent_array_path():
+        candidates = array.array("Q", candidate_list)
+        count = sigmaker._refine_candidate_offsets(
+            data,
+            candidates,
+            len(candidates),
+            signature,
+            1,
+            search_ranges,
+        )
+        return candidates, count
+
+    (
+        temporary_elapsed,
+        temporary_result,
+        persistent_elapsed,
+        persistent_result,
+    ) = _interleaved_medians(
+        temporary_copy_path,
+        persistent_array_path,
+    )
+    temporary_candidates, temporary_count = temporary_result
+    persistent_candidates, persistent_count = persistent_result
+    if (
+        list(temporary_candidates[:temporary_count])
+        != list(persistent_candidates[:persistent_count])
+    ):
+        raise AssertionError("Candidate refinement paths disagree")
+
+    print("\ncandidate refinement and range compaction:")
+    print(f"candidates: {len(candidate_list):,}")
+    print(f"temporary:  {temporary_elapsed * 1000:.3f} ms")
+    print(f"persistent: {persistent_elapsed * 1000:.3f} ms")
+    print(f"speedup:    {temporary_elapsed / persistent_elapsed:.2f}x")
+
+
+def main():
+    if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+        raise RuntimeError("SIMD extension is not built; run: pip install -e .")
+
+    total_size = SEGMENT_SIZE * SEGMENT_COUNT
+    candidate_list = list(range(0, total_size, 4))
+    range_starts = array.array(
+        "Q", range(0, total_size, SEGMENT_SIZE)
+    )
+    range_ends = array.array(
+        "Q", range(SEGMENT_SIZE, total_size + 1, SEGMENT_SIZE)
+    )
+
+    def python_filter():
+        return _python_filter(
+            candidate_list,
+            PATTERN_SIZE,
+            range_starts,
+            range_ends,
+        )
+
+    def converted_cython_filter():
+        candidates = array.array("I", candidate_list)
+        count = sigmaker.simd_scan.filter_offsets_by_search_ranges(
+            candidates,
+            len(candidates),
+            PATTERN_SIZE,
+            range_starts,
+            range_ends,
+        )
+        return candidates, count
+
+    (
+        python_elapsed,
+        expected,
+        converted_elapsed,
+        converted_result,
+    ) = _interleaved_medians(python_filter, converted_cython_filter)
+    converted_candidates, converted_count = converted_result
+
+    inplace_samples = []
+    for _ in range(7):
+        candidates = array.array("I", candidate_list)
+        start = time.perf_counter()
+        sigmaker.simd_scan.filter_offsets_by_search_ranges(
+            candidates,
+            len(candidates),
+            PATTERN_SIZE,
+            range_starts,
+            range_ends,
+        )
+        inplace_samples.append(time.perf_counter() - start)
+    inplace_elapsed = statistics.median(inplace_samples)
+
+    if list(converted_candidates[:converted_count]) != expected:
+        raise AssertionError("Python and Cython range filters disagree")
+
+    converted_ratio = python_elapsed / converted_elapsed
+    inplace_ratio = python_elapsed / inplace_elapsed
+    print(f"candidates: {len(candidate_list):,}")
+    print(f"survivors:  {converted_count:,}")
+    print(
+        "array bytes: "
+        f"{len(candidates) * candidates.itemsize:,} candidates + "
+        f"{(len(range_starts) + len(range_ends)) * range_starts.itemsize:,} ranges"
+    )
+    print(f"python:     {python_elapsed * 1000:.3f} ms")
+    print(f"converted:  {converted_elapsed * 1000:.3f} ms")
+    print(f"in-place:   {inplace_elapsed * 1000:.3f} ms")
+    print(f"ratios:     {converted_ratio:.2f}x / {inplace_ratio:.2f}x")
+    _benchmark_candidate_refinement(
+        candidate_list,
+        total_size,
+        range_starts,
+        range_ends,
+    )
+    _benchmark_direct_single_range()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -1920,6 +1920,24 @@ class TestBatchSignatureSearcher(CoveredUnitTest):
         self.assertEqual(results[0].search_pattern, "48 8B ? 90 90")
         self.assertEqual(results[0].normalized_signature, "48 8B ?? 90 90")
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_search_rejects_match_across_address_gap(self):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        buf._buffer.extend(b"\xAA\xDD\xF1\xBB")
+        buf._segments.extend(
+            [(0, 0x1000, 2), (2, 0x2000, 2)]
+        )
+
+        with patch.object(
+            sigmaker.idaapi, "get_imagebase", return_value=0x1000
+        ):
+            results = sigmaker.BatchSignatureSearcher.from_text(
+                "cross := DD F1"
+            ).search(buf=buf)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].matches, [])
+
     def test_search_rejects_buffer_and_scope_together(self):
         with self.assertRaisesRegex(ValueError, "buf.*scope_ea"):
             sigmaker.BatchSignatureSearcher.from_text("90").search(
@@ -3856,7 +3874,7 @@ class TestNibbleWildcardFallback(CoveredUnitTest):
 
         self.assertEqual(matches, [sigmaker.Match(0x2000)])
 
-    def test_nibble_fallback_does_not_match_across_segment_boundaries(self):
+    def test_nibble_fallback_does_not_match_across_address_gap(self):
         buf = self._buffer(
             b"\x48\x4A\x1F\x90",
             segments=[(0, 0x1000, 2), (2, 0x2000, 2)],
@@ -4303,6 +4321,88 @@ class TestUniqueSignatureGeneratorSeedThenRefine(CoveredUnitTest):
         # Two 0x90 bytes survive to uniqueness (offset 0: 0x90 0x90).
         self.assertEqual(len(result.signature), 2)
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_wildcard_growth_drops_candidate_across_address_gap(self):
+        append_count = 0
+        processor = MagicMock()
+
+        def append_byte(sig, *_args):
+            nonlocal append_count
+            sig.append(
+                sigmaker.SignatureByte(0x90, is_wildcard=append_count == 1)
+            )
+            append_count += 1
+
+        processor.append_instruction_to_sig.side_effect = append_byte
+        generator = sigmaker.UniqueSignatureGenerator(processor)
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(b"\x90\x00\x90\x00\x90\x00")
+        seed_buf._segments.extend(
+            [(0, 0x1000, 3), (3, 0x2000, 3)]
+        )
+
+        with patch.object(
+            sigmaker,
+            "InstructionWalker",
+            return_value=[
+                (0x1000, MagicMock(), 1),
+                (0x1001, MagicMock(), 1),
+                (0x1002, MagicMock(), 1),
+            ],
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            return_value=([0, 2], seed_buf),
+        ):
+            result = generator.generate(
+                0x1000,
+                self._make_cfg(),
+                policy=sigmaker.GenerationPolicy.strict(),
+            )
+
+        self.assertEqual(result.status, sigmaker.GenerationStatus.UNIQUE)
+        self.assertEqual(append_count, 3)
+        self.assertEqual(len(result.signature), 3)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_trailing_wildcard_gap_only_uniqueness_is_rejected(self):
+        append_count = 0
+        processor = MagicMock()
+
+        def append_byte(sig, *_args):
+            nonlocal append_count
+            sig.append(
+                sigmaker.SignatureByte(0x90, is_wildcard=append_count == 1)
+            )
+            append_count += 1
+
+        processor.append_instruction_to_sig.side_effect = append_byte
+        generator = sigmaker.UniqueSignatureGenerator(processor)
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(b"\x90\x00\x90")
+        seed_buf._segments.extend(
+            [(0, 0x1000, 2), (2, 0x2000, 1)]
+        )
+
+        with patch.object(
+            sigmaker,
+            "InstructionWalker",
+            return_value=[
+                (0x1000, MagicMock(), 1),
+                (0x1001, MagicMock(), 1),
+            ],
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            return_value=([0, 2], seed_buf),
+        ):
+            with self.assertRaises(sigmaker.Unexpected):
+                generator.generate(
+                    0x1000,
+                    self._make_cfg(),
+                    policy=sigmaker.GenerationPolicy.strict(),
+                )
+
 
 class TestGeneratedSignatureDisplay(CoveredUnitTest):
     """display() branches on status and respects the no-clipboard rule for partials."""
@@ -4535,8 +4635,22 @@ class TestSignatureSearcherCountMatches(CoveredUnitTest):
         self.assertFalse(kwargs.get("skip_more_than_one", False))
 
 
-class TestRefineOffsets(CoveredUnitTest):
-    """In-memory candidate refinement: keep offsets whose byte at c+j matches."""
+def _refine_offsets_with_python_fallback(data, offsets, index, value, mask):
+    candidates = array.array("Q", offsets)
+    with patch.object(sigmaker, "SIMD_SPEEDUP_AVAILABLE", False):
+        count = sigmaker._refine_offsets_into(
+            data,
+            candidates,
+            len(candidates),
+            index,
+            value,
+            mask,
+        )
+    return list(candidates[:count])
+
+
+class TestRefineOffsetsInto(CoveredUnitTest):
+    """Python fallback keeps matching offsets and compacts them in place."""
 
     def _mv(self, b: bytes):
         return memoryview(bytearray(b))
@@ -4544,29 +4658,42 @@ class TestRefineOffsets(CoveredUnitTest):
     def test_exact_byte_keeps_matching(self):
         data = self._mv(b"\x90\x48\x90\x48\x90")
         # offsets 0..4; appended byte index j=1 must equal 0x48 (mask 0xFF)
-        out = sigmaker._refine_offsets(data, [0, 1, 2, 3], 1, 0x48, 0xFF)
+        out = _refine_offsets_with_python_fallback(
+            data, [0, 1, 2, 3], 1, 0x48, 0xFF
+        )
         # c=0 -> data[1]=0x48 keep; c=1 -> data[2]=0x90 drop; c=2 -> data[3]=0x48 keep; c=3 -> data[4]=0x90 drop
         self.assertEqual(out, [0, 2])
 
     def test_full_wildcard_keeps_all(self):
         data = self._mv(b"\x01\x02\x03\x04")
-        out = sigmaker._refine_offsets(data, [0, 1, 2], 1, 0x00, 0x00)
+        out = _refine_offsets_with_python_fallback(
+            data, [0, 1, 2], 1, 0x00, 0x00
+        )
         self.assertEqual(out, [0, 1, 2])
 
     def test_nibble_mask(self):
         data = self._mv(b"\x4A\x4B\x9C")
         # mask 0xF0 keeps where high nibble == 0x40
-        out = sigmaker._refine_offsets(data, [0, 1, 2], 0, 0x40, 0xF0)
+        out = _refine_offsets_with_python_fallback(
+            data, [0, 1, 2], 0, 0x40, 0xF0
+        )
         self.assertEqual(out, [0, 1])
 
     def test_out_of_bounds_dropped(self):
         data = self._mv(b"\x90\x90")
         # c=1, j=2 -> c+j=3 is past the buffer; must be dropped, not raise
-        out = sigmaker._refine_offsets(data, [0, 1], 2, 0x90, 0xFF)
+        out = _refine_offsets_with_python_fallback(
+            data, [0, 1], 2, 0x90, 0xFF
+        )
         self.assertEqual(out, [])
 
     def test_empty_input(self):
-        self.assertEqual(sigmaker._refine_offsets(self._mv(b"\x90"), [], 0, 0x90, 0xFF), [])
+        self.assertEqual(
+            _refine_offsets_with_python_fallback(
+                self._mv(b"\x90"), [], 0, 0x90, 0xFF
+            ),
+            [],
+        )
 
 
 class TestFindAllOffsets(CoveredUnitTest):
@@ -4633,7 +4760,9 @@ class TestRefinementEquivalence(CoveredUnitTest):
             if offsets is None:
                 offsets = self._full_matches(data, pattern)  # seed at length 1
             else:
-                offsets = sigmaker._refine_offsets(mv, offsets, j, v, msk)
+                offsets = _refine_offsets_with_python_fallback(
+                    mv, offsets, j, v, msk
+                )
             expected = self._full_matches(data, pattern)
             self.assertEqual(
                 sorted(offsets), sorted(expected),
@@ -5037,6 +5166,107 @@ class TestMinimalFunctionSignatureGeneratorSeedThenRefine(CoveredUnitTest):
             f"seed must be deferred to >= {min_useful} bytes; got {seed_sig_byte_lens}",
         )
         self.assertEqual(len(result.signature), 5)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_wildcard_growth_drops_candidate_across_address_gap(self):
+        pattern = b"\x10\x20\x30\x40\x50"
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(
+            pattern + b"\x00\x60" + pattern + b"\x00\x60"
+        )
+        seed_buf._segments.extend(
+            [(0, 0x1000, 7), (7, 0x2000, 5), (12, 0x3000, 2)]
+        )
+        index = sigmaker._ByteIndex.build(seed_buf.data())
+        decoded = [
+            sigmaker._DecodedInstruction(
+                ea=0x1000,
+                size=5,
+                raw_bytes=pattern,
+                operand_offb=0,
+                operand_length=0,
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1005,
+                size=1,
+                raw_bytes=b"\x00",
+                operand_offb=0,
+                operand_length=1,
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1006,
+                size=1,
+                raw_bytes=b"\x60",
+                operand_offb=0,
+                operand_length=0,
+            ),
+        ]
+        generator = sigmaker.MinimalFunctionSignatureGenerator(
+            sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        )
+
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            signature = generator._grow_unique_from_decoded(
+                decoded,
+                0,
+                50,
+                self._make_cfg(),
+                buf=seed_buf,
+                index=index,
+            )
+
+        self.assertIsNotNone(signature)
+        self.assertEqual(len(signature), 7)
+        self.assertTrue(signature[5].is_wildcard)
+        self.assertFalse(signature[6].is_wildcard)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_short_trimmed_nonunique_pattern_keeps_growing(self):
+        seed_buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        seed_buf._buffer.extend(b"\x10\x20\x30\x40\x50\x60")
+        seed_buf._segments.append((0, 0x1000, 6))
+        decoded = [
+            sigmaker._DecodedInstruction(
+                ea=0x1000,
+                size=4,
+                raw_bytes=b"\x10\x20\x30\x40",
+                operand_offb=3,
+                operand_length=1,
+            ),
+            sigmaker._DecodedInstruction(
+                ea=0x1004,
+                size=2,
+                raw_bytes=b"\x50\x60",
+                operand_offb=0,
+                operand_length=0,
+            ),
+        ]
+        generator = sigmaker.MinimalFunctionSignatureGenerator(
+            sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
+        )
+
+        with patch.object(
+            sigmaker.SignatureSearcher,
+            "is_unique",
+            side_effect=[True, False],
+        ), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            return_value=([0], seed_buf),
+        ):
+            signature = generator._grow_unique_from_decoded(
+                decoded,
+                0,
+                50,
+                self._make_cfg(),
+                buf=seed_buf,
+                index=None,
+            )
+
+        self.assertIsNotNone(signature)
+        self.assertEqual(len(signature), 6)
 
 
 class TestSignatureSearcherBufferCache(CoveredUnitTest):
@@ -5624,6 +5854,17 @@ class TestSeedViaIndex(CoveredUnitTest):
             sig.append(sigmaker.SignatureByte(v, w))
         return sig
 
+    def _segmented_buffer(self, *payloads):
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        offset = 0
+        for segment_index, payload in enumerate(payloads):
+            buf._segments.append(
+                (offset, 0x1000 + segment_index * 0x1000, len(payload))
+            )
+            buf._buffer.extend(payload)
+            offset += len(payload)
+        return buf
+
     def test_index_seed_matches_buffer(self):
         buf = MagicMock()
         buf.data.return_value = memoryview(
@@ -5749,6 +5990,22 @@ class TestSeedViaIndex(CoveredUnitTest):
         sig = self._sig([(0x90, False), (0x91, False)])
         self.assertIsNone(sigmaker._seed_via_index(sig, None, buf))
 
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_rejects_seed_that_exists_only_across_address_gap(self):
+        buf = self._segmented_buffer(b"\x00\xAA", b"\xBB\x00")
+        index = sigmaker._ByteIndex.build(buf.data())
+        sig = self._sig([(0xAA, False), (0xBB, False)])
+        candidates, count = sigmaker._seed_via_index(sig, index, buf)
+        self.assertEqual(list(candidates[:count]), [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_keeps_valid_seeds_around_gap_candidate(self):
+        buf = self._segmented_buffer(b"\xAA\xBB\xAA", b"\xBB\xAA\xBB")
+        index = sigmaker._ByteIndex.build(buf.data())
+        sig = self._sig([(0xAA, False), (0xBB, False)])
+        candidates, count = sigmaker._seed_via_index(sig, index, buf)
+        self.assertEqual(list(candidates[:count]), [0, 4])
+
 
 class TestSelectSeedRun(CoveredUnitTest):
     """Dynamic Seed Selection across 1-byte and 2-byte runs."""
@@ -5813,6 +6070,60 @@ class TestSelectSeedRun(CoveredUnitTest):
     def test_returns_none_when_no_exact_byte(self):
         sig = self._sig([(0, True), (0, True)])
         self.assertIsNone(sigmaker._select_seed_run(sig, self._index({})))
+
+
+class TestValidatedTrimmedSignature(CoveredUnitTest):
+    @staticmethod
+    def _signature(*wildcards):
+        return sigmaker.Signature(
+            [sigmaker.SignatureByte(0x90, False)]
+            + [sigmaker.SignatureByte(0, wildcard) for wildcard in wildcards]
+        )
+
+    def test_reuses_signature_when_no_trimming_is_needed(self):
+        signature = self._signature(False)
+        with patch.object(sigmaker.SignatureSearcher, "is_unique") as is_unique:
+            result = sigmaker._validated_trimmed_signature(signature, None)
+        self.assertIs(result, signature)
+        is_unique.assert_not_called()
+
+    def test_returns_trimmed_copy_after_uniqueness_validation(self):
+        signature = self._signature(True, True)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=True
+        ) as is_unique:
+            result = sigmaker._validated_trimmed_signature(signature, None)
+        self.assertIsNot(result, signature)
+        self.assertEqual(len(signature), 3)
+        self.assertEqual(result, signature[:1])
+        is_unique.assert_called_once()
+
+    def test_rejects_nonunique_trimmed_copy(self):
+        signature = self._signature(True)
+        with patch.object(
+            sigmaker.SignatureSearcher, "is_unique", return_value=False
+        ):
+            result = sigmaker._validated_trimmed_signature(signature, None)
+        self.assertIsNone(result)
+
+    def test_uses_index_when_validating_trimmed_copy(self):
+        signature = self._signature(True)
+        buf = MagicMock()
+        index = MagicMock()
+        seeded = (array.array("I", [0]), 1)
+        with patch.object(
+            sigmaker, "_seed_via_index", return_value=seeded
+        ) as seed_via_index, patch.object(
+            sigmaker.SignatureSearcher, "is_unique"
+        ) as is_unique:
+            result = sigmaker._validated_trimmed_signature(
+                signature,
+                buf,
+                index=index,
+            )
+        self.assertEqual(result, signature[:1])
+        seed_via_index.assert_called_once()
+        is_unique.assert_not_called()
 
 
 class TestByteIndexOneByte(CoveredUnitTest):
@@ -6003,10 +6314,171 @@ class TestRefineOffsetsCython(CoveredUnitTest):
             j = rng.randrange(8)
             value = rng.randrange(256)
             mask = rng.choice([0x00, 0x0F, 0xF0, 0xFF])
-            py = sigmaker._refine_offsets(mv, list(cand_list), j, value, mask)
+            target = value & mask
+            py = [
+                candidate
+                for candidate in cand_list
+                if candidate + j < len(mv)
+                and (mv[candidate + j] & mask) == target
+            ]
             arr = array.array("I", cand_list)
             n = sigmaker.simd_scan.refine_offsets(mv, arr, len(cand_list), j, value, mask)
             self.assertEqual(sorted(arr[:n]), sorted(py))
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_supports_uint64_candidate_array(self):
+        data = memoryview(bytearray(b"\x90\x48\x90\x48\x90"))
+        candidates = array.array("Q", [0, 1, 2, 3])
+        count = sigmaker.simd_scan.refine_offsets(
+            data, candidates, 4, 1, 0x48, 0xFF
+        )
+        self.assertEqual(count, 2)
+        self.assertEqual(list(candidates[:count]), [0, 2])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_uint64_candidate_past_py_ssize_is_dropped(self):
+        data = memoryview(bytearray(b"\x90"))
+        candidates = array.array("Q", [(1 << 64) - 1])
+        count = sigmaker.simd_scan.refine_offsets(
+            data, candidates, 1, 0, 0x90, 0xFF
+        )
+        self.assertEqual(count, 0)
+
+
+class TestSearchRangeCandidateFilter(CoveredUnitTest):
+    def _filter(self, candidates, pattern_size, starts, ends):
+        cands = array.array("I", candidates)
+        count = sigmaker._filter_offsets_into_search_ranges(
+            cands,
+            len(cands),
+            pattern_size,
+            array.array("Q", starts),
+            array.array("Q", ends),
+        )
+        return list(cands[:count])
+
+    def test_compacts_multiple_ranges_without_reordering(self):
+        self.assertEqual(
+            self._filter([0, 2, 3, 4, 6, 7], 2, [0, 4], [4, 8]),
+            [0, 2, 4, 6],
+        )
+
+    def test_rejects_candidate_before_clipped_range_start(self):
+        self.assertEqual(
+            self._filter([0, 2, 4, 6], 2, [2, 6], [4, 8]),
+            [2, 6],
+        )
+
+    def test_shared_refinement_removes_cross_range_candidate_in_place(self):
+        data = memoryview(bytearray(b"\x90\x00\x90\x00"))
+        candidates = array.array("Q", [1, 2])
+        signature = sigmaker.Signature(
+            [
+                sigmaker.SignatureByte(0x90, False),
+                sigmaker.SignatureByte(0, True),
+            ]
+        )
+        count = sigmaker._refine_candidate_offsets(
+            data,
+            candidates,
+            len(candidates),
+            signature,
+            1,
+            (array.array("Q", [0, 2]), array.array("Q", [2, 4])),
+        )
+        self.assertEqual(count, 1)
+        self.assertEqual(list(candidates[:count]), [2])
+
+    def test_keeps_candidate_ending_exactly_at_range_end(self):
+        self.assertEqual(self._filter([2], 2, [0], [4]), [2])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_supports_offsets_past_four_gibibytes(self):
+        start = 0x1_0000_0000
+        candidates = array.array("Q", [start])
+        count = sigmaker._filter_offsets_into_search_ranges(
+            candidates,
+            1,
+            2,
+            array.array("Q", [start]),
+            array.array("Q", [start + 2]),
+        )
+        self.assertEqual(count, 1)
+        self.assertEqual(candidates[0], start)
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_rejects_candidate_whose_end_would_overflow_uint64(self):
+        maximum = (1 << 64) - 1
+        candidates = array.array("Q", [maximum - 1])
+        count = sigmaker._filter_offsets_into_search_ranges(
+            candidates,
+            1,
+            2,
+            array.array("Q", [maximum - 1]),
+            array.array("Q", [maximum]),
+        )
+        self.assertEqual(count, 0)
+
+    def test_python_fallback_matches_expected_ranges(self):
+        with patch.object(sigmaker, "SIMD_SPEEDUP_AVAILABLE", False):
+            self.assertEqual(
+                self._filter([0, 2, 3, 4, 6, 7], 2, [0, 4], [4, 8]),
+                [0, 2, 4, 6],
+            )
+
+    def test_rejects_invalid_arguments(self):
+        cands = array.array("I", [0])
+        starts = array.array("Q", [0])
+        ends = array.array("Q", [4])
+        invalid = (
+            (2, 1, starts, ends),
+            (1, 0, starts, ends),
+            (1, 1, array.array("Q"), array.array("Q")),
+            (1, 1, array.array("Q", [0, 4]), ends),
+            (
+                1,
+                1,
+                array.array("Q", [0, 3]),
+                array.array("Q", [4, 8]),
+            ),
+        )
+        for count, pattern_size, range_starts, range_ends in invalid:
+            with self.subTest(
+                count=count,
+                pattern_size=pattern_size,
+                starts=list(range_starts),
+                ends=list(range_ends),
+            ):
+                with self.assertRaises(ValueError):
+                    sigmaker._filter_offsets_into_search_ranges(
+                        cands,
+                        count,
+                        pattern_size,
+                        range_starts,
+                        range_ends,
+                    )
+
+    def test_randomized_python_and_cython_results_match(self):
+        if not sigmaker.SIMD_SPEEDUP_AVAILABLE:
+            self.skipTest("SIMD speedup not available")
+        rng = random.Random(8675309)
+        for _ in range(200):
+            lengths = [rng.randint(1, 128) for _ in range(rng.randint(1, 12))]
+            ends = list(itertools.accumulate(lengths))
+            starts = [0, *ends[:-1]]
+            total = ends[-1]
+            candidates = sorted(
+                rng.sample(range(total), rng.randint(0, min(total, 200)))
+            )
+            pattern_size = rng.randint(1, 24)
+            with patch.object(sigmaker, "SIMD_SPEEDUP_AVAILABLE", False):
+                expected = self._filter(
+                    candidates, pattern_size, starts, ends
+                )
+            self.assertEqual(
+                self._filter(candidates, pattern_size, starts, ends),
+                expected,
+            )
 
 
 class TestBuildByteIndex(CoveredUnitTest):
@@ -6418,6 +6890,18 @@ class TestSearchAddressMapping(unittest.TestCase):
             mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS
         )
 
+    @staticmethod
+    def _adjacent_segment_buffer():
+        buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
+        buf._buffer.extend(b"\xAA\xBB\xCC\xDD")
+        buf._segments.extend(
+            (
+                (0, 0x1000, 2),
+                (2, 0x1002, 2),
+            )
+        )
+        return buf
+
     def test_load_segments_rejects_non_advancing_iterator(self):
         seg = MagicMock(start_ea=0x1000, end_ea=0x1004)
         sigmaker.idaapi.get_first_seg = MagicMock(return_value=seg)
@@ -6447,11 +6931,52 @@ class TestSearchAddressMapping(unittest.TestCase):
         buf = sigmaker.InMemoryBuffer(file_path=pathlib.Path("/x"))
         self.assertEqual(buf.offset_mapper()(0x40), 0x1000 + 0x40)
 
+    def test_search_ranges_merge_address_contiguous_segments(self):
+        buf = self._adjacent_segment_buffer()
+        self.assertEqual(list(buf._search_ranges()), [(0, 4)])
+
+    def test_scoped_search_ranges_merge_address_contiguous_segments(self):
+        buf = self._adjacent_segment_buffer()
+        self.assertEqual(
+            list(buf._search_ranges((0x1001, 0x1003))),
+            [(1, 3)],
+        )
+
     @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
     def test_find_all_simd_reports_real_address_in_second_segment(self):
         buf = self._two_segment_buffer()
         matches = sigmaker.SignatureSearcher._find_all_simd("F1 B5 04 00", buf=buf)
         self.assertEqual([int(m.address) for m in matches], [0x1F78000])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_accepts_match_across_contiguous_segments(self):
+        buf = self._adjacent_segment_buffer()
+        matches = sigmaker.SignatureSearcher._find_all_simd("BB CC", buf=buf)
+        self.assertEqual([int(match.address) for match in matches], [0x1001])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_simd_rejects_match_across_address_gap(self):
+        buf = self._two_segment_buffer()
+        matches = sigmaker.SignatureSearcher._find_all_simd("DD F1", buf=buf)
+        self.assertEqual(matches, [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_offsets_rejects_match_across_address_gap(self):
+        buf = self._two_segment_buffer()
+        offsets, returned = sigmaker.SignatureSearcher.find_all_offsets(
+            "DD F1", buf=buf
+        )
+        self.assertIs(returned, buf)
+        self.assertEqual(offsets, [])
+
+    @unittest.skipUnless(sigmaker.SIMD_SPEEDUP_AVAILABLE, "SIMD not built")
+    def test_find_all_offsets_accepts_match_across_contiguous_segments(self):
+        buf = self._adjacent_segment_buffer()
+        offsets, returned = sigmaker.SignatureSearcher.find_all_offsets(
+            "BB CC", buf=buf
+        )
+        self.assertIs(returned, buf)
+        self.assertEqual(offsets, [1])
 
 
 class TestSegmentScope(unittest.TestCase):


### PR DESCRIPTION
## Why

SigMaker concatenates loaded IDA segments into one buffer for fast SIMD search and indexed signature generation. Consecutive bytes in that buffer are not always consecutive addresses in the IDB, so a pattern must not match across an address gap. A segment boundary by itself is not a gap: adjacent segments remain searchable as one continuous byte range.

## What changed

- coalesce neighboring segment ranges only when their buffer offsets and IDA addresses are both contiguous
- scan each resulting contiguous range independently in direct and batch SIMD search
- apply the same full-pattern containment rule to offset enumeration, ordinary uniqueness refinement, and shortest-function generation
- keep one persistent candidate array and share one refinement/range-compaction path across both signature generators
- support 32-bit and 64-bit candidate arrays in the Cython refiner, including overflow-safe bounds checks
- share trailing-wildcard validation across both generators and reuse the original `Signature` when no trimming is needed
- retain existing cancellation, address mapping, scope, and early-exit behavior

No feature flag is added: accepting a match depends on address continuity, while the existing `scope_to_segment` / `scope_ea` controls still decide whether the search corpus is one segment or the whole database. No public method signature or result format changes.

## Performance

The benchmark uses 1,048,576 candidates and a 262,144-hit single-range direct scan. Across the latest three bounded x86-emulated runs:

- the persistent candidate-refinement path was `13.60x`, `13.82x`, and `13.04x` faster than the former list-plus-temporary-array path
- direct range scanning measured `-6.6%`, `+5.4%`, and `-1.3%` versus the previous loop, within the existing emulation variance
- in-place range filtering was `187x` to `225x` faster than the Python reference

The benchmark is non-gating and checks result equivalence rather than asserting wall-clock thresholds.

## Verification

- `idapro-tests-9.2`: 390 tests passed in 8.254s, 4 platform skips
- `idapro-tests`: 390 tests passed in 5.542s, 4 platform skips
- both full runs rebuilt the Cython extension and used a 180-second deadline plus a 2 GiB RSS guard
- 71 affected batch, nibble, address-mapping, scope, indexed-seeding, and generator tests passed under a 90-second deadline plus the same RSS guard
- regression coverage accepts direct and offset matches across adjacent segments while rejecting the same matches across address gaps
- randomized Python/Cython equivalence covers range filtering and 32-bit/64-bit candidate refinement
- `python3 -m compileall -q src tests`
- `git diff --check`

Supersedes #72.