### PR TITLE
Make Xref startup cancelable

### DIFF
--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -15,6 +15,7 @@ import dataclasses
 import enum
 import functools
 import io
+import itertools
 import json
 import logging
 import os
@@ -2921,7 +2922,6 @@ class XrefFinder:
     """Handles finding and generating signatures for XREF addresses."""
 
     def __init__(self):
-        self.progress_dialog = ProgressDialog()
         self.signature_maker = SignatureMaker()
 
     @classmethod
@@ -2945,26 +2945,30 @@ class XrefFinder:
     def find_xrefs(self, ea: int, cfg: SigMakerConfig) -> XrefGeneratedSignature:
         """Find XREF signatures to a given address."""
         xref_signatures: list[GeneratedSignature] = []
+        ui = UIServices.current()
 
-        total = self.count_code_xrefs_to(ea)
-        if total == 0:
+        # Open a cancelable wait box before the first xref lookup. Each
+        # candidate generator owns its own wait box, so only keep this scope
+        # around the preflight lookup and stream the remaining xrefs lazily.
+        with ui.progress(
+            "Find shortest XREF signature\n\n"
+            "Enumerating code XREFs...\n\n"
+            "Press Cancel to stop"
+        ):
+            if ui.cancel_requested():
+                return XrefGeneratedSignature([])
+            xref_sources = iter(self.iter_code_xrefs_to(ea))
+            first_xref = next(xref_sources, None)
+
+        if first_xref is None:
             return XrefGeneratedSignature([])
 
         # Non-interactive during xref search
         cfg_no_prompt = dataclasses.replace(cfg, ask_longer_signature=False)
 
-        shortest_len = cfg.max_xref_signature_length + 1
-
-        for i, frm_ea in enumerate(self.iter_code_xrefs_to(ea), start=1):
-            if self.progress_dialog.user_canceled():
+        for frm_ea in itertools.chain((first_xref,), xref_sources):
+            if ui.cancel_requested():
                 break
-
-            self.progress_dialog.replace_message(
-                f"Find shortest XREF signature\n\n"
-                f"Processing xref {i} of {total} ({(i / total) * 100.0:.1f}%)...\n\n"
-                f"Suitable Signatures: {len(xref_signatures)}\n"
-                f"Shortest Signature: {shortest_len if shortest_len <= cfg.max_xref_signature_length else 0} Bytes"
-            )
 
             try:
                 # Public API: returns SignatureResult
@@ -2978,8 +2982,6 @@ class XrefFinder:
             if sig is None:
                 continue
 
-            if len(sig) < shortest_len:
-                shortest_len = len(sig)
             xref_signatures.append(GeneratedSignature(sig, Match(frm_ea)))
 
         xref_signatures.sort()
@@ -5098,10 +5100,9 @@ class SigMakerPlugin(idaapi.plugin_t):
                 f"{hex(pfn.start_ea)}; trying xref signatures...\n"
             )
 
-        with ProgressDialog(
-            "Falling back to xref signatures...\n\nPress Cancel to stop"
-        ):
-            xref_result = XrefFinder().find_xrefs(pfn.start_ea, config)
+        # XrefFinder opens its own bounded preflight wait box, then each
+        # candidate generator owns its cancelable wait box.
+        xref_result = XrefFinder().find_xrefs(pfn.start_ea, config)
 
         if xref_result.signatures:
             best = xref_result.signatures[0]

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -62,6 +62,10 @@ def _never_cancel() -> bool:
     return False
 
 
+def _ignore_progress_message(message: str) -> None:
+    """Discard progress updates when the host has no UI."""
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class UIServices:
     """Context-local UI hooks selected for the current IDA host."""
@@ -70,6 +74,10 @@ class UIServices:
     progress: typing.Callable[..., typing.ContextManager[object]] = _null_progress
     #: Cheap predicate polled periodically by long-running search loops.
     cancel_requested: typing.Callable[[], bool] = _never_cancel
+    #: Update the message shown by the current progress scope, when there is one.
+    replace_progress_message: typing.Callable[[str], None] = _ignore_progress_message
+    #: Whether a nested operation may open its own progress scope.
+    allow_nested_progress: bool = True
     _ctx = _UI_SERVICES_CTX
 
     @classmethod
@@ -1988,9 +1996,12 @@ class UniqueSignatureGenerator:
                 match_count=progress.last_match_count,
             )
 
-        with _CancelToPartial(policy, build_partial) as cancel:
-            for cur_ea, ins, ins_len in ProgressBox(
-                InstructionWalker(ea),
+        instructions: typing.Iterable[tuple[int, idaapi.insn_t, int]] = (
+            InstructionWalker(ea)
+        )
+        if UIServices.current().allow_nested_progress:
+            instructions = ProgressBox(
+                instructions,
                 initial_message=(
                     "Create unique signature (from cursor address)\n\n"
                     "Growing a pattern from the current address until it "
@@ -1998,10 +2009,13 @@ class UniqueSignatureGenerator:
                     "Press Cancel to stop"
                 ),
                 format_message=progress,
-            ):
+            )
+
+        with _CancelToPartial(policy, build_partial) as cancel:
+            for cur_ea, ins, ins_len in instructions:
                 # Modal continue-prompt opt-in (issue #18) still goes through
-                # the progress reporter. The wait-box cancel is already handled
-                # by ProgressBox raising UserCanceledError.
+                # the reporter. ProgressBox handles its own wait-box cancel;
+                # composite operations retain their outer wait box instead.
                 if (
                     self.progress_reporter is not None
                     and self.progress_reporter.should_cancel()
@@ -2946,10 +2960,10 @@ class XrefFinder:
         """Find XREF signatures to a given address."""
         xref_signatures: list[GeneratedSignature] = []
         ui = UIServices.current()
+        shortest_len = cfg.max_xref_signature_length + 1
 
-        # Open a cancelable wait box before the first xref lookup. Each
-        # candidate generator owns its own wait box, so only keep this scope
-        # around the preflight lookup and stream the remaining xrefs lazily.
+        # Keep one cancelable wait box for the full operation. Candidate
+        # generation reuses it rather than nesting its normal wait box.
         with ui.progress(
             "Find shortest XREF signature\n\n"
             "Enumerating code XREFs...\n\n"
@@ -2960,32 +2974,45 @@ class XrefFinder:
             xref_sources = iter(self.iter_code_xrefs_to(ea))
             first_xref = next(xref_sources, None)
 
-        if first_xref is None:
-            return XrefGeneratedSignature([])
+            if first_xref is None:
+                return XrefGeneratedSignature([])
 
-        # Non-interactive during xref search
-        cfg_no_prompt = dataclasses.replace(cfg, ask_longer_signature=False)
+            # Non-interactive during xref search
+            cfg_no_prompt = dataclasses.replace(cfg, ask_longer_signature=False)
 
-        for frm_ea in itertools.chain((first_xref,), xref_sources):
-            if ui.cancel_requested():
-                break
+            candidate_ui = dataclasses.replace(ui, allow_nested_progress=False)
+            with UIServices.use(candidate_ui):
+                for index, frm_ea in enumerate(
+                    itertools.chain((first_xref,), xref_sources), start=1
+                ):
+                    ui.replace_progress_message(
+                        f"Find shortest XREF signature\n\n"
+                        f"Processing XREF {index}...\n\n"
+                        f"Suitable Signatures: {len(xref_signatures)}\n"
+                        "Shortest Signature: "
+                        f"{shortest_len if shortest_len <= cfg.max_xref_signature_length else 0} Bytes\n\n"
+                        "Press Cancel to stop"
+                    )
+                    if ui.cancel_requested():
+                        break
 
-            try:
-                # Public API: returns SignatureResult
-                result = self.signature_maker.make_signature(frm_ea, cfg_no_prompt)
-                sig: typing.Optional[Signature] = result.signature
-            except UserCanceledError:
-                break
-            except Exception:
-                sig = None
+                    try:
+                        # Public API: returns SignatureResult
+                        result = self.signature_maker.make_signature(frm_ea, cfg_no_prompt)
+                        sig: typing.Optional[Signature] = result.signature
+                    except UserCanceledError:
+                        break
+                    except Exception:
+                        sig = None
 
-            if sig is None:
-                continue
+                    if sig is None:
+                        continue
 
-            xref_signatures.append(GeneratedSignature(sig, Match(frm_ea)))
+                    shortest_len = min(shortest_len, len(sig))
+                    xref_signatures.append(GeneratedSignature(sig, Match(frm_ea)))
 
-        xref_signatures.sort()
-        return XrefGeneratedSignature(xref_signatures)
+            xref_signatures.sort()
+            return XrefGeneratedSignature(xref_signatures)
 
 
 @dataclasses.dataclass(slots=True)
@@ -4389,6 +4416,7 @@ def _ida_ui_services() -> UIServices:
     return UIServices(
         progress=ProgressDialog,
         cancel_requested=idaapi_user_canceled,
+        replace_progress_message=idaapi.replace_wait_box,
     )
 
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4547,6 +4547,43 @@ class TestXrefFinderCancellation(CoveredUnitTest):
         self.assertTrue(scope.entered)
         self.assertIn("Enumerating", scope.initial_message)
 
+    def test_keeps_one_xref_wait_box_with_indeterminate_status(self):
+        _RecordingXrefProgressScope.instances = []
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+        messages: list[str] = []
+        ui = sigmaker.UIServices(
+            progress=_RecordingXrefProgressScope,
+            cancel_requested=lambda: False,
+            replace_progress_message=messages.append,
+            allow_nested_progress=True,
+        )
+        nested_progress_values: list[bool] = []
+
+        def make_signature(*_args, **_kwargs):
+            nested_progress_values.append(
+                sigmaker.UIServices.current().allow_nested_progress
+            )
+            return generated
+
+        with sigmaker.UIServices.use(ui), patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            side_effect=lambda _ea: iter([0x1010]),
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            side_effect=make_signature,
+        ):
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(len(result.signatures), 1)
+        self.assertEqual(len(_RecordingXrefProgressScope.instances), 1)
+        self.assertEqual(len(messages), 1)
+        self.assertIn("Processing XREF 1", messages[0])
+        self.assertNotIn(" of ", messages[0])
+        self.assertEqual(nested_progress_values, [False])
+
     def test_cancel_during_xref_enumeration_skips_signature_generation(self):
         finder = self._finder()
 

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4480,18 +4480,22 @@ class TestGeneratedSignatureDisplay(CoveredUnitTest):
         fa.assert_not_called()
 
 
-class _FakeXrefProgressDialog:
-    """Minimal progress dialog for XrefFinder unit tests."""
+class _RecordingXrefProgressScope:
+    """Records the XREF collection scope selected through UIServices."""
 
-    def __init__(self) -> None:
-        self.messages: list[str] = []
+    instances: list["_RecordingXrefProgressScope"] = []
 
-    def user_canceled(self) -> bool:
-        return False
+    def __init__(self, message: str = "") -> None:
+        self.initial_message = message
+        self.entered = False
+        type(self).instances.append(self)
 
-    def replace_message(self, msg: str) -> None:
-        self.messages.append(msg)
+    def __enter__(self) -> "_RecordingXrefProgressScope":
+        self.entered = True
+        return self
 
+    def __exit__(self, *_args: object) -> None:
+        return None
 
 class TestXrefFinderCancellation(CoveredUnitTest):
     """Cancel during one XREF candidate stops and keeps prior results."""
@@ -4510,22 +4514,98 @@ class TestXrefFinderCancellation(CoveredUnitTest):
         sig.append(sigmaker.SignatureByte(value + 1, False))
         return sig
 
+    @staticmethod
+    def _ui(cancel_requested=lambda: False) -> sigmaker.UIServices:
+        return sigmaker.UIServices(
+            progress=_RecordingXrefProgressScope,
+            cancel_requested=cancel_requested,
+        )
+
     def _finder(self) -> sigmaker.XrefFinder:
-        finder = sigmaker.XrefFinder()
-        finder.progress_dialog = _FakeXrefProgressDialog()
-        return finder
+        return sigmaker.XrefFinder()
+
+    def test_enumerates_xrefs_once_inside_injected_progress_scope(self):
+        _RecordingXrefProgressScope.instances = []
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+
+        with sigmaker.UIServices.use(self._ui()), patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            side_effect=lambda _ea: iter([0x1010]),
+        ) as iter_xrefs, patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            return_value=generated,
+        ):
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(iter_xrefs.call_count, 1)
+        self.assertEqual(len(result.signatures), 1)
+        self.assertEqual(len(_RecordingXrefProgressScope.instances), 1)
+        scope = _RecordingXrefProgressScope.instances[0]
+        self.assertTrue(scope.entered)
+        self.assertIn("Enumerating", scope.initial_message)
+
+    def test_cancel_during_xref_enumeration_skips_signature_generation(self):
+        finder = self._finder()
+
+        with sigmaker.UIServices.use(self._ui(lambda: True)), patch.object(
+            sigmaker,
+            "idaapi_user_canceled",
+            return_value=False,
+        ), patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            side_effect=lambda _ea: iter([0x1010]),
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+        ) as make_signature:
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(result.signatures, [])
+        make_signature.assert_not_called()
+
+    def test_starts_generation_before_xref_enumeration_finishes(self):
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+        events: list[str] = []
+
+        def xrefs(_ea):
+            events.append("first xref")
+            yield 0x1010
+            events.append("second xref")
+            yield 0x1020
+
+        def make_signature(*_args, **_kwargs):
+            events.append("generate")
+            return generated
+
+        with sigmaker.UIServices.use(self._ui()), patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            side_effect=xrefs,
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            side_effect=make_signature,
+        ):
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(len(result.signatures), 2)
+        self.assertLess(events.index("generate"), events.index("second xref"))
 
     def test_cancel_inside_candidate_generation_returns_prior_xrefs(self):
         finder = self._finder()
         first = sigmaker.GeneratedSignature(self._sig(0x40))
         third = sigmaker.GeneratedSignature(self._sig(0x50))
 
-        with patch.object(sigmaker.XrefFinder, "count_code_xrefs_to", return_value=3), \
-                patch.object(
-                    sigmaker.XrefFinder,
-                    "iter_code_xrefs_to",
-                    return_value=iter([0x1010, 0x1020, 0x1030]),
-                ), patch.object(
+        with patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            return_value=iter([0x1010, 0x1020, 0x1030]),
+        ), patch.object(
                     sigmaker.SignatureMaker,
                     "make_signature",
                     side_effect=[
@@ -4546,12 +4626,11 @@ class TestXrefFinderCancellation(CoveredUnitTest):
         first = sigmaker.GeneratedSignature(self._sig(0x40))
         third = sigmaker.GeneratedSignature(self._sig(0x50))
 
-        with patch.object(sigmaker.XrefFinder, "count_code_xrefs_to", return_value=3), \
-                patch.object(
-                    sigmaker.XrefFinder,
-                    "iter_code_xrefs_to",
-                    return_value=iter([0x1010, 0x1020, 0x1030]),
-                ), patch.object(
+        with patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            return_value=iter([0x1010, 0x1020, 0x1030]),
+        ), patch.object(
                     sigmaker.SignatureMaker,
                     "make_signature",
                     side_effect=[


### PR DESCRIPTION
## What changed

- Open one injected, cancelable UI progress scope before SigMaker asks IDA for the first code Xref and keep it active through the full Xref operation.
- Remove the eager `count_code_xrefs_to()` pass, which previously walked every code Xref before any signature work began.
- Stream Xrefs lazily, so the first signature starts as soon as the first code Xref is available.
- Report indeterminate `Processing XREF N` status with the suitable-signature count and shortest result. There is no percentage because the total is deliberately not pre-counted.
- Run candidate generation with nested progress suppressed, so the outer Xref wait box remains visible and cancelable.
- Poll the injected cancellation hook before enumeration and between candidates.
- Remove redundant wait-box ownership from the function-signature Xref fallback.

## Why

The direct Xref action constructed a `ProgressDialog` but never entered it. It then traversed all Xrefs once to count them and a second time to generate signatures. On targets with many Xrefs this created a long, non-cancelable startup period.

## Validation

- 42 focused unit tests covering Xref cancellation, lazy traversal, the continuous UI scope, standalone wait-box behavior, search cancellation, and the signature-generation paths.
- `compileall` and `git diff --check`.

## Stacking

This PR is based on #80 because it uses that PR's injected `UIServices` seam. Merge #80 first.