### PR TITLE
Publish SigMaker through Hex-Rays HCLI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,5 +17,5 @@ python3 tools/sync_plugin_version.py
 
 if ! git diff --quiet -- ida-plugin.json; then
     git add ida-plugin.json
-    echo "pre-commit: synced ida-plugin.json version and staged it"
+    echo "pre-commit: synced ida-plugin.json package references and staged it"
 fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,6 @@ on:
     release:
         types:
             - published
-    workflow_run:
-        workflows: ["Release"]
-        types:
-            - completed
 
 # make concurrency tag-aware so one run doesn't cancel the other incorrectly
 concurrency:
@@ -61,14 +57,12 @@ jobs:
         steps:
             - uses: actions/checkout@v5
 
-            - &display-version
-              name: Display version
+            - name: Display version
               run: |
                   python --version
                   pip --version
 
-            - &install-build-twine
-              name: Install pypa/build pypa/twine
+            - name: Install pypa/build pypa/twine
               run: |
                   pip install --upgrade pip
                   pip install --upgrade setuptools==77.0.1
@@ -78,19 +72,16 @@ jobs:
                   echo "Installed versions:"
                   pip list | grep -E "(twine|packaging|setuptools|build)"
 
-            - &build-sdist
-              name: Build sdist
+            - name: Build sdist
               run: |
                   rm -rf dist/*
                   python -m build --sdist
 
-            - &display-content-dist-folder
-              name: Display content dist folder
+            - name: Display content dist folder
               run: |
                   ls -shR dist/
 
-            - &run-twine-check
-              name: Run twin check
+            - name: Run twin check
               run: |
                   twine check dist/*
 
@@ -123,9 +114,9 @@ jobs:
 
             - uses: pypa/gh-action-pypi-publish@release/v1
               if: ${{
-                  github.repository_owner == 'mahmoudimus' && (
-                  (github.event_name == 'release' && github.event.action == 'published') ||
-                  (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'))
+                  github.repository_owner == 'mahmoudimus' &&
+                  github.event_name == 'release' &&
+                  github.event.action == 'published'
                   }}
               # See https://docs.pypi.org/trusted-publishers/using-a-publisher/
               with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,27 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    hcli-lint:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout plugin source
+              uses: actions/checkout@v5
+              with:
+                  persist-credentials: false
+
+            - name: Validate HCLI plugin archive
+              run: |
+                  curl -LsSf --retry 3 \
+                    https://github.com/HexRaysSA/ida-hcli/releases/download/v0.18.5/hcli-linux-x86_64-0.18.5 \
+                    -o /tmp/hcli
+                  echo "b35eb351ce9e706709212604f937118643eee861bf4411bc4cac94217245b277  /tmp/hcli" \
+                    | sha256sum --check
+                  chmod 0755 /tmp/hcli
+                  curl -LsSf --retry 3 \
+                    https://raw.githubusercontent.com/HexRaysSA/plugin-repository/3cee9691f72459c5ac75b028c827016e93e58923/plugin-repository.json \
+                    -o /tmp/plugin-repository-v1.json
+                  /tmp/hcli plugin --repo /tmp/plugin-repository-v1.json lint .
+
     unit-tests:
         runs-on: ubuntu-24.04
         strategy:
@@ -98,6 +119,7 @@ jobs:
                     https://api.github.com/users/mahmoudimus/packages/container/idapro-linux/versions | \
                     jq -r ".[]|select(.metadata.container.tags[]==\"${TAG}\")|.name")
                   echo "SHA_NAME: ${SHA_NAME}"
+                  # shellcheck disable=SC2046,SC2086
                   docker save $(docker images --format '{{.Repository}}')@${SHA_NAME} -o /tmp/docker-cache/${{ matrix.service }}.tar || echo "Failed to save image."
                   # Only save the image if it was not restored from cache
                   # The cache will be updated for future runs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,130 +2,87 @@ name: Release
 
 on:
     push:
-        # Sequence of patterns matched against refs/tags
         tags:
-            - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+            - "v*"
     workflow_dispatch:
         inputs:
             tag:
-                description: "Release tag name (e.g. v1.2.3). If empty, will use latest."
-                required: false
-                default: ""
-    workflow_run:
-        workflows: [ida-sigmaker tests] # Reference the test workflow name
-        types:
-            - completed
+                description: "Release tag name (for example, v1.12.0)"
+                required: true
 
-# make concurrency tag-aware so one run doesn't cancel the other incorrectly
 concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ inputs.tag || github.ref || github.run_id }}
     cancel-in-progress: true
 
 permissions:
     contents: write
 
 jobs:
-    debug-vars:
+    release:
         runs-on: ubuntu-latest
         steps:
-            - name: Look at environment variables
-              run: |
-                  echo -e "GITHUB_REF=${{ github.ref }}"
-                  echo -e "GITHUB_HEAD_REF=${{ github.head_ref }}"
-                  echo -e "GITHUB_BASE_REF=${{ github.base_ref }}"
-                  echo -e "GITHUB_ACTOR=${{ github.actor }}"
-                  echo -e "GITHUB_REPOSITORY=${{ github.repository }}"
-                  echo -e "GITHUB_SHA=${{ github.sha }}"
-                  echo -e "GITHUB_EVENT_NAME=${{ github.event_name }}"
-                  echo -e "GITHUB_EVENT_WORKFLOW_RUN_CONCLUSION=${{ github.event.workflow_run.conclusion }}"
-                  echo -e "GITHUB_EVENT_WORKFLOW_RUN_EVENT=${{ github.event.workflow_run.event }}"
-                  echo -e "GITHUB_EVENT_WORKFLOW_RUN_HEAD_BRANCH=${{ github.event.workflow_run.head_branch }}"
-                  echo -e "GITHUB_EVENT_INPUTS_TAG=${{ github.event.inputs.tag }}"
-            - name: Dump GitHub context
+            - name: Resolve release tag
+              id: version
               env:
-                  GITHUB_CONTEXT: ${{ toJson(github) }}
-              run: echo "$GITHUB_CONTEXT"
+                  REQUESTED_TAG: ${{ inputs.tag }}
+              run: |
+                  if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+                    TAG="$REQUESTED_TAG"
+                  else
+                    TAG="${GITHUB_REF#refs/tags/}"
+                  fi
+                  TAG="${TAG#refs/tags/}"
+                  if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].*)?$ ]]; then
+                    echo "Release tag must use vMAJOR.MINOR.PATCH: $TAG" >&2
+                    exit 1
+                  fi
+                  {
+                    echo "ref=refs/tags/$TAG"
+                    echo "tag=$TAG"
+                    echo "version=${TAG#v}"
+                  } >> "$GITHUB_OUTPUT"
 
-    # releases only when a v tag points at the tested commit* (and tests succeeded).
-    release-from-workflow-run:
-        runs-on: ubuntu-latest
-        if: >
-            (
-              github.event_name == 'workflow_run' &&
-              github.event.workflow_run.conclusion == 'success'
-            )
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+            - name: Check for an existing release
+              id: guard
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG: ${{ steps.version.outputs.tag }}
+              run: |
+                  if gh release view "$TAG" >/dev/null 2>&1; then
+                    echo "already=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "already=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Checkout release tag
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              uses: actions/checkout@v5
               with:
-                  ref: ${{ github.event.workflow_run.head_sha }}
+                  ref: ${{ steps.version.outputs.ref }}
                   fetch-tags: true
 
-            - name: Extract version from tag
-              id: version
-              run: |
-                  # get tags pointing at this exact commit
-                  TAGS=$(git tag --points-at HEAD | tr -d '\r')
-                  echo "found tags:"
-                  printf '%s\n' "$TAGS"
-                  # pick the first v* tag (if any)
-                  TAG=$(printf '%s\n' "$TAGS" | grep -E '^v' | head -n1 || true)
-                  if [ -z "$TAG" ]; then
-                      echo "No v* tag points at $GITHUB_SHA; exiting."
-                      echo "should_release=false" >> $GITHUB_OUTPUT
-                      exit 0
-                  fi
-                  echo "ref=refs/tags/$TAG" >> $GITHUB_OUTPUT
-                  echo "tag=$TAG" >> $GITHUB_OUTPUT
-                  echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-                  echo "should_release=true" >> $GITHUB_OUTPUT
+            - name: Create standalone sigmaker.py
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              run: cp src/sigmaker/__init__.py sigmaker.py
 
-            - &skip-if-release-exists
-              name: Skip if release already exists
-              id: guard
-              if: ${{ steps.version.outputs.should_release == 'true' }}
-              run: |
-                  if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-                  echo "already=true" >> $GITHUB_OUTPUT
-                  else
-                  echo "already=false" >> $GITHUB_OUTPUT
-                  fi
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-            - &setup-python
-              name: Set up Python
-              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
-              uses: actions/setup-python@v5
-              with:
-                  python-version: "3.10"
-            - &create-sigmaker-py
-              name: Create sigmaker.py from __init__.py
-              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
-              run: |
-                  cp src/sigmaker/__init__.py sigmaker.py
-            - &read-changelog
-              name: 📖 Read CHANGELOG section for this version
+            - name: Read changelog section
               id: changelog
-              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
-              # Pinned to v2.4.0 (mindsers/changelog-reader-action).
+              if: ${{ steps.guard.outputs.already == 'false' }}
               uses: mindsers/changelog-reader-action@1faaf50aa09d5793d9a100819973df801febfb31
               with:
                   version: ${{ steps.version.outputs.version }}
                   path: ./CHANGELOG.md
-            - &create-release-body
-              name: ✏️ Create release body
-              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
-              # changes_file is a path to the parsed section body, so we cat it
-              # in (never interpolate changelog text into the shell, which would
-              # execute backticks/$() in the markdown).
+
+            - name: Create release body
+              if: ${{ steps.guard.outputs.already == 'false' }}
+              env:
+                  VERSION: ${{ steps.version.outputs.version }}
+                  CHANGES_FILE: ${{ steps.changelog.outputs.changes_file }}
               run: |
-                  VERSION="${{ steps.version.outputs.version }}"
-                  CHANGES_FILE="${{ steps.changelog.outputs.changes_file }}"
                   {
-                    echo "# sigmaker.py - IDA Python Standalone Python Release"
+                    echo "# sigmaker.py - IDAPython standalone release"
                     echo ""
-                    echo "## Release Information"
+                    echo "## Release information"
                     echo "- **Version**: ${VERSION}"
                     echo "- **Source**: https://github.com/mahmoudimus/ida-sigmaker"
                     echo "- **Author**: @mahmoudimus (Mahmoud Abdelkader)"
@@ -138,28 +95,23 @@ jobs:
                       echo "See [CHANGELOG.md](https://github.com/mahmoudimus/ida-sigmaker/blob/main/CHANGELOG.md) for details."
                     fi
                     echo ""
-                    echo "## Description"
-                    echo "This is a standalone release of the IDA Pro signature maker plugin. The file \`sigmaker.py\` contains the complete plugin code that can be directly imported into IDA Pro."
-                    echo ""
                     echo "## Installation"
-                    echo "1. Copy \`sigmaker.py\` to your IDA Pro plugins directory"
-                    echo "2. Restart IDA Pro"
-                    echo "3. Use Ctrl+Alt+S to access the Signature Maker menu"
+                    echo "1. Copy \`sigmaker.py\` to your IDA Pro plugins directory."
+                    echo "2. Restart IDA Pro."
+                    echo "3. Use Ctrl+Alt+S to access the Signature Maker menu."
+                    echo ""
+                    echo "The release source archive is also installable through Hex-Rays HCLI."
                     echo ""
                     echo "## License"
-                    echo "See the main repository for license information."
+                    echo "See the repository for license information."
                   } > release_body.md
 
-                  echo "----- release_body.md -----"
-                  cat release_body.md
-            - &generate-release
-              name: 📦 Generate Release
-              if: ${{ steps.version.outputs.should_release == 'true' && steps.guard.outputs.already == 'false' }}
+            - name: Publish GitHub release
+              if: ${{ steps.guard.outputs.already == 'false' }}
               uses: softprops/action-gh-release@v2
               with:
-                  files: |
-                      sigmaker.py
-                  tag_name: ${{ steps.version.outputs.tag }} # e.g. v1.3.0
+                  files: sigmaker.py
+                  tag_name: ${{ steps.version.outputs.tag }}
                   name: ${{ steps.version.outputs.tag }}
                   body_path: release_body.md
                   draft: false
@@ -167,53 +119,3 @@ jobs:
                   prerelease: ${{ contains(steps.version.outputs.version, '-') }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # releases only when tag push and manual dispatch.
-    release-from-other:
-        runs-on: ubuntu-latest
-        if: >
-            (             
-               github.event_name == 'push' &&
-               startsWith(github.ref, 'refs/tags/v')
-            ) || (
-               github.event_name == 'workflow_dispatch'
-            )
-        steps:
-            - name: Extract version from tag
-              id: version
-              run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.tag }}" ]; then
-                    IN='${{ github.event.inputs.tag }}'
-                    if [[ "$IN" == refs/* ]]; then REF="$IN"; else REF="refs/tags/$IN"; fi
-                    TAG="${REF#refs/tags/}"
-                    echo "ref=$REF" >> $GITHUB_OUTPUT
-                    echo "tag=$TAG" >> $GITHUB_OUTPUT
-                    echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-                  else
-                    echo "ref=refs/tags/${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-                    echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-                    echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-                  fi
-                  echo "should_release=true" >> $GITHUB_OUTPUT
-            - *skip-if-release-exists
-            - name: Checkout code
-              if: ${{ steps.guard.outputs.already == 'false' }}
-              uses: actions/checkout@v4
-              with:
-                  ref: ${{ steps.version.outputs.ref }}
-                  fetch-tags: true
-
-              #   if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              #       REF=${{ github.event.inputs.tag_name }}"
-              #       echo "version=${REF#refs/tags/}" >> $GITHUB_OUTPUT
-              #       echo "version_clean=${REF#refs/tags/v}" >> $GITHUB_OUTPUT
-              #   else
-              #       echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-              #       echo "version_clean=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-              #       # echo "::set-output name=tag::$(echo ${{ github.event.workflow_run.ref }} | sed 's|refs/tags/||')"
-              #   fi
-
-            - *setup-python
-            - *create-sigmaker-py
-            - *read-changelog
-            - *create-release-body
-            - *generate-release

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ hcli plugin search sigmaker
 hcli plugin install SigMaker
 ```
 
-`hcli` downloads the plugin and places it in `$IDAUSR/plugins` (`~/.idapro/plugins` on macOS/Linux), where IDA loads it on the next launch. Requires IDA 9.0+. For `SIMD` speedups, also run `pip install sigmaker` as above.
+`hcli` installs the plugin under `$IDAUSR/plugins/SigMaker` and installs the
+matching `sigmaker` wheel into IDA's Python environment. That wheel includes
+the SIMD speedups for supported Python and platform combinations, so an HCLI
+install does not require a separate `pip install`. IDA loads the plugin on its
+next launch. Requires IDA 9.0+.
 
 ### Need to find your plugin directory?
 
@@ -89,12 +93,18 @@ import idaapi, os; print(os.path.join(idaapi.get_user_idadir(), "plugins"))
 The user directory is a location where IDA stores some of the global settings and which can be used for some additional customization.
 Default location:
 
-- On Windows: `%APPDATA%/Hex-Rays/IDA Pro`
-- On Linux and Mac: `$HOME/.idapro`
+- On Windows: `%APPDATA%\Hex-Rays\IDA Pro`
+- On macOS: `~/Library/Application Support/IDA Pro`
+- On Linux: `~/.idapro`
 
 ## SIMD Speedups
 
-If you just followed the installation above and ran `pip install sigmaker`, then based on your system and architecture (i.e. Windows (x64), Linux (x64), Mac (x64), Mac (ARM/Silicon)), the plugin will install the appropriate wheel and will automatically use them if they're available. You do not have to do anything else. The plugin is designed to display the status of whether or not SIMD speedups are installed. They are shown in the top right menu bar of the plugin:
+An HCLI install pulls in the matching `sigmaker` wheel automatically. For a
+manual or standalone `sigmaker.py` install, run `pip install sigmaker` in
+IDA's Python environment. On supported Windows, Linux, and macOS systems, pip
+selects the wheel for the active CPython version and architecture. SigMaker
+uses the extension automatically when it is available and shows its status in
+the top-right menu bar:
 
 ### SIMD Enabled
 
@@ -675,7 +685,11 @@ The version lives in one place, `__version__` in `src/sigmaker/__init__.py`. To 
 git config core.hooksPath .githooks
 ```
 
-The pre-commit hook (`.githooks/pre-commit`) runs `tools/sync_plugin_version.py`, which copies `__version__` into `ida-plugin.json` and stages it, so the manifest the IDA Plugin Repository reads can never drift behind a version bump. CI runs the same check (`TestPluginManifestVersion`) as a backstop for commits that skip the hook.
+The pre-commit hook (`.githooks/pre-commit`) runs
+`tools/sync_plugin_version.py`, which copies `__version__` into both the HCLI
+manifest version and its exact `sigmaker==VERSION` dependency, then stages the
+manifest. CI checks the same contract as a backstop for commits that skip the
+hook.
 
 ## Contact
 

--- a/docs/superpowers/plans/2026-07-16-hcli-publishing.md
+++ b/docs/superpowers/plans/2026-07-16-hcli-publishing.md
@@ -1,0 +1,165 @@
+# HCLI Publishing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish SigMaker through Hex-Rays' HCLI plugin manager using each GitHub release's source archive.
+
+**Architecture:** Keep the root `ida-plugin.json` and existing source-tree entry point, then add the metadata HCLI requires. Treat GitHub release publication as the single deployment boundary: it triggers PyPI builds, while normal `main` test runs cannot start release work.
+
+**Tech Stack:** HCLI 0.18.5, GitHub Actions, JSON, Python `unittest`.
+
+## Global Constraints
+
+- Keep `src/sigmaker/__init__.py` as the plugin entry point.
+- Do not add an entry-point shim or modify SigMaker runtime code.
+- Keep `[project].dependencies` empty.
+- Pin HCLI's `pythonDependencies` entry to the manifest version.
+- Do not bump the version or publish a release in this pull request.
+
+---
+
+### Task 1: Guard the HCLI manifest contract
+
+**Files:**
+- Modify: `tests/unit_test_packaging.py`
+- Modify: `ida-plugin.json`
+
+**Interfaces:**
+- Consumes: `src/sigmaker/__init__.py::__version__` and the root manifest.
+- Produces: HCLI-compatible metadata with a matching `sigmaker==VERSION` dependency.
+
+- [ ] **Step 1: Add failing tests for the required metadata**
+
+Add tests that load `ida-plugin.json` and assert:
+
+```python
+self.assertEqual(manifest["$schema"], HCLI_SCHEMA)
+self.assertEqual(plugin["entryPoint"], "src/sigmaker/__init__.py")
+self.assertTrue((ROOT / plugin["entryPoint"]).is_file())
+self.assertEqual(plugin["urls"]["repository"], REPOSITORY_URL)
+self.assertEqual(plugin["pythonDependencies"], [f"sigmaker=={plugin['version']}"])
+self.assertEqual(project["dependencies"], [])
+```
+
+Also require author metadata, the MIT license, keywords, and explicit IDA 9.0+
+versions accepted by the current HCLI schema.
+
+- [ ] **Step 2: Run the focused test and verify the new assertions fail**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: failures for the missing HCLI schema, repository URL, author,
+dependency, and array-form IDA versions.
+
+- [ ] **Step 3: Update `ida-plugin.json`**
+
+Add the HCLI schema URL and required metadata while retaining:
+
+```json
+"entryPoint": "src/sigmaker/__init__.py"
+```
+
+Set:
+
+```json
+"pythonDependencies": ["sigmaker==1.12.0"]
+```
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: all packaging tests report `OK`.
+
+### Task 2: Make release publication the only automatic deployment boundary
+
+**Files:**
+- Modify: `tests/unit_test_packaging.py`
+- Modify: `.github/workflows/release.yml`
+- Modify: `.github/workflows/deploy.yml`
+
+**Interfaces:**
+- Consumes: tag pushes, manual workflow dispatches, and GitHub `release.published` events.
+- Produces: GitHub releases from tags and PyPI builds only from published releases or manual dispatch.
+
+- [ ] **Step 1: Add failing workflow-boundary tests**
+
+Assert that `release.yml` has no `workflow_run` trigger, `deploy.yml` has no
+`workflow_run` trigger, and the deploy workflow retains `release: types:
+[published]` plus `workflow_dispatch`.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: the workflow-boundary tests fail because both workflows currently
+contain `workflow_run`.
+
+- [ ] **Step 3: Simplify the workflows**
+
+Remove `release-from-workflow-run` and the `workflow_run` trigger from
+`release.yml`. Keep one tag/manual release job. Remove the `workflow_run`
+trigger and condition branch from `deploy.yml`, retaining release publication
+and manual dispatch.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `python3 -m unittest tests.unit_test_packaging -v`
+
+Expected: all packaging tests report `OK`.
+
+### Task 3: Document and validate HCLI installation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.github/workflows/python.yml`
+- Test: `tests/unit_test_packaging.py`
+
+**Interfaces:**
+- Consumes: HCLI 0.18.5 and GitHub-style source archives.
+- Produces: repeatable HCLI linting and accurate installation guidance.
+
+- [ ] **Step 1: Add a CI HCLI lint step**
+
+Download the pinned HCLI 0.18.5 Linux executable in the test workflow, verify
+its SHA-256 digest, mark it executable, and run:
+
+```bash
+/tmp/hcli plugin lint .
+```
+
+- [ ] **Step 2: Update the README**
+
+State that HCLI installs the matching `sigmaker` wheel and SIMD extension
+automatically. Correct `$IDAUSR` examples to the documented Windows, macOS,
+and Linux paths.
+
+- [ ] **Step 3: Validate the checkout and source archive locally**
+
+Run:
+
+```bash
+/tmp/hcli plugin lint .
+git archive --format=zip --prefix=ida-sigmaker-1.12.0/ -o /tmp/ida-sigmaker-1.12.0.zip HEAD
+/tmp/hcli plugin lint /tmp/ida-sigmaker-1.12.0.zip
+```
+
+Expected: both lint commands succeed and identify `SigMaker` version `1.12.0`.
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+
+```bash
+python3 -m unittest tests.unit_test_packaging -v
+python3 -m compileall -q tests
+git diff --check
+```
+
+Expected: tests report `OK`; compileall and diff checks exit zero.
+
+- [ ] **Step 5: Commit and publish the pull request**
+
+Stage only the design, plan, manifest, workflows, README, and packaging tests;
+commit them, push `diff/hcli-publishing`, and open a ready pull request against
+`main`.

--- a/docs/superpowers/specs/2026-07-16-hcli-publishing-design.md
+++ b/docs/superpowers/specs/2026-07-16-hcli-publishing-design.md
@@ -1,0 +1,55 @@
+# HCLI Publishing Design
+
+## Goal
+
+Make SigMaker discoverable and installable through Hex-Rays' HCLI plugin
+manager using the repository's normal GitHub releases.
+
+## Packaging
+
+- Keep `ida-plugin.json` at the repository root so GitHub's generated source
+  archive is a valid HCLI plugin archive.
+- Keep `src/sigmaker/__init__.py` as the IDAPython entry point. Do not add an
+  entry-point shim or change the module.
+- Add the HCLI-required repository URL and author metadata, plus license,
+  keywords, supported IDA versions, and the published JSON Schema URL.
+- Declare `sigmaker==1.12.0` in `pythonDependencies`. HCLI will install the
+  matching PyPI wheel into IDA's Python environment, providing the optional
+  SIMD extension while the source-tree entry point remains the plugin code.
+- Keep `[project].dependencies` empty. HCLI metadata is deployment metadata,
+  not a new runtime dependency for direct source installs.
+
+## Release Flow
+
+- Git tag pushes and explicit manual dispatches create GitHub releases.
+- Publishing a GitHub release triggers the wheel/sdist workflow and its PyPI
+  trusted-publishing step.
+- Ordinary successful `main` test runs must not trigger release or PyPI work.
+  Remove the `workflow_run` chain that currently reports success even when no
+  version tag exists and consequently starts an untagged deployment.
+- HCLI's daily indexer discovers the release source archive after publication.
+  No separate repository submission or custom HCLI ZIP is required.
+
+## Validation
+
+- Add dependency-free unit tests that enforce the manifest fields, entry-point
+  existence, version lockstep, and release-event boundaries.
+- Run `hcli plugin lint` against both the checkout and a GitHub-style source
+  archive before opening the pull request.
+- Keep the HCLI binary outside the package and project dependencies. CI may
+  download a pinned HCLI executable for validation without changing SigMaker's
+  installation contract.
+
+## Documentation
+
+- Explain that `hcli plugin install SigMaker` installs the matching PyPI wheel
+  automatically, so no follow-up `pip install` is needed for SIMD speedups.
+- Document the correct platform-specific `$IDAUSR` locations from Hex-Rays'
+  HCLI documentation.
+
+## Non-Goals
+
+- No SigMaker runtime or UI changes.
+- No new `sigmaker_entry.py` file.
+- No version bump or release in this pull request.
+- No custom plugin bundle for offline multi-plugin distribution.

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -1,16 +1,45 @@
 {
+    "$schema": "https://hcli.docs.hex-rays.com/schemas/ida-plugin.json",
     "IDAMetadataDescriptorVersion": 1,
     "plugin": {
         "name": "SigMaker",
         "entryPoint": "src/sigmaker/__init__.py",
+        "version": "1.12.0",
+        "idaVersions": [
+            "9.0",
+            "9.0sp1",
+            "9.1",
+            "9.2",
+            "9.3",
+            "9.4",
+            "10.0"
+        ],
+        "description": "Create and search resilient byte signatures for functions and addresses in IDA Pro.",
         "categories": [
             "collaboration-and-productivity",
             "decompilation",
             "debugging-and-tracing"
         ],
+        "keywords": [
+            "binary-patterns",
+            "function-identification",
+            "signature-generation",
+            "signature-search"
+        ],
+        "license": "MIT",
         "logoPath": "assets/sigmaker-logo.png",
-        "idaVersions": ">=9.0",
-        "description": "SigMaker is a cross-platform signature maker plugin that works on MacOS/Linux/Windows. The primary goal of this plugin is to work with future versions of IDA without needing to compile against the IDA SDK as well as to allow for easier community contributions",
-        "version": "1.12.0"
+        "pythonDependencies": [
+            "sigmaker==1.12.0"
+        ],
+        "urls": {
+            "repository": "https://github.com/mahmoudimus/ida-sigmaker",
+            "homepage": "https://mahmoudimus.com"
+        },
+        "authors": [
+            {
+                "name": "Mahmoud Abdelkader",
+                "email": "m{_no-spam_}@mahmoudimus.com"
+            }
+        ]
     }
 }

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import pathlib
 import re
@@ -97,7 +98,12 @@ class TestHCLIPackaging(unittest.TestCase):
         )
 
     def test_version_sync_updates_the_hcli_dependency(self):
-        from tools import sync_plugin_version
+        script = ROOT / "tools" / "sync_plugin_version.py"
+        spec = importlib.util.spec_from_file_location("sync_plugin_version", script)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        sync_plugin_version = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sync_plugin_version)
 
         manifest = json.dumps(
             {

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 import re
 import unittest
@@ -9,6 +10,18 @@ except ImportError:  # Python 3.10
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+HCLI_SCHEMA = "https://hcli.docs.hex-rays.com/schemas/ida-plugin.json"
+HCLI_VERSION = "0.18.5"
+REPOSITORY_URL = "https://github.com/mahmoudimus/ida-sigmaker"
+SUPPORTED_IDA_VERSIONS = [
+    "9.0",
+    "9.0sp1",
+    "9.1",
+    "9.2",
+    "9.3",
+    "9.4",
+    "10.0",
+]
 
 
 class TestWheelBuildConfiguration(unittest.TestCase):
@@ -25,3 +38,78 @@ class TestWheelBuildConfiguration(unittest.TestCase):
     def test_project_advertises_python_314(self):
         project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
         self.assertIn("Programming Language :: Python :: 3.14", project["classifiers"])
+
+
+class TestHCLIPackaging(unittest.TestCase):
+    def setUp(self):
+        self.manifest = json.loads((ROOT / "ida-plugin.json").read_text())
+        self.plugin = self.manifest["plugin"]
+
+    def test_manifest_has_hcli_metadata(self):
+        self.assertEqual(self.manifest["$schema"], HCLI_SCHEMA)
+        self.assertEqual(
+            self.plugin["entryPoint"], "src/sigmaker/__init__.py"
+        )
+        self.assertTrue((ROOT / self.plugin["entryPoint"]).is_file())
+        self.assertEqual(self.plugin["urls"]["repository"], REPOSITORY_URL)
+        self.assertTrue(self.plugin["authors"])
+        self.assertTrue(self.plugin["authors"][0]["email"])
+        self.assertEqual(self.plugin["license"], "MIT")
+        self.assertTrue(self.plugin["keywords"])
+        self.assertEqual(self.plugin["idaVersions"], SUPPORTED_IDA_VERSIONS)
+
+    def test_hcli_installs_the_matching_speedup_wheel(self):
+        self.assertEqual(
+            self.plugin["pythonDependencies"],
+            [f"sigmaker=={self.plugin['version']}"],
+        )
+
+    def test_direct_install_remains_dependency_free(self):
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+        self.assertEqual(project["dependencies"], [])
+
+    def test_automatic_deployments_require_a_published_release(self):
+        release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
+        deploy_workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+
+        self.assertNotIn("workflow_run:", release_workflow)
+        self.assertNotIn("workflow_run:", deploy_workflow)
+        self.assertRegex(deploy_workflow, r"release:\s+types:\s+- published")
+        self.assertIn("workflow_dispatch:", deploy_workflow)
+
+    def test_ci_lints_the_plugin_with_pinned_hcli_inputs(self):
+        workflow = (ROOT / ".github/workflows/python.yml").read_text()
+        self.assertIn(
+            f"HexRaysSA/ida-hcli/releases/download/v{HCLI_VERSION}/"
+            f"hcli-linux-x86_64-{HCLI_VERSION}",
+            workflow,
+        )
+        self.assertIn(
+            "b35eb351ce9e706709212604f937118643eee861bf4411bc4cac94217245b277",
+            workflow,
+        )
+        self.assertIn(
+            "3cee9691f72459c5ac75b028c827016e93e58923/plugin-repository.json",
+            workflow,
+        )
+        self.assertIn(
+            "plugin --repo /tmp/plugin-repository-v1.json lint .", workflow
+        )
+
+    def test_version_sync_updates_the_hcli_dependency(self):
+        from tools import sync_plugin_version
+
+        manifest = json.dumps(
+            {
+                "plugin": {
+                    "version": "1.0.0",
+                    "pythonDependencies": ["sigmaker==1.0.0"],
+                }
+            }
+        )
+        updated = json.loads(sync_plugin_version.sync_manifest(manifest, "2.0.0"))
+
+        self.assertEqual(updated["plugin"]["version"], "2.0.0")
+        self.assertEqual(
+            updated["plugin"]["pythonDependencies"], ["sigmaker==2.0.0"]
+        )

--- a/tools/sync_plugin_version.py
+++ b/tools/sync_plugin_version.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Keep ``ida-plugin.json``'s version in sync with ``sigmaker.__version__``.
+"""Keep HCLI's manifest version fields in sync with ``sigmaker.__version__``.
 
 The single source of truth for the version is ``__version__`` in
 ``src/sigmaker/__init__.py`` (``pyproject.toml`` already derives the package
-version from it). The IDA Plugin Repository and ``hcli`` read the version out
-of ``ida-plugin.json``, so the two must agree. This script copies the package
-version into the manifest.
+version from it). The IDA Plugin Repository and ``hcli`` read the version and
+the exact PyPI dependency out of ``ida-plugin.json``, so both must agree. This
+script updates them together.
 
 It reads ``__version__`` by parsing the source with ``ast`` rather than
 importing the module, because importing ``sigmaker`` pulls in ``idaapi``,
-which only exists inside IDA. The manifest is rewritten with a targeted
-substitution so the rest of its formatting is left untouched.
+which only exists inside IDA. The manifest is parsed and written as JSON so
+the two related fields cannot drift independently.
 
 Usage:
     python tools/sync_plugin_version.py            # write the manifest in place
@@ -23,7 +23,6 @@ import argparse
 import ast
 import json
 import pathlib
-import re
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -46,6 +45,15 @@ def manifest_version(text: str) -> str:
     return json.loads(text)["plugin"]["version"]
 
 
+def sync_manifest(text: str, version: str) -> str:
+    """Return manifest JSON with all package-version references updated."""
+    manifest = json.loads(text)
+    plugin = manifest["plugin"]
+    plugin["version"] = version
+    plugin["pythonDependencies"] = [f"sigmaker=={version}"]
+    return json.dumps(manifest, indent=4) + "\n"
+
+
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -57,27 +65,30 @@ def main(argv=None) -> int:
 
     version = package_version()
     text = MANIFEST.read_text(encoding="utf-8")
-    current = manifest_version(text)
+    manifest = json.loads(text)
+    current = manifest["plugin"]["version"]
+    dependencies = manifest["plugin"].get("pythonDependencies")
+    expected_dependencies = [f"sigmaker=={version}"]
 
-    if current == version:
+    if current == version and dependencies == expected_dependencies:
         return 0
 
     if args.check:
         print(
-            f"ida-plugin.json version {current!r} != sigmaker.__version__ "
-            f"{version!r}; run: python tools/sync_plugin_version.py",
+            "ida-plugin.json package references are out of sync: "
+            f"version={current!r}, pythonDependencies={dependencies!r}, "
+            f"expected version={version!r} and dependencies="
+            f"{expected_dependencies!r}; run: python "
+            "tools/sync_plugin_version.py",
             file=sys.stderr,
         )
         return 1
 
-    # Replace only the version string, so the manifest's formatting is preserved.
-    new_text, n = re.subn(
-        r'("version"\s*:\s*")[^"]*(")', r"\g<1>" + version + r"\g<2>", text, count=1
+    MANIFEST.write_text(sync_manifest(text, version), encoding="utf-8")
+    print(
+        "synced ida-plugin.json package references "
+        f"from version {current} to {version}"
     )
-    if n != 1:
-        raise SystemExit("could not locate the version field in ida-plugin.json")
-    MANIFEST.write_text(new_text, encoding="utf-8")
-    print(f"synced ida-plugin.json version {current} -> {version}")
     return 0
 
 


### PR DESCRIPTION
## Summary

- make the root `ida-plugin.json` valid for the HCLI plugin repository while keeping `src/sigmaker/__init__.py` as the entry point
- let HCLI install the matching `sigmaker==VERSION` PyPI wheel so managed installs receive SIMD speedups without a second command
- lint both the manifest and source-archive layout in CI with pinned HCLI inputs
- remove the `workflow_run` release chain that launched untagged PyPI builds after ordinary `main` tests
- keep manifest version and HCLI dependency pins synchronized from `sigmaker.__version__`
- document HCLI installation and the platform-specific `$IDAUSR` paths

GitHub release source archives are the HCLI plugin archives; this does not add an entry-point shim or any runtime dependency. A new versioned release after this merges will make SigMaker discoverable to the HCLI indexer and publish the already-configured CPython 3.14 wheel matrix.

## Verification

- `PYTHONPATH=src uv run --no-project --with coverage python -m unittest tests.unit_test_packaging tests.unit_test_sigmaker.TestPluginManifestVersion -v`
- `python3 tools/sync_plugin_version.py --check`
- `actionlint` 1.7.12
- `hcli plugin lint .` with HCLI 0.18.5 and a pinned plugin-repository snapshot
- `hcli plugin lint` against a GitHub-style prefixed source archive
- built `sigmaker-1.12.0-cp314-cp314-macosx_11_0_arm64.whl` and verified `simd_scan.cpython-314-darwin.so` is present
- `python3 -m compileall -q tests tools`
- `git diff --cached --check`