### PR TITLE
Keep speedups remediation test version-aware

### DIFF
--- a/tests/unit_test_sigmaker.py
+++ b/tests/unit_test_sigmaker.py
@@ -5135,7 +5135,11 @@ class TestSpeedupsCompatibility(CoveredUnitTest):
             message = sigmaker._Speedups.current().remediation_message()
 
         self.assertIn("hcli plugin upgrade SigMaker", message)
-        self.assertIn('"/ida/python/bin/python3" -m pip install --upgrade "sigmaker==1.13.0"', message)
+        self.assertIn(
+            '"/ida/python/bin/python3" -m pip install --upgrade '
+            f'"sigmaker=={sigmaker.PLUGIN_VERSION}"',
+            message,
+        )
         self.assertIn("/tmp/simd_scan.so", message)
         self.assertIn("github.com/mahmoudimus/ida-sigmaker/issues", message)
 


### PR DESCRIPTION
The optional-SIMD update command intentionally emits the current plugin version. This test used a hard-coded `1.13.0`, which broke the `1.14.0` release validation despite the emitted command being correct.

Validation:
- `TestSpeedupsCompatibility.test_speedups_remediation_message_has_hcli_and_manual_commands`
- `TestPluginManifestVersion`
- `git diff --check`