### PR TITLE
Publish wheels after automated releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,18 @@
 name: Build and upload to PyPI
 
 on:
+    workflow_call:
+        inputs:
+            publish:
+                required: true
+                type: boolean
     workflow_dispatch:
+        inputs:
+            publish:
+                description: "Publish the built distributions to PyPI"
+                required: true
+                type: boolean
+                default: false
     release:
         types:
             - published
@@ -115,8 +126,9 @@ jobs:
             - uses: pypa/gh-action-pypi-publish@release/v1
               if: ${{
                   github.repository_owner == 'mahmoudimus' &&
-                  github.event_name == 'release' &&
-                  github.event.action == 'published'
+                  (inputs.publish == true ||
+                  (github.event_name == 'release' &&
+                  github.event.action == 'published'))
                   }}
               # See https://docs.pypi.org/trusted-publishers/using-a-publisher/
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
     contents: write
+    id-token: write
 
 jobs:
     release:
@@ -119,3 +120,12 @@ jobs:
                   prerelease: ${{ contains(steps.version.outputs.version, '-') }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    publish-to-pypi:
+        needs: release
+        uses: ./.github/workflows/deploy.yml
+        with:
+            publish: true
+        permissions:
+            contents: read
+            id-token: write

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -69,14 +69,29 @@ class TestHCLIPackaging(unittest.TestCase):
         project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
         self.assertEqual(project["dependencies"], [])
 
-    def test_automatic_deployments_require_a_published_release(self):
+    def test_release_calls_the_pypi_workflow_directly(self):
         release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
         deploy_workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
 
         self.assertNotIn("workflow_run:", release_workflow)
         self.assertNotIn("workflow_run:", deploy_workflow)
+        self.assertIn("workflow_call:", deploy_workflow)
         self.assertRegex(deploy_workflow, r"release:\s+types:\s+- published")
-        self.assertIn("workflow_dispatch:", deploy_workflow)
+        self.assertRegex(
+            release_workflow,
+            r"publish-to-pypi:\s+needs: release\s+uses: "
+            r"\./\.github/workflows/deploy\.yml\s+with:\s+publish: true",
+        )
+
+    def test_manual_pypi_publish_requires_explicit_confirmation(self):
+        deploy_workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
+
+        self.assertRegex(
+            deploy_workflow,
+            r"workflow_dispatch:\s+inputs:\s+publish:\s+"
+            r"description:.*\s+required: true\s+type: boolean\s+default: false",
+        )
+        self.assertIn("inputs.publish == true", deploy_workflow)
 
     def test_ci_lints_the_plugin_with_pinned_hcli_inputs(self):
         workflow = (ROOT / ".github/workflows/python.yml").read_text()


### PR DESCRIPTION
## Summary

- call the reusable PyPI deployment directly after the GitHub release job
- retain `release.published` support for releases created outside Actions
- require an explicit `publish=true` confirmation for manual deployments
- add regression coverage for both release paths

GitHub suppresses workflow events caused by `GITHUB_TOKEN`, so the `v1.13.0` release created successfully but could not trigger the separate `release.published` deployment. This keeps the release boundary while avoiding an event chain that GitHub intentionally blocks.

## Verification

- packaging tests: 10 passed
- red/green verification for both new release-chain tests
- `actionlint` 1.7.12
- `git diff --check`