### PR TITLE
Fix automatic PyPI release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-    workflow_call:
-        inputs:
-            publish:
-                required: true
-                type: boolean
     workflow_dispatch:
         inputs:
             publish:
@@ -13,18 +8,24 @@ on:
                 required: true
                 type: boolean
                 default: false
-    release:
+    workflow_run:
+        workflows:
+            - Release
         types:
-            - published
+            - completed
 
 # make concurrency tag-aware so one run doesn't cancel the other incorrectly
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.event.workflow_run.id || github.ref || github.run_id }}
     cancel-in-progress: true
 
 jobs:
     build_wheels:
         name: Build wheels for ${{ matrix.os }}
+        if: >-
+            github.event_name != 'workflow_run' ||
+            (github.event.workflow_run.conclusion == 'success' &&
+            startsWith(github.event.workflow_run.head_branch, 'v'))
         runs-on: ${{ matrix.runs-on }}
         strategy:
             matrix:
@@ -44,6 +45,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v5
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Build wheels
               uses: pypa/cibuildwheel@v3.4.1
@@ -64,9 +67,15 @@ jobs:
 
     build_sdist:
         name: Build source distribution
+        if: >-
+            github.event_name != 'workflow_run' ||
+            (github.event.workflow_run.conclusion == 'success' &&
+            startsWith(github.event.workflow_run.head_branch, 'v'))
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v5
+              with:
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
             - name: Display version
               run: |
@@ -106,6 +115,14 @@ jobs:
         needs: [build_wheels, build_sdist]
         runs-on: ubuntu-latest
         name: Upload to pypi
+        if: >-
+            github.repository_owner == 'mahmoudimus' &&
+            (
+            (github.event_name == 'workflow_dispatch' && inputs.publish == true) ||
+            (github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success' &&
+            startsWith(github.event.workflow_run.head_branch, 'v'))
+            )
         permissions:
             # IMPORTANT: this permission is mandatory for trusted publishing
             id-token: write
@@ -127,8 +144,9 @@ jobs:
               if: ${{
                   github.repository_owner == 'mahmoudimus' &&
                   (inputs.publish == true ||
-                  (github.event_name == 'release' &&
-                  github.event.action == 'published'))
+                  (github.event_name == 'workflow_run' &&
+                  github.event.workflow_run.conclusion == 'success' &&
+                  startsWith(github.event.workflow_run.head_branch, 'v')))
                   }}
               # See https://docs.pypi.org/trusted-publishers/using-a-publisher/
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ concurrency:
 
 permissions:
     contents: write
-    id-token: write
 
 jobs:
     release:
@@ -120,12 +119,3 @@ jobs:
                   prerelease: ${{ contains(steps.version.outputs.version, '-') }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    publish-to-pypi:
-        needs: release
-        uses: ./.github/workflows/deploy.yml
-        with:
-            publish: true
-        permissions:
-            contents: read
-            id-token: write

--- a/tests/unit_test_packaging.py
+++ b/tests/unit_test_packaging.py
@@ -69,19 +69,21 @@ class TestHCLIPackaging(unittest.TestCase):
         project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
         self.assertEqual(project["dependencies"], [])
 
-    def test_release_calls_the_pypi_workflow_directly(self):
+    def test_release_dispatches_pypi_publish_after_successful_tagged_release(self):
         release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
         deploy_workflow = (ROOT / ".github/workflows/deploy.yml").read_text()
 
-        self.assertNotIn("workflow_run:", release_workflow)
-        self.assertNotIn("workflow_run:", deploy_workflow)
-        self.assertIn("workflow_call:", deploy_workflow)
-        self.assertRegex(deploy_workflow, r"release:\s+types:\s+- published")
-        self.assertRegex(
-            release_workflow,
-            r"publish-to-pypi:\s+needs: release\s+uses: "
-            r"\./\.github/workflows/deploy\.yml\s+with:\s+publish: true",
+        self.assertNotIn("publish-to-pypi:", release_workflow)
+        self.assertIn("workflow_run:", deploy_workflow)
+        self.assertIn("workflows:\n            - Release", deploy_workflow)
+        self.assertIn("types:\n            - completed", deploy_workflow)
+        self.assertIn(
+            "github.event.workflow_run.id || github.ref || github.run_id",
+            deploy_workflow,
         )
+        self.assertIn("github.event.workflow_run.head_sha || github.ref", deploy_workflow)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", deploy_workflow)
+        self.assertIn("startsWith(github.event.workflow_run.head_branch, 'v')", deploy_workflow)
 
     def test_manual_pypi_publish_requires_explicit_confirmation(self):
         deploy_workflow = (ROOT / ".github/workflows/deploy.yml").read_text()


### PR DESCRIPTION
## Summary

- Replace the tag-release reusable-workflow call that GitHub was skipping.
- Trigger the PyPI workflow after a successful tagged `Release` run.
- Build from the exact release SHA and keep manual publishing opt-in.
- Add a packaging regression test for the release/deploy contract.

## Verification

- `python3 -m unittest tests.unit_test_packaging -v` (13 passed)
- YAML parsing for `.github/workflows/release.yml` and `.github/workflows/deploy.yml`
- `git diff --check`

This addresses the red wrapper workflow seen for `v1.14.1` and `v1.14.2`; the release job itself succeeded, but the called PyPI job never materialized.
