### PR TITLE
build: publish Python 3.14 wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,10 +39,10 @@ jobs:
             - uses: actions/checkout@v5
 
             - name: Build wheels
-              uses: pypa/cibuildwheel@v3.1.4
+              uses: pypa/cibuildwheel@v3.4.1
               env:
                   # Build CPython 3.10+ wheels only (as required by project)
-                  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+                  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
                   # if no annotation for this build group, this shouldn't be skipped
                   # CIBW_SKIP: "pp*"
               with:

--- a/docs/superpowers/plans/2026-07-16-python-314-wheels.md
+++ b/docs/superpowers/plans/2026-07-16-python-314-wheels.md
@@ -1,0 +1,129 @@
+# Python 3.14 Wheels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish SigMaker's native speedup wheels for CPython 3.14 on every existing release platform.
+
+**Architecture:** Keep the explicit cibuildwheel version selector and extend it through CPython 3.14. Upgrade cibuildwheel to a release that uses final Python 3.14, then guard the workflow and PyPI metadata with an IDA-independent packaging test.
+
+**Tech Stack:** GitHub Actions, cibuildwheel 3.4.1, setuptools project metadata, Python 3.14, unittest.
+
+## Global Constraints
+
+- Do not modify SigMaker runtime or SIMD implementation code.
+- Do not change the IDA test matrix or supported IDA versions.
+- Keep the wheel selector explicit through `cp314-*`.
+- Keep HCLI manifest and release-pipeline restructuring out of this branch.
+
+---
+
+### Task 1: Guard the Python 3.14 packaging contract
+
+**Files:**
+- Create: `tests/unit_test_packaging.py`
+- Modify: `.github/workflows/deploy.yml:42-45`
+- Modify: `pyproject.toml:24-30`
+
+**Interfaces:**
+- Consumes: the `CIBW_BUILD` environment value and `[project].classifiers` metadata.
+- Produces: CPython 3.10 through 3.14 wheel selection using cibuildwheel 3.4.1 and a Python 3.14 PyPI classifier.
+
+- [ ] **Step 1: Write the failing packaging tests**
+
+```python
+import pathlib
+import re
+import tomllib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class TestWheelBuildConfiguration(unittest.TestCase):
+    def test_release_workflow_builds_supported_cpython_wheels(self):
+        workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+        self.assertIn("pypa/cibuildwheel@v3.4.1", workflow)
+        selection = re.search(r'CIBW_BUILD: "([^"]+)"', workflow)
+        self.assertIsNotNone(selection)
+        self.assertEqual(
+            selection.group(1).split(),
+            ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"],
+        )
+
+    def test_project_advertises_python_314(self):
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+        self.assertIn("Programming Language :: Python :: 3.14", project["classifiers"])
+```
+
+- [ ] **Step 2: Run the tests and verify they fail for the missing contract**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: both tests fail because the workflow uses cibuildwheel 3.1.4, omits `cp314-*`, and the classifier is absent.
+
+- [ ] **Step 3: Update the release workflow and package metadata**
+
+Change the action and selector to:
+
+```yaml
+- name: Build wheels
+  uses: pypa/cibuildwheel@v3.4.1
+  env:
+      CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+```
+
+Add this classifier to `[project].classifiers`:
+
+```toml
+"Programming Language :: Python :: 3.14",
+```
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: `Ran 2 tests` and `OK`.
+
+- [ ] **Step 5: Verify cibuildwheel selects CPython 3.10 through 3.14**
+
+Run:
+
+```bash
+CIBW_BUILD="cp310-* cp311-* cp312-* cp313-* cp314-*" \
+  uvx --from cibuildwheel==3.4.1 cibuildwheel \
+  --platform macos --print-build-identifiers
+```
+
+Expected: the selected identifiers include `cp310`, `cp311`, `cp312`, `cp313`, and `cp314` for the current macOS architecture.
+
+- [ ] **Step 6: Build and inspect the native CPython 3.14 wheel**
+
+Run:
+
+```bash
+WHEELHOUSE=$(mktemp -d)
+uv run --python 3.14 --with build python -m build --wheel --outdir "$WHEELHOUSE"
+python3 -m zipfile -l "$WHEELHOUSE"/sigmaker-1.12.0-cp314-*.whl
+```
+
+Expected: the build exits zero, the filename contains `cp314`, and the archive contains `sigmaker/_speedups/simd_scan` with a native extension suffix.
+
+- [ ] **Step 7: Run final static verification**
+
+Run:
+
+```bash
+python3 -m unittest tests.unit_test_packaging -v
+python3 -m compileall -q tests
+git diff --check
+```
+
+Expected: tests report `OK`; compileall and diff checks exit zero.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add .github/workflows/deploy.yml pyproject.toml tests/unit_test_packaging.py
+git commit -m "build: publish Python 3.14 wheels"
+```

--- a/docs/superpowers/specs/2026-07-16-python-314-wheels-design.md
+++ b/docs/superpowers/specs/2026-07-16-python-314-wheels-design.md
@@ -1,0 +1,29 @@
+# Python 3.14 Wheels Design
+
+## Goal
+
+Publish SigMaker's compiled speedup wheel for CPython 3.14 on the same platform
+matrix already used for CPython 3.10 through 3.13.
+
+## Design
+
+- Update the cibuildwheel GitHub Action from 3.1.4 to 3.4.1. Version 3.1.4
+  carried a Python 3.14 release candidate; 3.4.1 uses the final Python 3.14
+  toolchain and supports the existing Linux, Windows, and macOS runners.
+- Add `cp314-*` to the explicit `CIBW_BUILD` selection. Keep the explicit list
+  so new Python versions do not enter the release matrix without review.
+- Add the `Programming Language :: Python :: 3.14` PyPI classifier.
+
+## Verification
+
+- Parse the edited workflow and project metadata.
+- Ask cibuildwheel 3.4.1 to enumerate the selected macOS build identifiers and
+  confirm that CPython 3.10 through 3.14 are present.
+- Build the native wheel with CPython 3.14 locally and inspect its wheel tag.
+- Run the focused packaging checks and repository diff checks.
+
+## Non-Goals
+
+- No changes to SigMaker runtime code or its SIMD implementation.
+- No changes to the IDA test matrix or supported IDA versions.
+- No HCLI manifest or release-pipeline restructuring in this branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Debuggers",
     "Topic :: Software Development :: Disassemblers",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,11 @@ dependencies = []
 
 
 [project.optional-dependencies]
-ci = ["coverage", "cython>=3.1.3"]
+ci = [
+    "coverage",
+    "cython>=3.1.3",
+    "tomli>=2; python_version < '3.11'",
+]
 speedups = ["cython>=3.1.3"]
 
 [project.urls]

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -1,7 +1,11 @@
 import pathlib
 import re
-import tomllib
 import unittest
+
+try:
+    import tomllib
+except ImportError:  # Python 3.10
+    import tomli as tomllib
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -1,0 +1,23 @@
+import pathlib
+import re
+import tomllib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class TestWheelBuildConfiguration(unittest.TestCase):
+    def test_release_workflow_builds_supported_cpython_wheels(self):
+        workflow = (ROOT / ".github" / "workflows" / "deploy.yml").read_text()
+        self.assertIn("pypa/cibuildwheel@v3.4.1", workflow)
+        selection = re.search(r'CIBW_BUILD: "([^"]+)"', workflow)
+        self.assertIsNotNone(selection)
+        self.assertEqual(
+            selection.group(1).split(),
+            ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp314-*"],
+        )
+
+    def test_project_advertises_python_314(self):
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+        self.assertIn("Programming Language :: Python :: 3.14", project["classifiers"])


### PR DESCRIPTION
## Why

SigMaker publishes compiled SIMD wheels through PyPI, but the release matrix stopped at CPython 3.13. HCLI's supported bundle targets now include Python 3.14, so a 3.14 installation would otherwise fall back to a local source build or fail when creating an offline bundle.

This PR adds Python 3.14 wheel coverage without changing SigMaker's runtime behavior or dependency-free default installation.

## What changed

- Upgrade cibuildwheel from 3.1.4, which carried a Python 3.14 release candidate, to 3.4.1.
- Add `cp314-*` to every existing Linux, Windows, and macOS wheel job.
- Advertise Python 3.14 in the package classifiers.
- Add an IDA-independent packaging test that guards the cibuildwheel version, explicit CPython matrix, and classifier.
- Use `tomli` only in the `ci` extra on Python 3.10, where the standard-library `tomllib` module is unavailable.

`[project].dependencies` remains empty. A normal `pip install sigmaker` still has no Python dependencies and receives the compiled SIMD extension from the platform wheel.

## Validation

- Built `sigmaker-1.12.0-cp314-cp314-macosx_11_0_arm64.whl` with final CPython 3.14.0.
- Confirmed the wheel contains `sigmaker/_speedups/simd_scan.cpython-314-darwin.so`.
- Confirmed cibuildwheel 3.4.1 selects `cp310` through `cp314` on macOS ARM.
- Ran the packaging tests under Python 3.10, the host Python, and Python 3.14.
- The first GitHub run completed the existing 390 runtime tests; its only error was the packaging test importing `tomllib` under Python 3.10. The conditional `tomli` backport in this branch addresses that error.

The HCLI manifest and publishing workflow changes will remain a separate follow-up PR.
