### PR TITLE
Reuse buffers across one Xref action

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ checked before any change to the public surface:
 
 - **Stable method signatures**
   - Signature generation
-    - `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict())`
+    - `SignatureMaker.make_signature(ea, cfg, end=None, *, progress_reporter=None, policy=GenerationPolicy.strict(), buf=None)`
   - Cross-reference generation
     - `XrefFinder.find_xrefs(ea, cfg)`
     - `XrefFinder.count_code_xrefs_to(ea)`

--- a/src/sigmaker/__init__.py
+++ b/src/sigmaker/__init__.py
@@ -1925,9 +1925,11 @@ class UniqueSignatureGenerator:
         self,
         processor: InstructionProcessor,
         progress_reporter: typing.Optional[ProgressReporter] = None,
+        buf: typing.Optional["InMemoryBuffer"] = None,
     ):
         self.processor = processor
         self.progress_reporter = progress_reporter
+        self.buf = buf
 
     def generate(
         self,
@@ -1973,11 +1975,11 @@ class UniqueSignatureGenerator:
         # first scan; buf holds the segment buffer the offsets index into.
         offsets: typing.Optional["array.array"] = None
         offset_count = 0
-        buf: typing.Optional["InMemoryBuffer"] = None
+        buf = self.buf
         search_ranges: typing.Optional[
             tuple["array.array", "array.array"]
         ] = None
-        if cfg.scope_to_segment:
+        if cfg.scope_to_segment and buf is None:
             # Issue #64: scope uniqueness to the anchor's segment. Pre-load it so
             # the seed scan and every refinement stay within the segment.
             buf = InMemoryBuffer.load(
@@ -2851,6 +2853,7 @@ class SignatureMaker:
         self,
         for_range: bool,
         progress_reporter: typing.Optional[ProgressReporter],
+        buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> UniqueSignatureGenerator | RangeSignatureGenerator:
         """Factory method to create the appropriate signature generator.
 
@@ -2866,7 +2869,7 @@ class SignatureMaker:
         """
         if for_range:
             return RangeSignatureGenerator(self._instruction_processor, progress_reporter)
-        return UniqueSignatureGenerator(self._instruction_processor, progress_reporter)
+        return UniqueSignatureGenerator(self._instruction_processor, progress_reporter, buf)
 
     def make_signature(
         self,
@@ -2876,6 +2879,7 @@ class SignatureMaker:
         *,
         progress_reporter: typing.Optional[ProgressReporter] = None,
         policy: GenerationPolicy = GenerationPolicy.strict(),
+        buf: typing.Optional["InMemoryBuffer"] = None,
     ) -> GeneratedSignature:
         """Creates a signature for a single address (unique) or an address range.
 
@@ -2885,6 +2889,7 @@ class SignatureMaker:
             end: Optional ending address for range-based signatures
             progress_reporter: Optional progress reporter for cancellation and updates.
                               If not provided, one will be created based on cfg.enable_continue_prompt.
+            buf: Optional preloaded search buffer reused by the SIMD path.
 
         Returns:
             A GeneratedSignature containing the signature and metadata
@@ -2917,7 +2922,11 @@ class SignatureMaker:
 
         if end is None:
             # Create unique signature generator via factory method
-            generator = self._create_generator(for_range=False, progress_reporter=progress_reporter)
+            generator = self._create_generator(
+                for_range=False,
+                progress_reporter=progress_reporter,
+                buf=buf,
+            )
             # UniqueSignatureGenerator.generate returns a GeneratedSignature
             # directly so it can carry status + match_count on cancel.
             return generator.generate(start_ea, cfg, policy=policy)
@@ -2930,6 +2939,37 @@ class SignatureMaker:
         generator = self._create_generator(for_range=True, progress_reporter=progress_reporter)
         sig = generator.generate(start_ea, end, cfg)
         return GeneratedSignature(sig)
+
+
+class _XrefSearchBuffers:
+    """Own the reusable SIMD search buffers for one Xref operation."""
+
+    def __init__(self, cfg: SigMakerConfig) -> None:
+        self._scope_to_segment = cfg.scope_to_segment
+        self._buffers: dict[typing.Optional[int], InMemoryBuffer] = {}
+
+    def for_ea(self, ea: int) -> typing.Optional[InMemoryBuffer]:
+        """Return the database or containing-segment buffer for ``ea``."""
+        if not _Speedups.current().available:
+            return None
+
+        scope_ea: typing.Optional[int] = None
+        if self._scope_to_segment:
+            segment = idaapi.getseg(ea)
+            if segment is not None:
+                scope_ea = int(segment.start_ea)
+
+        buf = self._buffers.get(scope_ea)
+        if buf is None:
+            if scope_ea is None:
+                buf = InMemoryBuffer.load(mode=InMemoryBuffer.LoadMode.SEGMENTS)
+            else:
+                buf = InMemoryBuffer.load(
+                    mode=InMemoryBuffer.LoadMode.SEGMENTS,
+                    scope_ea=scope_ea,
+                )
+            self._buffers[scope_ea] = buf
+        return buf
 
 
 class XrefFinder:
@@ -2961,6 +3001,7 @@ class XrefFinder:
         xref_signatures: list[GeneratedSignature] = []
         ui = UIServices.current()
         shortest_len = cfg.max_xref_signature_length + 1
+        buffers = _XrefSearchBuffers(cfg)
 
         # Keep one cancelable wait box for the full operation. Candidate
         # generation reuses it rather than nesting its normal wait box.
@@ -2998,7 +3039,11 @@ class XrefFinder:
 
                     try:
                         # Public API: returns SignatureResult
-                        result = self.signature_maker.make_signature(frm_ea, cfg_no_prompt)
+                        result = self.signature_maker.make_signature(
+                            frm_ea,
+                            cfg_no_prompt,
+                            buf=buffers.for_ea(frm_ea),
+                        )
                         sig: typing.Optional[Signature] = result.signature
                     except UserCanceledError:
                         break

--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -4287,6 +4287,29 @@ class TestUniqueSignatureGeneratorSeedThenRefine(CoveredUnitTest):
             ask_longer_signature=False,
         )
 
+    def test_signature_maker_uses_supplied_buffer_for_simd_seed(self):
+        supplied_buffer = MagicMock()
+        supplied_buffer.data.return_value = memoryview(bytearray(b"\x90"))
+        observed_buffers: list[object] = []
+
+        def find_all_offsets(_ida_signature, buf=None):
+            observed_buffers.append(buf)
+            return [0], supplied_buffer
+
+        with _with_test_speedups(), patch.object(
+            sigmaker.SignatureSearcher,
+            "find_all_offsets",
+            side_effect=find_all_offsets,
+        ):
+            result = sigmaker.SignatureMaker().make_signature(
+                0x1000,
+                self._make_cfg(),
+                buf=supplied_buffer,
+            )
+
+        self.assertEqual(result.status, sigmaker.GenerationStatus.UNIQUE)
+        self.assertEqual(observed_buffers, [supplied_buffer])
+
     @unittest.skipUnless(sigmaker._Speedups.current().available, "SIMD not built")
     def test_seed_once_then_refine_to_unique(self):
         processor = sigmaker.InstructionProcessor(sigmaker.OperandProcessor())
@@ -4583,6 +4606,108 @@ class TestXrefFinderCancellation(CoveredUnitTest):
         self.assertIn("Processing XREF 1", messages[0])
         self.assertNotIn(" of ", messages[0])
         self.assertEqual(nested_progress_values, [False])
+
+    def test_reuses_one_database_buffer_for_every_xref_candidate(self):
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+        shared_buffer = MagicMock()
+
+        with _with_test_speedups(), patch.object(
+            sigmaker.InMemoryBuffer,
+            "load",
+            return_value=shared_buffer,
+        ) as load, patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            return_value=iter([0x1010, 0x1020, 0x1030]),
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            return_value=generated,
+        ) as make_signature:
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(len(result.signatures), 3)
+        load.assert_called_once_with(mode=sigmaker.InMemoryBuffer.LoadMode.SEGMENTS)
+        self.assertEqual(
+            [call.kwargs.get("buf") for call in make_signature.call_args_list],
+            [shared_buffer, shared_buffer, shared_buffer],
+        )
+
+    def test_reuses_one_buffer_per_scoped_segment(self):
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+        first_segment = types.SimpleNamespace(start_ea=0x1000)
+        second_segment = types.SimpleNamespace(start_ea=0x2000)
+        first_buffer = MagicMock()
+        second_buffer = MagicMock()
+        cfg = dataclasses.replace(self._cfg(), scope_to_segment=True)
+
+        def getseg(ea):
+            return first_segment if ea < 0x2000 else second_segment
+
+        with _with_test_speedups(), patch.object(
+            sigmaker.idaapi,
+            "getseg",
+            side_effect=getseg,
+        ), patch.object(
+            sigmaker.InMemoryBuffer,
+            "load",
+            side_effect=[first_buffer, second_buffer],
+        ) as load, patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            return_value=iter([0x1010, 0x1020, 0x2010]),
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            return_value=generated,
+        ) as make_signature:
+            result = finder.find_xrefs(0x3000, cfg)
+
+        self.assertEqual(len(result.signatures), 3)
+        self.assertEqual(
+            [call.kwargs for call in load.call_args_list],
+            [
+                {
+                    "mode": sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
+                    "scope_ea": 0x1000,
+                },
+                {
+                    "mode": sigmaker.InMemoryBuffer.LoadMode.SEGMENTS,
+                    "scope_ea": 0x2000,
+                },
+            ],
+        )
+        self.assertEqual(
+            [call.kwargs.get("buf") for call in make_signature.call_args_list],
+            [first_buffer, first_buffer, second_buffer],
+        )
+
+    def test_does_not_prepare_xref_buffers_without_speedups(self):
+        finder = self._finder()
+        generated = sigmaker.GeneratedSignature(self._sig(0x40))
+
+        with _without_speedups(), patch.object(
+            sigmaker.InMemoryBuffer,
+            "load",
+        ) as load, patch.object(
+            sigmaker.XrefFinder,
+            "iter_code_xrefs_to",
+            return_value=iter([0x1010, 0x1020]),
+        ), patch.object(
+            sigmaker.SignatureMaker,
+            "make_signature",
+            return_value=generated,
+        ) as make_signature:
+            result = finder.find_xrefs(0x2000, self._cfg())
+
+        self.assertEqual(len(result.signatures), 2)
+        load.assert_not_called()
+        self.assertEqual(
+            [call.kwargs.get("buf") for call in make_signature.call_args_list],
+            [None, None],
+        )
 
     def test_cancel_during_xref_enumeration_skips_signature_generation(self):
         finder = self._finder()


### PR DESCRIPTION
Closes #82

Reuses the copied searchable-segment buffer for the lifetime of one Xref action. Database-wide mode loads it once; `scope_to_segment` keeps one buffer per containing segment. The cache is local to `XrefFinder.find_xrefs()`, so it cannot outlive the action or leak across databases.

Each Xref candidate still performs its own SIMD seed scan and refinement. This removes repeated segment copying without changing uniqueness scope, signature ordering, cancellation behavior, or the no-SIMD fallback.

Validation:
- one database buffer is loaded for multiple candidates
- segment-scoped candidates reuse only their matching segment buffer
- no-SIMD mode does not prepare buffers
- supplied buffers reach the SIMD seed scan
- 53 focused tests passed (9 expected native-extension skips)

Stacked on #81.