### PR TITLE
chore: release v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-visible changes to this plugin are documented here. The format 
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-07-16
+
 ### Added
 
 - **Batch signature search API** supports several named or unnamed signatures at once, using one `foo = "48 8B ?? ??"`, `foo := 48 8B ?? ??`, or plain signature per non-empty line. The batch parser does not infer C declarations or join entries across multiple lines. Each pattern is normalized and searched independently; invalid patterns are reported per entry instead of aborting the whole batch.
@@ -29,7 +31,8 @@ All notable user-visible changes to this plugin are documented here. The format 
 
 - README now documents the batch search workflow, accepted input forms, export formats, batch search API, and custom formatter registration. A C-style formatter example lives in `examples/batch_search_c_formatter.py`.
 
-[Unreleased]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/mahmoudimus/ida-sigmaker/compare/v1.11.0...v1.12.0
 
 ## [1.11.0] - 2026-07-05
 

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -11,6 +11,6 @@
         "logoPath": "assets/sigmaker-logo.png",
         "idaVersions": ">=9.0",
         "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.11.0"
+        "version": "1.12.0"
     }
 }

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -29,7 +29,7 @@ import idaapi
 import idc
 
 __author__ = "mahmoudimus"
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 PLUGIN_NAME: str = "Signature Maker (py)"
 PLUGIN_VERSION: str = __version__


### PR DESCRIPTION
## Release v1.12.0

Bundles the work merged since v1.11.0:

- **#57 batch signature search:** strict multi-pattern parsing, shared search buffers, structured results, text/CSV/JSON output, and guarded extensible formatters.
- **#73 headless and no-SIMD search:** context-local UI services for embedders, nibble-wildcard fallback without the optional SIMD extension, and non-advancing iterator/search guards.
- **#74 address-gap correctness:** searches all configured segments while rejecting synthetic matches across unmapped gaps; adjacent IDA segments remain searchable as one contiguous range.

## Release metadata

- Bump `sigmaker.__version__` to `1.12.0`.
- Synchronize `ida-plugin.json` to `1.12.0`.
- Promote the existing Unreleased changelog to `1.12.0` dated 2026-07-16.

## Verification

- Both IDA matrices passed 390 tests on #74 before merge, under 2 GiB RSS and 180-second deadline guards.
- Release metadata, changelog links, manifest synchronization, Python compilation, and `git diff --check` pass locally.
- This PR must pass the normal GitHub test matrix before merge and tagging.

## After merge

Tag the release merge commit as `v1.12.0`. The tag triggers `release.yml`, which publishes the standalone `sigmaker.py` release asset; publishing the GitHub release triggers the package deployment workflow.